### PR TITLE
Travis add retry support for pulling docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ jobs:
     include:
         - stage: build test push
           script:
+              - travis_retry timeout 2m docker pull registry.access.redhat.com/ubi8/nodejs-12
+              - travis_retry timeout 2m docker pull registry.access.redhat.com/ubi8/ubi-minimal
               - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export COMPONENT_TAG_EXTENSION="-PR${TRAVIS_PULL_REQUEST}-${TRAVIS_COMMIT}"; fi;
               - make component/build
               - if [ "$DOCKER_PASS" != "" ]; then make component/push ; else echo "No DOCKER_PASS. Skipping image push."; fi


### PR DESCRIPTION
Travis keeps failing build and it seems to be from a hang upon downloading docker images.
Adding a timeout and retry to attempt to solve the issue.