### PR TITLE
fix fastify-reply-from not found

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "console-backend",
+    "name": "@open-cluster-management/console-backend",
     "version": "0.0.1",
     "lockfileVersion": 1,
     "requires": true,
@@ -3172,7 +3172,6 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/fastify-reply-from/-/fastify-reply-from-3.4.0.tgz",
             "integrity": "sha512-q+U77Y1Vt1+fCkpPVcUQDWhQ9HfqjGlF5Ifb1ZCXB+EiOmJJGlZo0CACp4lkwCjiHOR882/8b4e969/6o9NpLQ==",
-            "dev": true,
             "requires": {
                 "end-of-stream": "^1.4.1",
                 "fastify-plugin": "^3.0.0",
@@ -3187,7 +3186,6 @@
                     "version": "1.8.0",
                     "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
                     "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-                    "dev": true,
                     "requires": {
                         "depd": "~1.1.2",
                         "inherits": "2.0.4",
@@ -3199,14 +3197,12 @@
                 "semver": {
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-                    "dev": true
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
                 },
                 "setprototypeof": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-                    "dev": true
+                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
                 }
             }
         },
@@ -7244,8 +7240,7 @@
         "undici": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/undici/-/undici-2.2.0.tgz",
-            "integrity": "sha512-pNts1nTVW1e9rOFGXdueH28FGYZz2TdeuQtJSzcto95bx7HQCegmJr+A+51fW+XU2ZNE4vZlzI7VnfKHuALitQ==",
-            "dev": true
+            "integrity": "sha512-pNts1nTVW1e9rOFGXdueH28FGYZz2TdeuQtJSzcto95bx7HQCegmJr+A+51fW+XU2ZNE4vZlzI7VnfKHuALitQ=="
         },
         "union-value": {
             "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
         "fastify-helmet": "^5.0.3",
         "fastify-https-redirect": "^1.0.3",
         "fastify-oauth2": "^4.2.1",
+        "fastify-reply-from": "^3.4.0",
         "fastify-static": "^3.3.0",
         "pino": "^6.7.0",
         "yamljs": "^0.3.0"
@@ -45,7 +46,6 @@
         "eslint": "^7.14.0",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.1.4",
-        "fastify-reply-from": "^3.4.0",
         "jest": "^26.x.x",
         "nock": "^13.0.5",
         "pino-zen": "^1.0.20",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,7 +2,7 @@
 import { config } from 'dotenv'
 config()
 
-import { logger } from './lib/logger'
+import { logger, stopLogger } from './lib/logger'
 
 if (!process.env.GENERATE) {
     if (!process.env.CLUSTER_API_URL) throw new Error('CLUSTER_API_URL required')
@@ -34,6 +34,7 @@ process.on('exit', function processExit(code) {
     } else {
         logger.debug({ msg: `process exit` })
     }
+    stopLogger()
 })
 
 process.on('uncaughtException', (error) => {


### PR DESCRIPTION
When running in a cluster, the container will crash, and turns out it's missing the `fastify-reply-from` package in node_modules.

Updates:
- made fastify-reply-from non-dev dependency.
- added stoplogger in main.ts.
