### PR TITLE
Align import cluster page closer to designs - remove cloud and environment fields

### DIFF
--- a/frontend/src/routes/ClusterManagement/Clusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/ImportCluster/ImportCluster.test.tsx
@@ -113,7 +113,7 @@ const mockManagedCluster: ManagedCluster = {
     kind: ManagedClusterKind,
     metadata: {
         name: 'foobar',
-        labels: { cloud: 'AWS', vendor: 'auto-detect', name: 'foobar', environment: 'dev', foo: 'bar' },
+        labels: { cloud: 'auto-detect', vendor: 'auto-detect', name: 'foobar', foo: 'bar' },
     },
     spec: { hubAcceptsClient: true },
 }
@@ -125,7 +125,7 @@ const mockKlusterletAddonConfig: KlusterletAddonConfig = {
     spec: {
         clusterName: 'foobar',
         clusterNamespace: 'foobar',
-        clusterLabels: { cloud: 'AWS', vendor: 'auto-detect', name: 'foobar', environment: 'dev', foo: 'bar' },
+        clusterLabels: { cloud: 'auto-detect', vendor: 'auto-detect', name: 'foobar', foo: 'bar' },
         applicationManager: { enabled: true, argocdCluster: false },
         policyController: { enabled: true },
         searchCollector: { enabled: true },
@@ -158,7 +158,7 @@ const mockManagedClusterResponse: ManagedCluster = {
     apiVersion: ManagedClusterApiVersion,
     kind: ManagedClusterKind,
     metadata: {
-        labels: { cloud: 'AWS', environment: 'dev', name: 'foobar', vendor: 'auto-detect', foo: 'bar' },
+        labels: { cloud: 'auto-detect', name: 'foobar', vendor: 'auto-detect', foo: 'bar' },
         name: 'foobar',
         uid: 'e60ef618-324b-49d4-8a28-48839c546565',
     },
@@ -176,7 +176,7 @@ const mockKlusterletAddonConfigResponse: KlusterletAddonConfig = {
     spec: {
         applicationManager: { enabled: true, argocdCluster: false },
         certPolicyController: { enabled: true },
-        clusterLabels: { cloud: 'AWS', environment: 'dev', name: 'foobar', vendor: 'auto-detect', foo: 'bar' },
+        clusterLabels: { cloud: 'auto-detect', name: 'foobar', vendor: 'auto-detect', foo: 'bar' },
         clusterName: 'foobar',
         clusterNamespace: 'foobar',
         iamPolicyController: { enabled: true },
@@ -205,8 +205,6 @@ describe('ImportCluster', () => {
         const { getByTestId, getByText } = render(<Component />)
         expect(getByTestId('import-cluster-form')).toBeInTheDocument()
         expect(getByTestId('clusterName-label')).toBeInTheDocument()
-        expect(getByTestId('cloudLabel-label')).toBeInTheDocument()
-        expect(getByTestId('environmentLabel-label')).toBeInTheDocument()
         expect(getByTestId('additionalLabels-label')).toBeInTheDocument()
         // expect(getByTestId('importModeManual')).toBeInTheDocument()
         expect(getByText('import.form.submit')).toBeInTheDocument()
@@ -221,12 +219,6 @@ describe('ImportCluster', () => {
         const { getByTestId, getByText, queryByTestId } = render(<Component />)
 
         userEvent.type(getByTestId('clusterName'), 'foobar')
-        userEvent.click(getByTestId('cloudLabel-button'))
-        await waitFor(() => expect(getByText('AWS')).toBeInTheDocument())
-        userEvent.click(getByText('AWS'))
-        userEvent.click(getByTestId('environmentLabel-button'))
-        await waitFor(() => expect(getByText('dev')).toBeInTheDocument())
-        userEvent.click(getByText('dev'))
         userEvent.click(getByTestId('label-input-button'))
         userEvent.type(getByTestId('additionalLabels'), 'foo=bar{enter}')
 
@@ -266,10 +258,6 @@ describe('ImportCluster', () => {
         const { getByTestId, getByText } = render(<Component />)
 
         userEvent.type(getByTestId('clusterName'), 'foobar')
-        userEvent.click(getByTestId('cloudLabel-button'))
-        userEvent.click(getByText('AWS'))
-        userEvent.click(getByTestId('environmentLabel-button'))
-        userEvent.click(getByText('dev'))
         userEvent.click(getByTestId('label-input-button'))
         userEvent.type(getByTestId('additionalLabels'), 'foo=bar{enter}')
         userEvent.click(getByText('import.form.submit'))
@@ -337,10 +325,6 @@ describe('Import Discovered Cluster', () => {
         await waitFor(() => expect(getByText('import.form.submit')).toBeInTheDocument()) // Wait for next page to render
 
         // Add labels
-        userEvent.click(getByTestId('cloudLabel-button'))
-        userEvent.click(getByText('AWS'))
-        userEvent.click(getByTestId('environmentLabel-button'))
-        userEvent.click(getByText('dev'))
         userEvent.click(getByTestId('label-input-button'))
         userEvent.type(getByTestId('additionalLabels'), 'foo=bar{enter}')
 

--- a/frontend/src/routes/ClusterManagement/Clusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/ImportCluster/ImportCluster.tsx
@@ -7,12 +7,11 @@ import {
     AcmPage,
     AcmPageCard,
     AcmPageHeader,
-    AcmSelect,
     AcmTextInput,
     AcmSubmit,
     AcmButton,
 } from '@open-cluster-management/ui-components'
-import { ActionGroup, Button, SelectOption, AlertVariant, Label, Text, TextVariants } from '@patternfly/react-core'
+import { ActionGroup, Button, AlertVariant, Label, Text, TextVariants } from '@patternfly/react-core'
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon'
 import '@patternfly/react-styles/css/components/CodeEditor/code-editor.css'
 import { useTranslation } from 'react-i18next'


### PR DESCRIPTION
https://marvelapp.com/prototype/fcb41ia/screen/74701580

Closes:  https://github.com/open-cluster-management/backlog/issues/8467

---

APIs have auto-detect behavior, which makes the Cloud input field not useful to surface to the user
The environment field is not surfaced to the user on the Create cluster flow, on create cluster the user has just the additional labels behavior which already exists on this page, the user can add environment if desired through that field.