### PR TITLE
Create BMA rbac bug fix

### DIFF
--- a/frontend/src/resources/self-subject-access-review.ts
+++ b/frontend/src/resources/self-subject-access-review.ts
@@ -233,6 +233,16 @@ export function rbacMapping(action: string, name?: string, namespace?: string) {
                     verb: 'patch',
                 },
             ]
+        case 'bma.create':
+            return [
+                {
+                    name,
+                    namespace,
+                    group: 'inventory.open-cluster-management.io',
+                    resource: 'baremetalassets',
+                    verb: 'create',
+                },
+            ]
         case 'bma.delete':
             return [
                 {

--- a/frontend/src/routes/BareMetalAssets/CreateBareMetalAsset.test.tsx
+++ b/frontend/src/routes/BareMetalAssets/CreateBareMetalAsset.test.tsx
@@ -16,8 +16,10 @@ const mockSelfSubjectAccessRequest: SelfSubjectAccessReview = {
     metadata: {},
     spec: {
         resourceAttributes: {
+            name: '',
             namespace: 'test-namespace',
-            resource: 'secrets',
+            group: 'inventory.open-cluster-management.io',
+            resource: 'baremetalassets',
             verb: 'create',
         },
     },

--- a/frontend/src/routes/BareMetalAssets/CreateBareMetalAsset.tsx
+++ b/frontend/src/routes/BareMetalAssets/CreateBareMetalAsset.tsx
@@ -151,7 +151,7 @@ export function CreateBareMetalAssetPageData() {
         result.promise
             .then(async (projects) => {
                 const namespaces = projects!.map((project) => project.metadata.name!)
-                await rbacNamespaceFilter('secret.create', namespaces).then(setProjects).catch(setError)
+                await rbacNamespaceFilter('bma.create', namespaces).then(setProjects).catch(setError)
             })
             .catch(setError)
             .finally(() => setIsLoading(false))


### PR DESCRIPTION
regarding: https://coreos.slack.com/archives/GUGB0LDDL/p1612417671208100

Namespace Filter in CreateBareMetalAsset.tsx was using incorrect permission check, allowing default edit users to create BMA assets.