### PR TITLE
test multiple worker pool change

### DIFF
--- a/frontend/src/routes/ClusterManagement/Clusters/CreateCluster/templates/install-config.hbs
+++ b/frontend/src/routes/ClusterManagement/Clusters/CreateCluster/templates/install-config.hbs
@@ -85,7 +85,7 @@ compute:
 {{/if_eq}}
 
 {{#each workerPools}}
-{{#if @first}}
+{{! #if @first}}
 compute:
 - hyperthreading: Enabled
   name: {{{workerName}}}
@@ -140,7 +140,7 @@ compute:
   {{/case}}
 
 {{/switch}}
-{{/if}}
+{{! /if}}
 {{/each}}
 
 


### PR DESCRIPTION
Tried original change and the yaml was not correct for hive.  I did a manual change to correct yaml and hive still did not like it.  Will need to table this investigative item for now.


OK, found this info in the OpenShift installer doc - https://docs.openshift.com/container-platform/4.6/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal
```
The controlPlane section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the compute section must begin with a hyphen, -, and the first line of the controlPlane section must not. Although both sections currently define a single machine pool, it is possible that future versions of OpenShift Container Platform will support defining multiple compute pools during installation.
```
so multiple worker pools not currently supported.