### PR TITLE
further cleanup of server side events

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -76,6 +76,6 @@ export async function stop(): Promise<void> {
     stopLogger()
 }
 
-if (process.env.NODE_ENV === 'development' || process.env.LOG_MEMORY === 'true') {
+if (process.env.LOG_MEMORY === 'true') {
     startLoggingMemory()
 }

--- a/backend/src/lib/compression.ts
+++ b/backend/src/lib/compression.ts
@@ -18,15 +18,15 @@ export function getDecodeStream(stream: Readable, contentEncoding?: string | str
             return stream
         case 'deflate':
             return pipeline(stream, createDeflate(), (err) => {
-                if (err) logger.error(err)
+                if (err) logger.warn(err)
             })
         case 'br':
             return pipeline(stream, createBrotliDecompress(), (err) => {
-                if (err) logger.error(err)
+                if (err) logger.warn(err)
             })
         case 'gzip':
             return pipeline(stream, createGunzip(), (err) => {
-                if (err) logger.error(err)
+                if (err) logger.warn(err)
             })
         default:
             throw new Error('Unknown content encoding')
@@ -58,7 +58,11 @@ export function getEncodeStream(
 
     if (compressionStream) {
         pipeline(compressionStream, stream, (err) => {
-            if (err) logger.error(err)
+            // Client might close stream while we are still writing to it
+            // ignore it for now as there is no issue here
+            // TODO - long term should we close the compression stream
+            // when client request ends?
+            // if (err) logger.warn(err)
         })
     }
     return [stream, compressionStream, encoding]

--- a/backend/src/lib/main.ts
+++ b/backend/src/lib/main.ts
@@ -7,7 +7,7 @@ import { cpus, totalmem } from 'os'
 import { logger, logLevel } from './logger'
 import { start, stop } from '../app'
 
-logger.info({
+logger.debug({
     msg: `process start`,
     NODE_ENV: process.env.NODE_ENV,
     cpus: `${Object.keys(cpus()).length}`,
@@ -20,7 +20,7 @@ process.on('exit', function processExit(code) {
     if (code !== 0) {
         logger.error({ msg: `process exit`, code: code })
     } else {
-        logger.info({ msg: `process exit`, code: code })
+        logger.debug({ msg: `process exit`, code: code })
     }
 })
 
@@ -32,12 +32,13 @@ process.on('SIGINT', () => {
 })
 
 process.on('SIGTERM', () => {
-    logger.info({ msg: 'process SIGTERM' })
+    logger.debug({ msg: 'process SIGTERM' })
     void stop()
 })
 
 process.on('uncaughtException', (err) => {
     logger.error({ msg: `process uncaughtException`, error: err.message })
+    console.log(err.stack)
     // void stop()
 })
 

--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -1,6 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { type } from 'node:os'
 import { Transform } from 'stream'
 import { clearInterval } from 'timers'
 import { Zlib } from 'zlib'

--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -1,5 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import { type } from 'node:os'
 import { Transform } from 'stream'
 import { clearInterval } from 'timers'
 import { Zlib } from 'zlib'
@@ -38,8 +39,12 @@ export interface IEventClient {
 }
 
 export class ServerSideEvents {
-    private static eventID = 0
-    private static events: Record<number, IEvent> = {}
+    private static eventID = 2
+    private static lastDoneID = 2
+    private static events: Record<number, IEvent> = {
+        1: { id: '1', data: { type: 'START' } },
+        2: { id: '2', data: { type: 'BOOKMARK' } },
+    }
     private static clients: Record<string, IEventClient> = {}
 
     public static eventFilter: (clientID: string, event: Readonly<IEvent>) => Promise<IEvent | undefined>
@@ -66,6 +71,16 @@ export class ServerSideEvents {
         event.id = eventID.toString()
         this.events[eventID] = event
         this.broadcastEvent(event)
+
+        this.removeEvent(this.lastDoneID)
+        this.lastDoneID = ++this.eventID
+        const doneEvent = {
+            id: this.lastDoneID.toString(),
+            data: { type: 'BOOKMARK' },
+        }
+        this.events[this.lastDoneID] = doneEvent
+        this.broadcastEvent(doneEvent)
+
         return eventID
     }
 
@@ -118,7 +133,7 @@ export class ServerSideEvents {
                         }
                     }
 
-                    if (watchEvent.object) {
+                    if (watchEvent?.object) {
                         const { kind, metadata } = watchEvent.object
                         const name = metadata?.name
                         const namespace = metadata?.namespace
@@ -242,16 +257,9 @@ export class ServerSideEvents {
             this.sendEvent(clientID, this.events[eventID])
             sentCount++
         }
-        eventClient.eventQueue.push(
-            Promise.resolve({
-                data: {
-                    type: 'LOADED',
-                },
-            })
-        )
 
         const msg: Record<string, string | number | undefined> = {
-            msg: 'OK',
+            msg: 'Streaming',
             status: 200,
             method: req.method,
             path: req.url,
@@ -284,5 +292,5 @@ export class ServerSideEvents {
     }
     private static intervalTimer: NodeJS.Timer | undefined = setInterval(() => {
         ServerSideEvents.keepAlivePing()
-    }, 60 * 1000)
+    }, 110 * 1000)
 }

--- a/backend/src/routes/watch.ts
+++ b/backend/src/routes/watch.ts
@@ -17,7 +17,7 @@ const resources: Record<string, Record<string, number>> = {}
 const watchRequests: Record<string, ClientRequest> = {}
 
 interface WatchEvent {
-    type: 'ADDED' | 'DELETED' | 'MODIFIED'
+    type: 'ADDED' | 'DELETED' | 'MODIFIED' | 'BOOKMARK' | 'START'
     object: {
         kind: string
         apiVersion: string
@@ -114,8 +114,15 @@ export function startWatching(token: string): void {
 
     ServerSideEvents.eventFilter = (token, event) => {
         const watchEvent = event.data as WatchEvent
+        if (watchEvent.type === 'START') return Promise.resolve(event)
+        if (watchEvent.type === 'BOOKMARK') return Promise.resolve(event)
         if (watchEvent.type === 'DELETED') return Promise.resolve(event)
         // TODO - track what is sent to s specific token and only send delete
+
+        if (!watchEvent.object) {
+            console.log(watchEvent)
+            return Promise.reject()
+        }
 
         return canAccess(
             { kind: watchEvent.object.kind, apiVersion: watchEvent.object.apiVersion },


### PR DESCRIPTION
The BOOKMARK events needed an id, otherwise the server side event reconnect would reload everything.
Handled reconnecting to different instances of the backend.