### PR TITLE
Add open-cluster-management label to featuregate example

### DIFF
--- a/backend/src/routes/watch.ts
+++ b/backend/src/routes/watch.ts
@@ -77,7 +77,7 @@ export function startWatching(): void {
     watchResource(token, 'discovery.open-cluster-management.io/v1', 'discoveryConfigs')
     watchResource(token, 'config.openshift.io/v1', 'featureGates', {
         labelSelector: {
-            'open-cluster-management': '',
+            'console.open-cluster-management.io': '',
         },
     })
     watchResource(token, 'v1', 'configmaps', {

--- a/docs/featuregate.yaml
+++ b/docs/featuregate.yaml
@@ -6,6 +6,6 @@ kind: FeatureGate
 metadata:
   name: open-cluster-management-discovery
   labels:
-    open-cluster-management: ''
+    console.open-cluster-management.io: ''
 spec:
   featureSet: DiscoveryEnabled

--- a/docs/featuregate.yaml
+++ b/docs/featuregate.yaml
@@ -5,5 +5,7 @@ apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
   name: open-cluster-management-discovery
+  labels:
+    open-cluster-management: ''
 spec:
   featureSet: DiscoveryEnabled


### PR DESCRIPTION
Ensure example of discovery feature gate in docs has label shown here - 
https://github.com/open-cluster-management/console/blob/main/backend/src/routes/watch.ts#L80