### PR TITLE
Add cluster set label to ClusterDeployment

### DIFF
--- a/frontend/src/routes/ClusterManagement/Clusters/CreateCluster/templates/hive-template.hbs
+++ b/frontend/src/routes/ClusterManagement/Clusters/CreateCluster/templates/hive-template.hbs
@@ -16,6 +16,9 @@ metadata:
     region: '{{{region}}}'  ##region
 {{/if}}
     vendor: '{{distribution}}'
+{{#if clusterSet}}
+    cluster.open-cluster-management.io/clusterSet: {{{clusterSet}}}
+{{/if}}
 {{#if_eq infrastructure 'BMC'}}
   annotations:
     hive.openshift.io/try-install-once: "true"


### PR DESCRIPTION
Per architecture call, cluster set labels will also need to be added to ClusterDeployments