### PR TITLE
Added actionList to cluster empty and bma empty

### DIFF
--- a/frontend/src/routes/BareMetalAssets/BareMetalAssetsPage.tsx
+++ b/frontend/src/routes/BareMetalAssets/BareMetalAssetsPage.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { AcmButton, AcmEmptyState, AcmPageContent, AcmTable } from '@open-cluster-management/ui-components'
-import { Bullseye, PageSection, Split, SplitItem } from '@patternfly/react-core'
+import { ActionList, ActionListItem, Bullseye, PageSection, Split, SplitItem } from '@patternfly/react-core'
 import { fitContent, TableGridBreakpoint } from '@patternfly/react-table'
 import React, { Fragment, useEffect, useState } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
@@ -165,8 +165,8 @@ export function BareMetalAssetsTable(props: {
                         }
                         action={
                             <Bullseye>
-                                <Split hasGutter>
-                                    <SplitItem>
+                                <ActionList>
+                                    <ActionListItem>
                                         <AcmButton
                                             variant="primary"
                                             onClick={() => {
@@ -175,8 +175,8 @@ export function BareMetalAssetsTable(props: {
                                         >
                                             {t('createBareMetalAsset.title')}
                                         </AcmButton>
-                                    </SplitItem>
-                                    <SplitItem>
+                                    </ActionListItem>
+                                    <ActionListItem>
                                         <AcmButton
                                             variant="primary"
                                             onClick={() => {
@@ -185,8 +185,8 @@ export function BareMetalAssetsTable(props: {
                                         >
                                             {t('importBareMetalAssets.title')}
                                         </AcmButton>
-                                    </SplitItem>
-                                </Split>
+                                    </ActionListItem>
+                                </ActionList>
                             </Bullseye>
                         }
                     />

--- a/frontend/src/routes/BareMetalAssets/BareMetalAssetsPage.tsx
+++ b/frontend/src/routes/BareMetalAssets/BareMetalAssetsPage.tsx
@@ -1,10 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { AcmButton, AcmEmptyState, AcmPageContent, AcmTable } from '@open-cluster-management/ui-components'
-import { ActionList, ActionListItem, Bullseye, PageSection, Split, SplitItem } from '@patternfly/react-core'
+import { ActionList, ActionListItem, Bullseye, PageSection } from '@patternfly/react-core'
 import { fitContent, TableGridBreakpoint } from '@patternfly/react-table'
-import React, { Fragment, useEffect, useState } from 'react'
-import { useTranslation, Trans } from 'react-i18next'
+import { Fragment, useEffect, useState } from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
 import { bareMetalAssetsState } from '../../atoms'

--- a/frontend/src/routes/ClusterManagement/Clusters/components/AddCluster.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/AddCluster.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { AcmButton, AcmDropdown } from '@open-cluster-management/ui-components'
-import { Bullseye, Split, SplitItem } from '@patternfly/react-core'
+import { ActionList, ActionListItem, Bullseye } from '@patternfly/react-core'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
@@ -24,8 +24,8 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
     if (props.type === 'button') {
         return (
             <Bullseye>
-                <Split hasGutter>
-                    <SplitItem>
+                <ActionList>
+                    <ActionListItem>
                         <AcmButton
                             component={Link}
                             isDisabled={!canCreateCluster}
@@ -35,8 +35,8 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
                         >
                             {t('managed.createCluster')}
                         </AcmButton>
-                    </SplitItem>
-                    <SplitItem>
+                    </ActionListItem>
+                    <ActionListItem>
                         <AcmButton
                             component={Link}
                             isDisabled={!canCreateCluster}
@@ -46,8 +46,8 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
                         >
                             {t('managed.importCluster')}
                         </AcmButton>
-                    </SplitItem>
-                </Split>
+                    </ActionListItem>
+                </ActionList>
             </Bullseye>
         )
     } else {


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Added ActionList and ActionListItems to empty page buttons on clusters and bare metal assets page.

![Screen Shot 2021-04-17 at 2 51 43 PM](https://user-images.githubusercontent.com/21374229/115123747-70b3c700-9f8c-11eb-931b-6874d794d7a5.png)

![Screen Shot 2021-04-17 at 2 56 49 PM](https://user-images.githubusercontent.com/21374229/115123886-2c74f680-9f8d-11eb-9043-97291e99d9d9.png)
