### PR TITLE
fix installconfig can be undefined in clusterdeployment

### DIFF
--- a/frontend/src/lib/get-cluster.ts
+++ b/frontend/src/lib/get-cluster.ts
@@ -172,7 +172,7 @@ export function getHiveConfig(clusterDeployment?: ClusterDeployment, clusterClai
         secrets: {
             kubeconfig: clusterDeployment?.spec?.clusterMetadata?.adminKubeconfigSecretRef.name,
             kubeadmin: clusterDeployment?.spec?.clusterMetadata?.adminPasswordSecretRef.name,
-            installConfig: clusterDeployment?.spec?.provisioning.installConfigSecretRef.name,
+            installConfig: clusterDeployment?.spec?.provisioning?.installConfigSecretRef?.name,
         },
         clusterClaimName: clusterDeployment?.spec?.clusterPoolRef?.claimName,
         lifetime: clusterClaim?.spec?.lifetime,


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

Fixing cluster page crashing when using Assisted-Installer ClusterDeployments where installconfig can be omitted.