### PR TITLE
Update cidebar to use new PolicyReport & use watch

### DIFF
--- a/backend/src/routes/watch.ts
+++ b/backend/src/routes/watch.ts
@@ -81,6 +81,7 @@ export function startWatching(): void {
         },
     })
     watchResource(token, 'cluster.open-cluster-management.io/v1beta1', 'clustercurators')
+    watchResource(token, 'wgpolicyk8s.io/v1alpha2', 'policyreports')
 }
 
 const watchRequests: Record<string, ClientRequest> = {}

--- a/frontend/src/atoms.tsx
+++ b/frontend/src/atoms.tsx
@@ -21,6 +21,8 @@ import { ManagedClusterAddOn, ManagedClusterAddOnKind } from './resources/manage
 import { ManagedClusterInfo, ManagedClusterInfoKind } from './resources/managed-cluster-info'
 import { ManagedClusterSet, ManagedClusterSetKind } from './resources/managed-cluster-set'
 import { MultiClusterHub, MultiClusterHubKind } from './resources/multi-cluster-hub'
+import { PolicyReport, PolicyReportKind } from './resources/policy-report'
+
 import { Namespace, NamespaceKind } from './resources/namespace'
 import { Secret, SecretKind } from './resources/secret'
 import { ClusterCurator, ClusterCuratorKind } from './resources/cluster-curator'
@@ -53,6 +55,7 @@ export const managedClusterSetsState = atom<ManagedClusterSet[]>({ key: 'managed
 export const multiClusterHubState = atom<MultiClusterHub[]>({ key: 'multiClusterHubs', default: [] })
 export const namespacesState = atom<Namespace[]>({ key: 'namespaces', default: [] })
 export const secretsState = atom<Secret[]>({ key: 'secrets', default: [] })
+export const policyreportState = atom<PolicyReport[]>({ key: 'policyreports', default: [] })
 
 interface IEventData {
     type: 'ADDED' | 'DELETED' | 'MODIFIED' | 'LOADED' | 'START'
@@ -90,6 +93,7 @@ export function LoadData(props: { children?: ReactNode }) {
     const [, setNamespaces] = useRecoilState(namespacesState)
     const [, setSecrets] = useRecoilState(secretsState)
     const [, setClusterCurators] = useRecoilState(clusterCuratorsState)
+    const [, setPolicyReports] = useRecoilState(policyreportState)
 
     const setters: Record<string, SetterOrUpdater<any[]>> = {
         [BareMetalAssetKind]: setBareMetalAssets,
@@ -113,6 +117,7 @@ export function LoadData(props: { children?: ReactNode }) {
         [NamespaceKind]: setNamespaces,
         [SecretKind]: setSecrets,
         [ClusterCuratorKind]: setClusterCurators,
+        [PolicyReportKind]: setPolicyReports,
     }
 
     useEffect(() => {

--- a/frontend/src/resources/policy-report.ts
+++ b/frontend/src/resources/policy-report.ts
@@ -1,7 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { V1ObjectMeta } from '@kubernetes/client-node/dist'
-import { listNamespacedResources } from '../lib/resource-request'
 
 export const PolicyReportApiVersion = 'wgpolicyk8s.io/v1alpha2'
 export type PolicyReportApiVersionType = 'wgpolicyk8s.io/v1alpha2'
@@ -13,27 +12,18 @@ export interface PolicyReport {
     apiVersion: PolicyReportApiVersionType
     kind: PolicyReportKindType
     metadata: V1ObjectMeta
-    results: [
-        {
-            category: string
-            properties: {
-                created_at: string
-                details: string
-                reason: string
-                resolution: string
-                total_risk: string
-            }
-            message: string
-            policy: string
-            result: string
-        }
-    ]
+    results: PolicyReportResults[]
 }
 
-export function listNamespacedPolicyReports(namespace: string) {
-    return listNamespacedResources<PolicyReport>({
-        apiVersion: PolicyReportApiVersion,
-        kind: PolicyReportKind,
-        metadata: { namespace },
-    })
+export interface PolicyReportResults {
+    policy: string
+    message: string
+    scored: boolean
+    category: string
+    result: string
+    properties: {
+        created_at: string
+        total_risk: string
+        component: string
+    }
 }

--- a/frontend/src/routes/ClusterManagement/Clusters/components/ClusterPolicySidebar.test.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/ClusterPolicySidebar.test.tsx
@@ -5,59 +5,80 @@ import { ClusterPolicySidebar } from './ClusterPolicySidebar'
 import { PolicyReport } from '../../../../resources/policy-report'
 import { clickByText, waitForText } from '../../../../lib/test-util'
 
-const testData: PolicyReport[] = [
-    {
-        apiVersion: 'wgpolicyk8s.io/v1alpha2',
-        kind: 'PolicyReport',
-        metadata: {
-            name: 'policyreport testing risk 1 policy',
-            namespace: 'test-cluster',
-            uid: 'uid.report.risk.1',
-        },
-        results: [
-            {
-                category: 'category,category1,category2',
-                properties: {
-                    created_at: '2021-03-02T21:26:04Z',
-                    details: 'policyreport testing risk 1 details',
-                    reason: 'policyreport testing risk 1 reason',
-                    resolution: 'policyreport testing\n\nrisk 1 resolution',
-                    total_risk: '1',
-                },
-                message: 'policyreport testing risk 1',
-                policy: 'policyreport testing risk 1 policy',
-                result: 'policyreport testing risk 1 result',
-            },
-        ],
+const mockPolicyReports: PolicyReport = {
+    apiVersion: 'wgpolicyk8s.io/v1alpha2',
+    kind: 'PolicyReport',
+    metadata: {
+        name: 'test-cluster',
+        namespace: 'test-cluster',
+        uid: 'uid.report.risk.1',
     },
-    {
-        apiVersion: 'wgpolicyk8s.io/v1alpha2',
-        kind: 'PolicyReport',
-        metadata: {
-            name: 'policyreport testing risk 2 policy',
-            namespace: 'test-cluster',
-            uid: 'uid.report.risk.2',
-        },
-        results: [
-            {
-                category: 'category,category1,category2',
-                properties: {
-                    created_at: '2021-03-02T21:26:04Z',
-                    details: 'policyreport testing risk 2 details',
-                    reason: 'policyreport testing risk 2 reason',
-                    resolution: 'policyreport testing risk 2 resolution',
-                    total_risk: '2',
-                },
-                message: 'policyreport testing risk 2',
-                policy: 'policyreport testing risk 2 policy',
-                result: 'policyreport testing risk 2 result',
+    results: [
+        {
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-03-02T21:26:04Z',
+                total_risk: '0',
+                component: 'rule.id.0',
             },
-        ],
-    },
-]
+            message: 'policyreport testing risk 0',
+            policy: 'policyreport testing risk 0 policy',
+            result: 'policyreport testing risk 0 result',
+        },
+        {
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-03-02T21:26:04Z',
+                total_risk: '1',
+                component: 'rule.id.1',
+            },
+            message: 'policyreport testing risk 1',
+            policy: 'policyreport testing risk 1 policy',
+            result: 'policyreport testing risk 1 result',
+        },
+        {
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-03-02T21:26:04Z',
+                total_risk: '2',
+                component: 'rule.id.2',
+            },
+            message: 'policyreport testing risk 2',
+            policy: 'policyreport testing risk 2 policy',
+            result: 'policyreport testing risk 2 result',
+        },
+        {
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-04-02T21:26:04Z',
+                total_risk: '3',
+                component: 'rule.id.3',
+            },
+            message: 'policyreport testing risk 3',
+            policy: 'policyreport testing risk 3 policy',
+            result: 'policyreport testing risk 3 result',
+        },
+        {
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-03-02T21:26:04Z',
+                total_risk: '4',
+                component: 'rule.id.4',
+            },
+            message: 'policyreport testing risk 4',
+            policy: 'policyreport testing risk 4 policy',
+            result: 'policyreport testing risk 4 result',
+        },
+    ],
+}
 
 describe('ClusterPolicySidebar', () => {
-    const Component = () => <ClusterPolicySidebar data={testData} />
+    const Component = () => <ClusterPolicySidebar data={mockPolicyReports} />
     test('renders', async () => {
         render(<Component />)
         await act(async () => {
@@ -70,15 +91,6 @@ describe('ClusterPolicySidebar', () => {
 
             // wait for drilldown risk subdetail component
             await waitForText('policy.report.low')
-
-            // Wait for the policyreport remediation text to be displayed
-            await waitForText('policy.report.flyout.details.tab.remediation')
-            await waitForText('policyreport testing')
-            await waitForText('risk 1 resolution')
-
-            // Click reason tab and wait for text to be displayed
-            await clickByText('policy.report.flyout.details.tab.reason')
-            await waitForText('policyreport testing risk 1 reason')
 
             // Click back button and wait for static text
             await clickByText('policy.report.flyout.back')

--- a/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.test.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.test.tsx
@@ -207,6 +207,7 @@ describe('StatusSummaryCount', () => {
             </MemoryRouter>
         </RecoilRoot>
     )
+
     test('renders', async () => {
         const search = nockSearch(mockSearchQuery, mockSearchResponse)
         render(<Component />)

--- a/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.test.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.test.tsx
@@ -3,10 +3,13 @@
 import { MemoryRouter } from 'react-router-dom'
 import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { RecoilRoot } from 'recoil'
+import { policyreportState } from '../../../../atoms'
 import { StatusSummaryCount } from './StatusSummaryCount'
 import { ClusterContext } from '../ClusterDetails/ClusterDetails'
 import { ClusterStatus, Cluster } from '../../../../lib/get-cluster'
-import { nockSearch, nockNamespacedList } from '../../../../lib/nock-util'
+import { nockSearch } from '../../../../lib/nock-util'
+import { PolicyReport } from '../../../../resources/policy-report'
 
 window.open = jest.fn()
 
@@ -156,87 +159,58 @@ const mockSearchResponse = {
     },
 }
 
-const mockPolicyReportList = {
-    kind: 'PolicyReportList',
-    apiVersion: 'v1',
-    metadata: {},
-    items: [
+const mockPolicyReports: PolicyReport[] = [{
+    apiVersion: 'wgpolicyk8s.io/v1alpha2',
+    kind: 'PolicyReport',
+    metadata: {
+        name: 'test-cluster',
+        namespace: 'test-cluster',
+        uid: 'uid.report.risk.1',
+    },
+    results: [
         {
-            apiVersion: 'wgpolicyk8s.io/v1alpha2',
-            kind: 'PolicyReport',
-            metadata: {
-                creationTimestamp: '2021-03-06T18:38:14Z',
-                name: 'policyreport testing risk 1 policy',
-                namespace: 'test-cluster',
-                uid: 'uid.report.risk.1',
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-03-02T21:26:04Z',
+                total_risk: '1',
+                component: 'rule.id.3',
             },
-            results: [
-                {
-                    category: 'category,category1,category2',
-                    properties: {
-                        created_at: '2021-03-02T21:26:04Z',
-                        details: 'policyreport testing risk 1 details',
-                        reason: 'policyreport testing risk 1 reason',
-                        resolution: 'policyreport testing risk 1 resolution',
-                        total_risk: '1',
-                    },
-                    message: 'policyreport testing risk 1',
-                    policy: 'policyreport testing risk 1 policy',
-                    result: 'policyreport testing risk 1 result',
-                },
-            ],
+            message: 'policyreport testing risk 1',
+            policy: 'policyreport testing risk 1 policy',
+            result: 'policyreport testing risk 1 result',
         },
         {
-            apiVersion: 'wgpolicyk8s.io/v1alpha2',
-            kind: 'PolicyReport',
-            metadata: {
-                creationTimestamp: '2021-03-06T18:38:14Z',
-                name: 'policyreport testing risk 2 policy',
-                namespace: 'test-cluster',
-                uid: 'uid.report.risk.2',
+            category: 'category,category1,category2',
+            scored: false,
+            properties: {
+                created_at: '2021-04-02T21:26:04Z',
+                total_risk: '3',
+                component: 'rule.id.3',
             },
-            results: [
-                {
-                    category: 'category,category1,category2',
-                    properties: {
-                        created_at: '2021-03-02T21:26:04Z',
-                        details: 'policyreport testing risk 2 details',
-                        reason: 'policyreport testing risk 2 reason',
-                        resolution: 'policyreport testing risk 2 resolution',
-                        total_risk: '2',
-                    },
-                    message: 'policyreport testing risk 2',
-                    policy: 'policyreport testing risk 2 policy',
-                    result: 'policyreport testing risk 2 result',
-                },
-            ],
+            message: 'policyreport testing risk 3',
+            policy: 'policyreport testing risk 3 policy',
+            result: 'policyreport testing risk 3 result',
         },
     ],
-}
+}]
 
 describe('StatusSummaryCount', () => {
     const Component = () => (
-        <MemoryRouter>
-            <ClusterContext.Provider value={{ cluster: mockCluster, addons: undefined }}>
-                <StatusSummaryCount />
-            </ClusterContext.Provider>
-        </MemoryRouter>
+        <RecoilRoot initializeState={(snapshot) => snapshot.set(policyreportState, mockPolicyReports)}>
+            <MemoryRouter>
+                <ClusterContext.Provider value={{ cluster: mockCluster, addons: undefined }}>
+                    <StatusSummaryCount />
+                </ClusterContext.Provider>
+            </MemoryRouter>
+        </RecoilRoot>
     )
     test('renders', async () => {
         const search = nockSearch(mockSearchQuery, mockSearchResponse)
-        const policyReportNock = nockNamespacedList(
-            {
-                apiVersion: 'wgpolicyk8s.io/v1alpha2',
-                kind: 'PolicyReport',
-                metadata: { namespace: 'test-cluster' },
-            },
-            mockPolicyReportList
-        )
         render(<Component />)
         await act(async () => {
             await waitFor(() => expect(screen.getAllByRole('progressbar').length).toBeGreaterThan(0))
             await waitFor(() => expect(search.isDone()).toBeTruthy())
-            await waitFor(() => expect(policyReportNock.isDone()).toBeTruthy())
             await waitFor(() => expect(screen.queryByRole('progressbar')).toBeNull())
             await waitFor(() => expect(screen.getByTestId('summary-status')).toBeInTheDocument())
 

--- a/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.test.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.test.tsx
@@ -159,41 +159,43 @@ const mockSearchResponse = {
     },
 }
 
-const mockPolicyReports: PolicyReport[] = [{
-    apiVersion: 'wgpolicyk8s.io/v1alpha2',
-    kind: 'PolicyReport',
-    metadata: {
-        name: 'test-cluster',
-        namespace: 'test-cluster',
-        uid: 'uid.report.risk.1',
+const mockPolicyReports: PolicyReport[] = [
+    {
+        apiVersion: 'wgpolicyk8s.io/v1alpha2',
+        kind: 'PolicyReport',
+        metadata: {
+            name: 'test-cluster',
+            namespace: 'test-cluster',
+            uid: 'uid.report.risk.1',
+        },
+        results: [
+            {
+                category: 'category,category1,category2',
+                scored: false,
+                properties: {
+                    created_at: '2021-03-02T21:26:04Z',
+                    total_risk: '1',
+                    component: 'rule.id.3',
+                },
+                message: 'policyreport testing risk 1',
+                policy: 'policyreport testing risk 1 policy',
+                result: 'policyreport testing risk 1 result',
+            },
+            {
+                category: 'category,category1,category2',
+                scored: false,
+                properties: {
+                    created_at: '2021-04-02T21:26:04Z',
+                    total_risk: '3',
+                    component: 'rule.id.3',
+                },
+                message: 'policyreport testing risk 3',
+                policy: 'policyreport testing risk 3 policy',
+                result: 'policyreport testing risk 3 result',
+            },
+        ],
     },
-    results: [
-        {
-            category: 'category,category1,category2',
-            scored: false,
-            properties: {
-                created_at: '2021-03-02T21:26:04Z',
-                total_risk: '1',
-                component: 'rule.id.3',
-            },
-            message: 'policyreport testing risk 1',
-            policy: 'policyreport testing risk 1 policy',
-            result: 'policyreport testing risk 1 result',
-        },
-        {
-            category: 'category,category1,category2',
-            scored: false,
-            properties: {
-                created_at: '2021-04-02T21:26:04Z',
-                total_risk: '3',
-                component: 'rule.id.3',
-            },
-            message: 'policyreport testing risk 3',
-            policy: 'policyreport testing risk 3 policy',
-            result: 'policyreport testing risk 3 result',
-        },
-    ],
-}]
+]
 
 describe('StatusSummaryCount', () => {
     const Component = () => (


### PR DESCRIPTION
Related issue: https://github.com/open-cluster-management/backlog/issues/11701

Changes:
  - Use watch to get PolicyReport resources in cluster details page
  - Update sidebar to handle new PolicyReport 