### PR TITLE
12655 disco tweaks

### DIFF
--- a/frontend/public/locales/en/discovery.json
+++ b/frontend/public/locales/en/discovery.json
@@ -12,6 +12,7 @@
     "alert.deleted.header": "{{credentialName}} discovery setting was removed successfully",
     "alert.msg": "You can configure settings in Clusters > Discovered clusters",
 
+    "techpreview.msg": "<bold>Tech preview</bold>: For more information, <a>view documentation</a> on Discovered clusters",
 
     "disable.title": "Delete discovery settings",
     "discoveryConfig.delete.btn": "Delete",
@@ -61,8 +62,7 @@
     "emptystate.enableClusterDiscovery": "Configure Discovery",
 
     "emptystate.discoveryEnabled.title": "No discovered clusters found",
-    "emptystate.discoveryEnabled.msg": "You don't have any discovered clusters. Cluster discovery was configured. Return to this page later, or configure Discovery again.",
-    "emptystate.viewDocumentation": "View documentation",
+    "emptystate.discoveryEnabled.msg": "You don't have any discovered clusters. Cluster discovery was configured. Return to this page later, configure Discovery again, or <a>view documentation <icon /></a>",
 
     "dcTbl.name": "Name",
     "dcTbl.status": "Status",

--- a/frontend/src/routes/Discovery/DiscoveredClusters/DiscoveredClusters.test.tsx
+++ b/frontend/src/routes/Discovery/DiscoveredClusters/DiscoveredClusters.test.tsx
@@ -190,7 +190,8 @@ describe('DiscoveredClusters', () => {
             </RecoilRoot>
         )
         await waitForText('emptystate.discoveryEnabled.title')
-        await waitForText('emptystate.discoveryEnabled.msg')
-        await waitForText('emptystate.viewDocumentation')
+        await waitForText('discovery:emptystate.discoveryEnabled.msg')
+        await waitForText('discovery.configureDiscovery')
+        await waitForText('discovery.addDiscovery')
     })
 })

--- a/frontend/src/routes/Discovery/DiscoveredClusters/DiscoveredClusters.tsx
+++ b/frontend/src/routes/Discovery/DiscoveredClusters/DiscoveredClusters.tsx
@@ -15,7 +15,7 @@ import {
     IAcmTableColumn,
     Provider,
 } from '@open-cluster-management/ui-components'
-import { ButtonVariant, PageSection } from '@patternfly/react-core'
+import { Alert, ActionList, ActionListItem, ButtonVariant, PageSection, Bullseye } from '@patternfly/react-core'
 import * as moment from 'moment'
 import { Fragment, useContext, useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -27,6 +27,7 @@ import { DiscoveredCluster } from '../../../resources/discovered-cluster'
 import { DiscoveryConfig } from '../../../resources/discovery-config'
 import { ProviderConnection, unpackProviderConnection } from '../../../resources/provider-connection'
 import { DiscoNotification } from '../DiscoveryComponents/Notification'
+import { BellIcon } from '@patternfly/react-icons'
 
 export default function DiscoveredClustersPage() {
     return (
@@ -108,16 +109,45 @@ function EmptyStateAwaitingDiscoveredClusters() {
     return (
         <AcmEmptyState
             title={t('emptystate.discoveryEnabled.title')}
-            message={t('emptystate.discoveryEnabled.msg')}
+            message={
+                <Trans
+                    i18nKey={'discovery:emptystate.discoveryEnabled.msg'}
+                    components={{
+                        a: (
+                            <a href="/#" target="_blank" rel="noreferrer">
+                                {}
+                            </a>
+                        ),
+                        icon: <AcmIcon icon={AcmIconVariant.openNewTab} />,
+                    }}
+                />
+            }
             key="dcEmptyState"
             showIcon={true}
             image={AcmEmptyStateImage.folder}
             action={
-                <AcmButton variant="link">
-                    <span style={{ whiteSpace: 'nowrap' }} key="dcStatusParent">
-                        {t('emptystate.viewDocumentation')} <AcmIcon icon={AcmIconVariant.openNewTab} />
-                    </span>
-                </AcmButton>
+                <Bullseye>
+                    <ActionList>
+                        <ActionListItem>
+                            <AcmButton
+                                variant={ButtonVariant.primary}
+                                component={Link}
+                                to={NavigationPath.configureDiscovery}
+                            >
+                                {t('discovery.configureDiscovery')}
+                            </AcmButton>
+                        </ActionListItem>
+                        <ActionListItem>
+                            <AcmButton
+                                variant={ButtonVariant.secondary}
+                                component={Link}
+                                to={NavigationPath.createDiscovery}
+                            >
+                                {t('discovery.addDiscovery')}
+                            </AcmButton>
+                        </ActionListItem>
+                    </ActionList>
+                </Bullseye>
             }
         />
     )
@@ -309,42 +339,72 @@ export function DiscoveredClustersTable(props: {
         },
     ]
 
-    return (
-        <AcmTable<DiscoveredCluster>
-            plural={t('discoveredClusters')}
-            items={props.discoveredClusters}
-            columns={discoveredClusterCols}
-            keyFn={dckeyFn}
-            key="tbl-discoveredclusters"
-            tableActions={[
-                {
-                    id: 'configureDiscovery',
-                    title: t('discovery.configureDiscovery'),
-                    click: () => history.push(NavigationPath.configureDiscovery),
-                },
-                {
-                    id: 'addDiscovery',
-                    title: t('discovery.addDiscovery'),
-                    click: () => history.push(NavigationPath.createDiscovery),
-                    variant: ButtonVariant.secondary,
-                },
-            ]}
-            bulkActions={[]}
-            rowActions={[
-                {
-                    id: 'importCluster',
-                    title: t('discovery.import'),
-                    click: (item) => {
-                        sessionStorage.setItem('DiscoveredClusterName', item.spec.name)
-                        sessionStorage.setItem('DiscoveredClusterDisplayName', item.spec.displayName)
-                        sessionStorage.setItem('DiscoveredClusterConsoleURL', item.spec.console)
-                        sessionStorage.setItem('DiscoveredClusterApiURL', item.spec.apiUrl)
-                        history.push(NavigationPath.importCluster)
-                    },
-                },
-            ]}
-            emptyState={emptyState}
+    const title = (
+        <Trans
+            i18nKey={'discovery:techpreview.msg'}
+            components={{
+                bold: <strong />,
+                a: (
+                    <a
+                        href="/#"
+                        target="_blank"
+                        rel="noreferrer"
+                        key="techPreviewAlert"
+                        style={{ textDecoration: 'underline', color: 'inherit' }}
+                    >
+                        {}
+                    </a>
+                ),
+            }}
         />
+    )
+
+    return (
+        <Fragment>
+            {/* Tech Preview Message */}
+            <Alert
+                customIcon={<BellIcon />}
+                isInline
+                variant="warning"
+                title={title}
+                style={{ marginBottom: '16px' }}
+            />
+            <AcmTable<DiscoveredCluster>
+                plural={t('discoveredClusters')}
+                items={props.discoveredClusters}
+                columns={discoveredClusterCols}
+                keyFn={dckeyFn}
+                key="tbl-discoveredclusters"
+                tableActions={[
+                    {
+                        id: 'configureDiscovery',
+                        title: t('discovery.configureDiscovery'),
+                        click: () => history.push(NavigationPath.configureDiscovery),
+                    },
+                    {
+                        id: 'addDiscovery',
+                        title: t('discovery.addDiscovery'),
+                        click: () => history.push(NavigationPath.createDiscovery),
+                        variant: ButtonVariant.secondary,
+                    },
+                ]}
+                bulkActions={[]}
+                rowActions={[
+                    {
+                        id: 'importCluster',
+                        title: t('discovery.import'),
+                        click: (item) => {
+                            sessionStorage.setItem('DiscoveredClusterName', item.spec.name)
+                            sessionStorage.setItem('DiscoveredClusterDisplayName', item.spec.displayName)
+                            sessionStorage.setItem('DiscoveredClusterConsoleURL', item.spec.console)
+                            sessionStorage.setItem('DiscoveredClusterApiURL', item.spec.apiUrl)
+                            history.push(NavigationPath.importCluster)
+                        },
+                    },
+                ]}
+                emptyState={emptyState}
+            />
+        </Fragment>
     )
 }
 

--- a/frontend/src/routes/Discovery/DiscoveryConfig/DiscoveryConfig.tsx
+++ b/frontend/src/routes/Discovery/DiscoveryConfig/DiscoveryConfig.tsx
@@ -199,7 +199,7 @@ export function DiscoveryConfigPageContent(props: {
                     confirm: async () => {
                         try {
                             if (discoveryConfig) {
-                                await deleteResource(discoveryConfig as DiscoveryConfig).promise
+                                const deletecmd = await deleteResource(discoveryConfig as DiscoveryConfig).promise
                                 setModalProps({
                                     open: false,
                                     confirm: () => {},
@@ -207,7 +207,7 @@ export function DiscoveryConfigPageContent(props: {
                                     title: '',
                                     message: '',
                                 })
-                                resolve(undefined)
+                                resolve(deletecmd)
                                 sessionStorage.setItem(
                                     'DISCOVERY_OP',
                                     JSON.stringify({ Operation: 'Delete', Name: discoveryConfig.metadata.namespace })
@@ -262,15 +262,18 @@ export function DiscoveryConfigPageContent(props: {
                         'DISCOVERY_OP',
                         JSON.stringify({ Operation: 'Create', Name: discoveryConfig.metadata.namespace })
                     )
-                    await createDiscoveryConfig(discoveryConfig as DiscoveryConfig).promise
+                    const importcmd = await createDiscoveryConfig(discoveryConfig as DiscoveryConfig).promise
+                    resolve(importcmd)
+                    history.push(NavigationPath.discoveredClusters)
                 } else {
                     sessionStorage.setItem(
                         'DISCOVERY_OP',
                         JSON.stringify({ Operation: 'Update', Name: discoveryConfig.metadata.namespace })
                     )
-                    await replaceDiscoveryConfig(discoveryConfig as DiscoveryConfig).promise
+                    const importcmd = await replaceDiscoveryConfig(discoveryConfig as DiscoveryConfig).promise
+                    resolve(importcmd)
+                    history.push(NavigationPath.discoveredClusters)
                 }
-                resolve(undefined)
             } catch (err) {
                 if (err instanceof Error) {
                     alertContext.addAlert({
@@ -280,8 +283,6 @@ export function DiscoveryConfigPageContent(props: {
                     })
                     reject()
                 }
-            } finally {
-                history.push(NavigationPath.discoveredClusters)
             }
         })
     }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/12655


Adds tech preview alert, adds buttons in empty state, fixes empty state message.

Also fixes errors not displaying in discoveryconfig form.

![image](https://user-images.githubusercontent.com/52431213/118881842-8422bc80-b8c1-11eb-823e-56b97cd10e53.png)
