### PR TITLE
Update Curator status checks

### DIFF
--- a/frontend/src/lib/get-cluster.ts
+++ b/frontend/src/lib/get-cluster.ts
@@ -478,14 +478,15 @@ export function getClusterStatus(
     let statusMessage: string | undefined
 
     // ClusterCurator status
-    let ccStatus: ClusterStatus = ClusterStatus.prehookjob
+    let ccStatus: ClusterStatus = ClusterStatus.pending
     if (clusterCurator) {
         const ccConditions: V1CustomResourceDefinitionCondition[] = clusterCurator.status?.conditions ?? []
 
         // ClusterCurator has not completed so loop through statuses
         if (
-            !checkCuratorConditionDone('clustercurator-job', ccConditions) &&
-            clusterCurator?.spec?.desiredCuration === 'install'
+            (!checkCuratorConditionDone('clustercurator-job', ccConditions) && clusterCurator?.spec?.desiredCuration === 'install') || 
+            checkCuratorConditionFailed('clustercurator-job', ccConditions)
+            
         ) {
             if (
                 !checkCuratorConditionDone('prehook-ansiblejob', ccConditions) &&
@@ -498,10 +499,7 @@ export function getClusterStatus(
             } else if (!checkCuratorConditionDone('activate-and-monitor', ccConditions)) {
                 ccStatus = checkCuratorConditionFailed('activate-and-monitor', ccConditions)
                     ? ClusterStatus.provisionfailed
-                    : ClusterStatus.creating
-            } else if (!checkCuratorConditionDone('hive-provisioning-job', ccConditions)) {
-                // check if provision job is in progress or failed
-                ccStatus = checkCuratorConditionFailed('hive-provisioning-job', ccConditions)
+                    : checkCuratorConditionFailed('hive-provisioning-job', ccConditions)
                     ? ClusterStatus.provisionfailed
                     : ClusterStatus.creating
             } else if (!checkCuratorConditionDone('monitor-import', ccConditions)) {

--- a/frontend/src/lib/get-cluster.ts
+++ b/frontend/src/lib/get-cluster.ts
@@ -484,9 +484,9 @@ export function getClusterStatus(
 
         // ClusterCurator has not completed so loop through statuses
         if (
-            (!checkCuratorConditionDone('clustercurator-job', ccConditions) && clusterCurator?.spec?.desiredCuration === 'install') || 
+            (!checkCuratorConditionDone('clustercurator-job', ccConditions) &&
+                clusterCurator?.spec?.desiredCuration === 'install') ||
             checkCuratorConditionFailed('clustercurator-job', ccConditions)
-            
         ) {
             if (
                 !checkCuratorConditionDone('prehook-ansiblejob', ccConditions) &&


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Set default status as pending
* Detect curator-job failed, so that we still check for sub condition failures
* Check the hive job status only when activate-and-monitor job is present.