### PR TITLE
Automatically show cluster issue sidebar if redirected from search re…

### DIFF
--- a/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.tsx
@@ -39,10 +39,10 @@ export function StatusSummaryCount() {
     const moderateCount = policyReport?.results?.filter((item) => item.properties?.total_risk === '2').length
     const lowCount = policyReport?.results?.filter((item) => item.properties?.total_risk === '1').length
 
-    // Show cluster issues sidebar by default if showSidebar url param is present
+    // Show cluster issues sidebar by default if showClusterIssues url param is present
     // This will be true if we are redirected to this page via search results table.
     useEffect(() => {
-        const autoShowIssueSidebar = decodeURIComponent(window.location.search).includes('showSidebar=true')
+        const autoShowIssueSidebar = decodeURIComponent(window.location.search).includes('showClusterIssues=true')
         if (autoShowIssueSidebar && policyReportViolationsCount > 0) {
             setDrawerContext({
                 isExpanded: true,

--- a/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/StatusSummaryCount.tsx
@@ -39,6 +39,20 @@ export function StatusSummaryCount() {
     const moderateCount = policyReport?.results?.filter((item) => item.properties?.total_risk === '2').length
     const lowCount = policyReport?.results?.filter((item) => item.properties?.total_risk === '1').length
 
+    // Show cluster issues sidebar by default if showSidebar url param is present
+    // This will be true if we are redirected to this page via search results table.
+    useEffect(() => {
+        const autoShowIssueSidebar = decodeURIComponent(window.location.search).includes('showSidebar=true')
+        if (autoShowIssueSidebar && policyReportViolationsCount > 0) {
+            setDrawerContext({
+                isExpanded: true,
+                onCloseClick: () => setDrawerContext(undefined),
+                panelContent: <ClusterPolicySidebar data={policyReport} />,
+                panelContentProps: { minSize: '50%' },
+            })
+        }
+    }, [policyReport, policyReportViolationsCount, setDrawerContext])
+
     return (
         <div style={{ marginTop: '24px' }}>
             <AcmCountCardSection


### PR DESCRIPTION
…sults page

Signed-off-by: Zack Layne <zlayne@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/12304

If we redirect to cluster details page from search results page via a PolicyReport. We should automatically show the cluster issue sidebar component.

Associated change is search-UI: https://github.com/open-cluster-management/search-ui/pull/154