### PR TITLE
BMA modal change icon

### DIFF
--- a/frontend/src/routes/BareMetalAssets/BareMetalAssetsPage.tsx
+++ b/frontend/src/routes/BareMetalAssets/BareMetalAssetsPage.tsx
@@ -103,6 +103,7 @@ export function BareMetalAssetsTable(props: {
     function setImportModalProps() {
         setImportedProps({
             open: true,
+            icon: 'default',
             title: t('bulk.title.import'),
             action: t('common:import'),
             processing: '',
@@ -124,6 +125,7 @@ export function BareMetalAssetsTable(props: {
                                 const result = await importBMAs()
                                 setImportedProps({
                                     open: true,
+                                    icon: 'default',
                                     title: t('bulk.title.import'),
                                     action: t('common:import'),
                                     processing: t('common:importing'),


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

issue: https://github.com/open-cluster-management/backlog/issues/12998

changed BMA import modal icon to 'default' (no icon)
![Screen Shot 2021-06-07 at 9 48 08 AM](https://user-images.githubusercontent.com/21374229/121028081-80be7a80-c775-11eb-9a6d-42a9b4545114.png)

