### PR TITLE
Prepend rule ID to description column text in cluster details sidebar

### DIFF
--- a/frontend/src/routes/ClusterManagement/Clusters/components/ClusterPolicySidebar.test.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/ClusterPolicySidebar.test.tsx
@@ -107,8 +107,8 @@ describe('ClusterPolicySidebar', () => {
             await waitForText('policy.report.flyout.description')
 
             // wait for policy reports to be displayed and click the first report in table
-            await waitForText('policyreport testing risk 1')
-            await clickByText('policyreport testing risk 1')
+            await waitForText('policyreport testing risk 1 policy: policyreport testing risk 1')
+            await clickByText('policyreport testing risk 1 policy: policyreport testing risk 1')
 
             // wait for drilldown risk subdetail component
             await waitForText('policy.report.low')

--- a/frontend/src/routes/ClusterManagement/Clusters/components/ClusterPolicySidebar.tsx
+++ b/frontend/src/routes/ClusterManagement/Clusters/components/ClusterPolicySidebar.tsx
@@ -319,11 +319,16 @@ export function ClusterPolicySidebar(props: { data: PolicyReport }) {
             <AcmTable<PolicyReportResults>
                 plural="Recommendations"
                 items={props.data.results}
+                initialSort={{
+                    index: 2, // default to sorting by highest risk
+                    direction: 'desc',
+                }}
                 columns={[
                     {
                         header: t('policy.report.table.description'),
-                        search: (report) => report.message,
-                        sort: (a: PolicyReportResults, b: PolicyReportResults) => compareStrings(a.message, b.message),
+                        search: (report) => report.policy + ': ' + report.message,
+                        sort: (a: PolicyReportResults, b: PolicyReportResults) =>
+                            compareStrings(a.policy + ': ' + a.message, b.policy + ': ' + b.message),
                         cell: (item: PolicyReportResults) => (
                             <Button
                                 variant="link"
@@ -334,7 +339,7 @@ export function ClusterPolicySidebar(props: { data: PolicyReport }) {
                                 isInline
                                 component="span"
                             >
-                                {item.message}
+                                {item.policy + ': ' + item.message}
                             </Button>
                         ),
                     },


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

We want users to be able to navigate from an alert (which uses the rule ID) to the cluster details sidebar and see the same rule ID text.

![Screen Shot 2021-06-10 at 10 01 22 AM](https://user-images.githubusercontent.com/14047925/121538650-f2dfcb00-c9d2-11eb-848a-a110a0d74b6c.png)
