### PR TITLE
Add image/jpeg content type

### DIFF
--- a/backend/src/routes/serve.ts
+++ b/backend/src/routes/serve.ts
@@ -91,6 +91,7 @@ const contentTypes: Record<string, string> = {
     '.css': 'text/css; charset=UTF-8',
     '.js': 'application/javascript; charset=UTF-8',
     '.map': 'application/json; charset=utf-8',
+    '.jpg': 'image/jpeg',
     '.json': 'application/json; charset=utf-8',
     '.svg': 'image/svg+xml',
     '.png': 'image/png',


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/12768

CLC About modal does not match the others because it is failing to serve the default JPG provided by PatternFly.

**Before:**
![image](https://user-images.githubusercontent.com/42188127/122088657-f2c93c00-cdd3-11eb-8e04-8a7a1456489c.png)

**After:**
![image](https://user-images.githubusercontent.com/42188127/122088699-fd83d100-cdd3-11eb-8a83-f6effe6eacf8.png)
