### PR TITLE
fix for status popover ansible link

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
@@ -7,13 +7,16 @@ import { Link } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
 import { Cluster, ClusterStatus } from '../../../../../lib/get-cluster'
 import { launchLogs } from './HiveNotification'
-import { configMapsState } from '../../../../../atoms'
+import { ansibleJobState, configMapsState } from '../../../../../atoms'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { ClusterStatusMessageAlert } from './ClusterStatusMessageAlert'
+import { getLatestAnsibleJob } from '../../../../../resources/ansible-job'
 
 export function StatusField(props: { cluster: Cluster }) {
     const { t } = useTranslation(['cluster'])
     const [configMaps] = useRecoilState(configMapsState)
+    const [ansibleJobs] = useRecoilState(ansibleJobState)
+    const latestJob = getLatestAnsibleJob(ansibleJobs, props.cluster?.name!)
 
     let type: StatusType
 
@@ -63,6 +66,42 @@ export function StatusField(props: { cluster: Cluster }) {
     let hasAction = false
     let Action = () => <></>
     switch (props.cluster?.status) {
+        case ClusterStatus.prehookjob:
+        case ClusterStatus.prehookfailed:
+            hasAction = true
+            Action = () => (
+                <AcmButton
+                    style={{ padding: 0, fontSize: 'inherit' }}
+                    key={props.cluster.name}
+                    onClick={() => window.open(latestJob.prehook?.status?.ansibleJobResult.url)}
+                    variant="link"
+                    role="link"
+                    icon={<ExternalLinkAltIcon />}
+                    iconPosition="right"
+                    isDisabled={!latestJob.prehook?.status?.ansibleJobResult?.url}
+                >
+                    {t('view.logs')}
+                </AcmButton>
+            )
+            break
+        case ClusterStatus.posthookjob:
+        case ClusterStatus.posthookfailed:
+            hasAction = true
+            Action = () => (
+                <AcmButton
+                    style={{ padding: 0, fontSize: 'inherit' }}
+                    key={props.cluster.name}
+                    onClick={() => window.open(latestJob.posthook?.status?.ansibleJobResult.url)}
+                    variant="link"
+                    role="link"
+                    icon={<ExternalLinkAltIcon />}
+                    iconPosition="right"
+                    isDisabled={!latestJob.posthook?.status?.ansibleJobResult?.url}
+                >
+                    {t('view.logs')}
+                </AcmButton>
+            )
+            break
         case ClusterStatus.creating:
         case ClusterStatus.destroying:
         case ClusterStatus.provisionfailed:


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Ansible log link was not appearing in status popover.
https://github.com/open-cluster-management/backlog/issues/13446

<img width="1495" alt="Screen Shot 2021-06-17 at 3 46 29 PM" src="https://user-images.githubusercontent.com/21374229/122463127-38783700-cf83-11eb-80e6-cce919bc5ade.png">

<img width="1237" alt="Screen Shot 2021-06-17 at 3 46 23 PM" src="https://user-images.githubusercontent.com/21374229/122463150-3e6e1800-cf83-11eb-816b-eaa95bd65e8d.png">


