### PR TITLE
add plural for channel select & cluster upgrade

### DIFF
--- a/frontend/public/locales/en/cluster.json
+++ b/frontend/public/locales/en/cluster.json
@@ -483,6 +483,8 @@
     "bulk.title.upgrade": "Upgrade clusters",
     "bulk.title.selectChannel": "Select channels",
     "bulk.message.upgrade": "Select the new versions for the clusters that you want to upgrade. Only the selected clusters that can be upgraded and have available upgrades are listed. This action is irreversible.",
+    "bulk.plural.upgrade": "clusters",
+    "bulk.plural.selectChannel": "channels",
     "bulk.title.deleteSet": "Delete cluster sets?",
     "bulk.message.deleteSet": "Deleting a cluster set will remove all access control permissions to resources in this set for all assigned cluster set users. Resources currently in this cluster set will not be deleted.",
     "bulk.message.selectChannel": "Select channels for the clusters. Only the selected clusters that have available channels are listed.",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.tsx
@@ -68,6 +68,7 @@ export function BatchChannelSelectModal(props: {
         <BulkActionModel<Cluster>
             open={props.open}
             title={t('bulk.title.selectChannel')}
+            plural={t('bulk.plural.selectChannel')}
             action={t('upgrade.selectChannel.submit')}
             processing={t('upgrade.selectChannel.submit.processing')}
             resources={channelSelectableClusters}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.tsx
@@ -80,6 +80,7 @@ export function BatchUpgradeModal(props: {
         <BulkActionModel<Cluster>
             open={props.open}
             title={t('bulk.title.upgrade')}
+            plural={t('bulk.plural.upgrade')}
             action={t('upgrade.submit')}
             processing={t('upgrade.submit.processing')}
             resources={upgradeableClusters}


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>
Issue: https://github.com/open-cluster-management/backlog/issues/13517

Updates:
- added plural for upgrade & channel modal, so it shows `no clusters/channels found`

Screenshot:
<img width="671" alt="Screen Shot 2021-06-18 at 4 56 33 PM" src="https://user-images.githubusercontent.com/31426239/122615254-3af79100-d056-11eb-9b49-bfa01ea014bd.png">
<img width="660" alt="Screen Shot 2021-06-18 at 4 56 24 PM" src="https://user-images.githubusercontent.com/31426239/122615262-3d59eb00-d056-11eb-9d6b-661f1c13cd65.png">
