### PR TITLE
Enforce unique job names in template creation

### DIFF
--- a/frontend/public/locales/en/cluster.json
+++ b/frontend/public/locales/en/cluster.json
@@ -568,6 +568,7 @@
     "template.templates.title": "Ansible job templates",
     "template.information.title": "Basic information",
     "template.information.description": "The default job templates that you select appear automatically during cluster creation. To create a sequence of events, select multiple jobs. Drag and drop the job templates to reorder the sequence.",
+    "template.job.duplicate.error":"The job name already exists in this hook. The job list cannot contain duplicates.",
 
     "template.create.name": "Template name",
     "template.create.placeholder": "Enter the name for the template",

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -467,7 +467,8 @@ function EditAnsibleJobModal(props: {
     const { t } = useTranslation(['common', 'cluster'])
     const [ansibleJob, setAnsibleJob] = useState<AnsibleJob | undefined>()
     let ansibleJobList: string[]
-    if (props.ansibleJobList) ansibleJobList = props.ansibleJobList.filter((job)=>ansibleJob !== job).map((ansibleJob) => ansibleJob.name)
+    if (props.ansibleJobList)
+        ansibleJobList = props.ansibleJobList.filter((job) => ansibleJob !== job).map((ansibleJob) => ansibleJob.name)
     useEffect(() => setAnsibleJob(props.ansibleJob), [props.ansibleJob])
     return (
         <AcmModal

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -450,7 +450,11 @@ export function AnsibleAutomationsForm(props: {
     return (
         <Fragment>
             <AcmDataFormPage formData={formData} mode={isViewing ? 'details' : isEditing ? 'form' : 'wizard'} />
-            <EditAnsibleJobModal ansibleJob={editAnsibleJob} setAnsibleJob={updateAnsibleJob} />
+            <EditAnsibleJobModal
+                ansibleJob={editAnsibleJob}
+                setAnsibleJob={updateAnsibleJob}
+                ansibleJobList={editAnsibleJobList?.jobs}
+            />
         </Fragment>
     )
 }
@@ -458,9 +462,12 @@ export function AnsibleAutomationsForm(props: {
 function EditAnsibleJobModal(props: {
     ansibleJob?: AnsibleJob
     setAnsibleJob: (ansibleJob?: AnsibleJob, old?: AnsibleJob) => void
+    ansibleJobList?: AnsibleJob[]
 }) {
     const { t } = useTranslation(['common', 'cluster'])
     const [ansibleJob, setAnsibleJob] = useState<AnsibleJob | undefined>()
+    let ansibleJobList: string[]
+    if (props.ansibleJobList) ansibleJobList = props.ansibleJobList.map((ansibleJob) => ansibleJob.name)
     useEffect(() => setAnsibleJob(props.ansibleJob), [props.ansibleJob])
     return (
         <AcmModal
@@ -484,6 +491,12 @@ function EditAnsibleJobModal(props: {
                             const copy = { ...ansibleJob }
                             copy.name = name
                             setAnsibleJob(copy)
+                        }
+                    }}
+                    validation={(name: string) => {
+                        if (ansibleJobList.includes(name)) {
+                            // no duplicate job names can be added
+                            return t('cluster:template.job.duplicate.error')
                         }
                     }}
                     isRequired

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -116,7 +116,7 @@ export function AnsibleAutomationsForm(props: {
 
     function updateAnsibleJob(ansibleJob?: AnsibleJob, replaceJob?: AnsibleJob) {
         if (ansibleJob && replaceJob && ansibleJob.name && editAnsibleJobList) {
-            if (installPreJobs.includes(replaceJob)) {
+            if (editAnsibleJobList.jobs.includes(replaceJob)) {
                 editAnsibleJobList.setJobs(
                     editAnsibleJobList.jobs.map((job) => (job === replaceJob ? ansibleJob : job))
                 )
@@ -467,7 +467,7 @@ function EditAnsibleJobModal(props: {
     const { t } = useTranslation(['common', 'cluster'])
     const [ansibleJob, setAnsibleJob] = useState<AnsibleJob | undefined>()
     let ansibleJobList: string[]
-    if (props.ansibleJobList) ansibleJobList = props.ansibleJobList.map((ansibleJob) => ansibleJob.name)
+    if (props.ansibleJobList) ansibleJobList = props.ansibleJobList.filter((job)=>ansibleJob !== job).map((ansibleJob) => ansibleJob.name)
     useEffect(() => setAnsibleJob(props.ansibleJob), [props.ansibleJob])
     return (
         <AcmModal


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>
https://github.com/open-cluster-management/backlog/issues/13378
Rather than support duplicate job name re-ordering, we will be enforcing unique job names in our job list.

![Screen Shot 2021-06-22 at 12 09 32 PM](https://user-images.githubusercontent.com/21374229/122962147-1ef43800-d353-11eb-9fa0-d202afa1e789.png)

