### PR TITLE
adding absolute path to distribution path

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -48,7 +48,7 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
                 : 'upgrade.ansible.prehook'
         let footerContent: ReactNode | string = (
             <AcmButton
-                onClick={() => window.open(latestAnsibleJob.prehook?.status?.ansibleJobResult?.url)}
+                onClick={() => window.open(`https://${latestAnsibleJob.prehook?.status?.ansibleJobResult?.url}`)}
                 variant="link"
                 isSmall
                 isInline


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

I missed this field in the last PR, but this covers the link surfaced in the distribution field.