### PR TITLE
Ansible status bug fix

### DIFF
--- a/frontend/src/lib/get-cluster.ts
+++ b/frontend/src/lib/get-cluster.ts
@@ -463,8 +463,10 @@ export function getDistributionInfo(
             checkCuratorLatestOperation(CuratorCondition.upgrade, curatorConditions) ||
             checkCuratorLatestFailedOperation(CuratorCondition.upgrade, curatorConditions)
         upgradeInfo.isUpgradeCuration = isUpgradeCuration
-        upgradeInfo.hookFailed = checkCuratorLatestFailedOperation(CuratorCondition.upgrade, curatorConditions) && (checkCuratorConditionFailed(CuratorCondition.prehook, curatorConditions) ||
-        checkCuratorConditionFailed(CuratorCondition.posthook, curatorConditions))
+        upgradeInfo.hookFailed =
+            checkCuratorLatestFailedOperation(CuratorCondition.upgrade, curatorConditions) &&
+            (checkCuratorConditionFailed(CuratorCondition.prehook, curatorConditions) ||
+                checkCuratorConditionFailed(CuratorCondition.posthook, curatorConditions))
         upgradeInfo.latestJob.conditionMessage =
             getConditionStatusMessage(CuratorCondition.curatorjob, curatorConditions) || ''
         upgradeInfo.latestJob.step =

--- a/frontend/src/lib/get-cluster.ts
+++ b/frontend/src/lib/get-cluster.ts
@@ -463,7 +463,8 @@ export function getDistributionInfo(
             checkCuratorLatestOperation(CuratorCondition.upgrade, curatorConditions) ||
             checkCuratorLatestFailedOperation(CuratorCondition.upgrade, curatorConditions)
         upgradeInfo.isUpgradeCuration = isUpgradeCuration
-        upgradeInfo.hookFailed = checkCuratorLatestFailedOperation(CuratorCondition.upgrade, curatorConditions)
+        upgradeInfo.hookFailed = checkCuratorLatestFailedOperation(CuratorCondition.upgrade, curatorConditions) && (checkCuratorConditionFailed(CuratorCondition.prehook, curatorConditions) ||
+        checkCuratorConditionFailed(CuratorCondition.posthook, curatorConditions))
         upgradeInfo.latestJob.conditionMessage =
             getConditionStatusMessage(CuratorCondition.curatorjob, curatorConditions) || ''
         upgradeInfo.latestJob.step =
@@ -662,7 +663,9 @@ export function getClusterStatus(
 
             if (
                 checkCuratorConditionFailed(CuratorCondition.curatorjob, ccConditions) &&
-                checkCuratorLatestFailedOperation(CuratorCondition.install, ccConditions)
+                checkCuratorLatestFailedOperation(CuratorCondition.install, ccConditions) &&
+                (checkCuratorConditionFailed(CuratorCondition.prehook, ccConditions) ||
+                    checkCuratorConditionFailed(CuratorCondition.posthook, ccConditions))
             ) {
                 if (!clusterDeployment.spec?.installed) {
                     ccStatus = ClusterStatus.prehookfailed

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -39,12 +39,12 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
         let statusType = StatusType.progress
         let statusTitle =
             props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
-                ? 'upgrade.ansible.posthookjob.title'
-                : 'upgrade.ansible.prehookjob.title'
+                ? t('upgrade.ansible.posthookjob.title')
+                : t('upgrade.ansible.prehookjob.title')
         let statusMessage: ReactNode | string =
             props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
-                ? 'upgrade.ansible.posthook'
-                : 'upgrade.ansible.prehook'
+                ? t('upgrade.ansible.posthook')
+                : t('upgrade.ansible.prehook')
 
         const jobUrl =
             props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -81,7 +81,7 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
                 statusTitle = 'upgrade.ansible.posthookjob.title'
                 statusMessage = (
                     <React.Fragment>
-                        {t('upgrade.ansible.posthook.failure')}{' '}
+                        {t('upgrade.ansible.posthook.failure')}
                         <div>{props.cluster?.distribution?.upgradeInfo?.latestJob.conditionMessage}</div>
                     </React.Fragment>
                 )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -3,7 +3,7 @@
 import { AcmButton, AcmInlineStatus, StatusType } from '@open-cluster-management/ui-components'
 import { ButtonVariant } from '@patternfly/react-core'
 import { ArrowCircleUpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons'
-import { ReactNode, useState } from 'react'
+import React, { ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RbacButton } from '../../../../../components/Rbac'
 import { Cluster, ClusterStatus, CuratorCondition } from '../../../../../lib/get-cluster'
@@ -21,7 +21,6 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
     const [open, toggleOpen] = useState<boolean>(false)
     const toggle = () => toggleOpen(!open)
     const [ansibleJobs] = useRecoilState(ansibleJobState)
-
     let latestAnsibleJob: { prehook: AnsibleJob | undefined; posthook: AnsibleJob | undefined }
     if (props.cluster?.namespace && ansibleJobs)
         latestAnsibleJob = getLatestAnsibleJob(ansibleJobs, props.cluster?.namespace)
@@ -42,20 +41,26 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
             props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
                 ? 'upgrade.ansible.posthookjob.title'
                 : 'upgrade.ansible.prehookjob.title'
-        let statusMessage =
+        let statusMessage: ReactNode | string =
             props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
                 ? 'upgrade.ansible.posthook'
                 : 'upgrade.ansible.prehook'
-        let footerContent: ReactNode | string = (
+
+        const jobUrl =
+            props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
+                ? latestAnsibleJob.posthook?.status?.ansibleJobResult?.url
+                : latestAnsibleJob.prehook?.status?.ansibleJobResult?.url
+
+        const footerContent: ReactNode = (
             <AcmButton
-                onClick={() => window.open(latestAnsibleJob.prehook?.status?.ansibleJobResult?.url)}
+                onClick={() => window.open(jobUrl)}
                 variant="link"
                 isSmall
                 isInline
                 role="link"
                 icon={<ExternalLinkAltIcon />}
                 iconPosition="right"
-                isDisabled={!latestAnsibleJob.prehook?.status?.ansibleJobResult?.url}
+                isDisabled={!jobUrl}
             >
                 {t('view.logs')}
             </AcmButton>
@@ -66,13 +71,21 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
             statusType = StatusType.warning
             if (props.cluster?.distribution?.upgradeInfo?.prehooks.failed) {
                 statusTitle = 'upgrade.ansible.prehookjob.title'
-                statusMessage = 'upgrade.ansible.prehook.failure'
+                statusMessage = (
+                    <React.Fragment>
+                        {t('upgrade.ansible.prehook.failure')}
+                        <div>{props.cluster?.distribution?.upgradeInfo?.latestJob.conditionMessage}</div>
+                    </React.Fragment>
+                )
             } else {
                 statusTitle = 'upgrade.ansible.posthookjob.title'
-                statusMessage = 'upgrade.ansible.posthook.failure'
+                statusMessage = (
+                    <React.Fragment>
+                        {t('upgrade.ansible.posthook.failure')}{' '}
+                        <div>{props.cluster?.distribution?.upgradeInfo?.latestJob.conditionMessage}</div>
+                    </React.Fragment>
+                )
             }
-
-            footerContent = props.cluster?.distribution?.upgradeInfo?.latestJob.conditionMessage
         }
         return (
             <>
@@ -82,7 +95,7 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
                     status={t(statusTitle)}
                     popover={{
                         headerContent: t(statusTitle),
-                        bodyContent: t(statusMessage || ''),
+                        bodyContent: statusMessage || '',
                         footerContent: footerContent,
                     }}
                 />

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -3,7 +3,7 @@
 import { AcmButton, AcmInlineStatus, StatusType } from '@open-cluster-management/ui-components'
 import { ButtonVariant } from '@patternfly/react-core'
 import { ArrowCircleUpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons'
-import React, { ReactNode, useState } from 'react'
+import { Fragment, ReactNode, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RbacButton } from '../../../../../components/Rbac'
 import { Cluster, ClusterStatus, CuratorCondition } from '../../../../../lib/get-cluster'
@@ -72,18 +72,18 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
             if (props.cluster?.distribution?.upgradeInfo?.prehooks.failed) {
                 statusTitle = 'upgrade.ansible.prehookjob.title'
                 statusMessage = (
-                    <React.Fragment>
+                    <Fragment>
                         {t('upgrade.ansible.prehook.failure')}
                         <div>{props.cluster?.distribution?.upgradeInfo?.latestJob.conditionMessage}</div>
-                    </React.Fragment>
+                    </Fragment>
                 )
             } else {
                 statusTitle = 'upgrade.ansible.posthookjob.title'
                 statusMessage = (
-                    <React.Fragment>
+                    <Fragment>
                         {t('upgrade.ansible.posthook.failure')}
                         <div>{props.cluster?.distribution?.upgradeInfo?.latestJob.conditionMessage}</div>
-                    </React.Fragment>
+                    </Fragment>
                 )
             }
         }


### PR DESCRIPTION
Upgrade status check must ensure that job failure is coming from a prehook/posthook. Added conditions to do this.
Also added link to logs for upgrade failure status.