### PR TITLE
String fixes

### DIFF
--- a/frontend/public/locales/en/create.json
+++ b/frontend/public/locales/en/create.json
@@ -386,7 +386,7 @@
     "template.create.title": "Create Ansible template",
     "template.clusterCreate.name":"Ansible Automation Template",
     "template.clusterCreate.title":"Automation",
-    "template.clusterCreate.info":"Choose an automation job template to automatically run at run Ansible jobs at different stages of a cluster's life cycle. (Optional)",
+    "template.clusterCreate.info":"Choose an automation job template to automatically run Ansible jobs at different stages of a cluster's life cycle. (Optional)",
     "template.clusterCreate.select.placeholder":"Select an Ansible job template",
     "template.create.tooltip":"Create a job template to automatically run Ansible jobs at different stages of a cluster's life cycle"
 }

--- a/frontend/public/locales/en/create.json
+++ b/frontend/public/locales/en/create.json
@@ -386,6 +386,7 @@
     "template.create.title": "Create Ansible template",
     "template.clusterCreate.name":"Ansible Automation Template",
     "template.clusterCreate.title":"Automation",
-    "template.clusterCreate.info":"Choose a automation job template to automatically run at different times of creation. (Optional)",
-    "template.clusterCreate.select.placeholder":"Select an Ansible job template"
+    "template.clusterCreate.info":"Choose an automation job template to automatically run at run Ansible jobs at different stages of a cluster's life cycle. (Optional)",
+    "template.clusterCreate.select.placeholder":"Select an Ansible job template",
+    "template.create.tooltip":"Create a job template to automatically run Ansible jobs at different stages of a cluster's life cycle"
 }

--- a/frontend/public/locales/en/credentials.json
+++ b/frontend/public/locales/en/credentials.json
@@ -216,7 +216,7 @@
     "credentialsForm.ansibleCredentials.wizardDescription": "How do I get Ansible Automation Platform credentials?",
 
     "credentialsForm.ansibleHost.label": "Ansible Tower host",
-    "credentialsForm.ansibleHost.placeholder": "Enter the Ansible Tower host name",
+    "credentialsForm.ansibleHost.placeholder": "Enter the Ansible Tower host URL",
 
     "credentialsForm.ansibleToken.label": "Ansible Tower token",
     "credentialsForm.ansibleToken.placeholder": "Enter the Ansible Tower token",

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -185,7 +185,7 @@ export function AnsibleAutomationsForm(props: {
 
     const formData: FormData = {
         title: t('create:template.create.title'),
-        titleTooltip: 'tooltip test',
+        titleTooltip: t('create:template.create.tooltip'),
         breadcrumb: [
             { text: t('template.title'), to: NavigationPath.ansibleAutomations },
             { text: t('create:template.create.title') },


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

https://github.com/open-cluster-management/backlog/issues/13886

Tooltip change:
![Screen Shot 2021-07-01 at 12 50 19 PM](https://user-images.githubusercontent.com/21374229/124161188-1beffa80-da6b-11eb-8270-9ab4d7e3190e.png)


The former string in creation wizard, above the template selector, was also a bit misleading (jobs can be run in creation and upgrade). The old string only mentioned creation.

![Screen Shot 2021-07-01 at 12 54 38 PM](https://user-images.githubusercontent.com/21374229/124161534-85700900-da6b-11eb-886d-663cfef3dca1.png)


There's one last change for the placeholder in Ansible credential creation. 