### PR TITLE
Api route for Ansible Job Templates (feature)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import { search } from './routes/search'
 import { serve } from './routes/serve'
 import { startWatching, stopWatching, events } from './routes/events'
 import { loadSettings, stopSettingsWatch } from './lib/config'
+import { ansibleTower } from './routes/ansibletower'
 
 export const router = Router<Router.HTTPVersion.V2>()
 router.get(`/readinessProbe`, readiness)
@@ -38,6 +39,7 @@ router.get(`/events`, events)
 router.post(`/proxy/search`, search)
 router.get(`/authenticated`, authenticated)
 router.get(`/*`, serve)
+router.get(`/ansibletower`, ansibleTower)
 
 export async function requestHandler(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
     if (process.env.NODE_ENV !== 'production') {

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -17,7 +17,7 @@ export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse):
         method: req.method,
         headers: {
             Authorization: `Bearer ${req.headers.tk}`,
-          },
+        },
         rejectUnauthorized: false,
     }
 
@@ -26,7 +26,7 @@ export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse):
         request(options, (response) => {
             if (!response) return notFound(req, res)
             res.writeHead(response.statusCode ?? 500, response.headers)
-            pipeline(response, (res as unknown) as NodeJS.WritableStream, () => logger.error)
+            pipeline(response, res as unknown as NodeJS.WritableStream, () => logger.error)
         }),
         (err) => {
             if (err) logger.error(err)

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { constants, Http2ServerRequest, Http2ServerResponse, OutgoingHttpHeaders } from 'http2'
+import { Http2ServerRequest, Http2ServerResponse } from 'http2'
 import { request, RequestOptions } from 'https'
 import { pipeline } from 'stream'
 import { URL } from 'url'

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -1,0 +1,35 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { constants, Http2ServerRequest, Http2ServerResponse, OutgoingHttpHeaders } from 'http2'
+import { request, RequestOptions } from 'https'
+import { pipeline } from 'stream'
+import { URL } from 'url'
+import { logger } from '../lib/logger'
+import { notFound, unauthorized } from '../lib/respond'
+
+export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse): void {
+    if (!req.headers.tk) return unauthorized(req, res)
+
+    const towerUrl = new URL(req.headers.path.toString())
+    const options: RequestOptions = {
+        protocol: towerUrl.protocol,
+        hostname: towerUrl.hostname,
+        path: towerUrl.pathname,
+        method: req.method,
+        headers: {
+            Authorization: `Bearer ${req.headers.tk}`,
+          },
+        rejectUnauthorized: false,
+    }
+
+    pipeline(
+        req,
+        request(options, (response) => {
+            if (!response) return notFound(req, res)
+            res.writeHead(response.statusCode ?? 500, response.headers)
+            pipeline(response, (res as unknown) as NodeJS.WritableStream, () => logger.error)
+        }),
+        (err) => {
+            if (err) logger.error(err)
+        }
+    )
+}

--- a/frontend/src/lib/resource-request.ts
+++ b/frontend/src/lib/resource-request.ts
@@ -193,6 +193,30 @@ export function listNamespacedResources<Resource extends IResource>(
         abort: result.abort,
     }
 }
+// TODO: validation for URL input
+// Code assumes protocol is present & ansiblehosturl ends without a /
+export function listAnsibleTowerJobs<ResultT>(ansibleHostUrl: string, token: string): IRequestResult<ResultT> {
+    const backendURLPath = backendUrl + '/ansibletower'
+    const ansibleJobsUrl = ansibleHostUrl + '/api/v2/job_templates/'
+    const abortController = new AbortController()
+    return {
+        promise: fetchGetAnsibleJobs<ResultT>(backendURLPath, ansibleJobsUrl, token, abortController.signal).then((result) => result.data),
+        abort: () => abortController.abort(),
+    }
+}
+
+export function fetchGetAnsibleJobs<T = unknown>(backendUrlPath: string, ansibleJobsUrl:string, token:string,  signal: AbortSignal) {
+    return fetchRetry<T>({
+        method: 'GET',
+        url:backendUrlPath,
+        signal,
+        headers: {
+            path: ansibleJobsUrl,
+            tk: token,
+        },
+        retries: process.env.NODE_ENV === 'production' ? 2 : 0,
+    })
+}
 
 export function getRequest<ResultT>(url: string): IRequestResult<ResultT> {
     const abortController = new AbortController()

--- a/frontend/src/lib/resource-request.ts
+++ b/frontend/src/lib/resource-request.ts
@@ -200,15 +200,22 @@ export function listAnsibleTowerJobs<ResultT>(ansibleHostUrl: string, token: str
     const ansibleJobsUrl = ansibleHostUrl + '/api/v2/job_templates/'
     const abortController = new AbortController()
     return {
-        promise: fetchGetAnsibleJobs<ResultT>(backendURLPath, ansibleJobsUrl, token, abortController.signal).then((result) => result.data),
+        promise: fetchGetAnsibleJobs<ResultT>(backendURLPath, ansibleJobsUrl, token, abortController.signal).then(
+            (result) => result.data
+        ),
         abort: () => abortController.abort(),
     }
 }
 
-export function fetchGetAnsibleJobs<T = unknown>(backendUrlPath: string, ansibleJobsUrl:string, token:string,  signal: AbortSignal) {
+export function fetchGetAnsibleJobs<T = unknown>(
+    backendUrlPath: string,
+    ansibleJobsUrl: string,
+    token: string,
+    signal: AbortSignal
+) {
     return fetchRetry<T>({
         method: 'GET',
-        url:backendUrlPath,
+        url: backendUrlPath,
         signal,
         headers: {
             path: ansibleJobsUrl,


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

My first iteration on the API route for our job template route.
NOTE: This is a PR from my fork to @chenz4027 feature branch, not to main.

Using this code you can demo the feature:
<img width="1006" alt="Screen Shot 2021-07-27 at 3 23 30 PM" src="https://user-images.githubusercontent.com/21374229/127215297-606c18e0-e733-4117-9184-db3a005c598c.png">

Output: 
<img width="524" alt="Screen Shot 2021-07-27 at 3 24 43 PM" src="https://user-images.githubusercontent.com/21374229/127215450-16f7320d-9d6a-404b-bc22-6d57ccb02336.png">
