### PR TITLE
update pages to use new AcmHeader witout Visual Web Terminal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "devDependencies": {
         "@kubernetes/client-node": "^0.15.0",
         "@open-cluster-management/resources": "^1.0.0",
-        "@open-cluster-management/ui-components": "^0.180.0",
+        "@open-cluster-management/ui-components": "^1.1.0",
         "@patternfly/react-core": "^4.135.5",
         "@patternfly/react-table": "^4.29.5",
         "@redhat-cloud-services/rule-components": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,10 +1828,10 @@
     node-gyp "^7.1.0"
     read-package-json-fast "^2.0.1"
 
-"@open-cluster-management/ui-components@^0.180.0":
-  version "0.180.0"
-  resolved "https://registry.yarnpkg.com/@open-cluster-management/ui-components/-/ui-components-0.180.0.tgz#9f6a5324ebc8e1e2c6346ebdebae57b76a9ebbf3"
-  integrity sha512-RMCmQfpeu4PhtiktMCN0Ze2FGLeQoj4QTHw7s8ot8/pilnAwEexRbI/Jw8GOi8T/FswCQVdAOmz1KRoVjj0i+g==
+"@open-cluster-management/ui-components@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@open-cluster-management/ui-components/-/ui-components-1.1.0.tgz#aeac9f51569e97e00f4850408c901352f17b8721"
+  integrity sha512-Nfn5m6ky9NBy6wUYlZCMDzWeDikeEE2aNtdB5PamAsMedvJ6ipnWWMb2QCZdgO2x51F+DpywPd8sU5yJkyJK8g==
   dependencies:
     "@material-ui/core" "^4.11.4"
     "@material-ui/styles" "^4.11.4"
@@ -1845,7 +1845,7 @@
     moment "^2.29.1"
     nock "^13.1.0"
     react-router-dom "^5.2.0"
-    react-tag-autocomplete "^6.1.0"
+    react-tag-autocomplete "6.1.0"
 
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"
@@ -12262,10 +12262,10 @@ react-style-proptype@^3.2.2:
   dependencies:
     prop-types "^15.5.4"
 
-react-tag-autocomplete@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/react-tag-autocomplete/-/react-tag-autocomplete-6.2.0.tgz#f5aefaa4ff972c8163d5340d2e6ad20e31391f46"
-  integrity sha512-sBBwYoBVdJFQffhqOjjvcN2/1M92cG1YRKeyFgXEN44xxlTIUyneqzkw8l096pA3DSmUmgNc9z3JFG26xZRnbg==
+react-tag-autocomplete@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-tag-autocomplete/-/react-tag-autocomplete-6.1.0.tgz#9fb70149a69b33379013e5255bcd7ad97d8ec06b"
+  integrity sha512-AMhVqxEEIrOfzH0A9XrpsTaLZCVYgjjxp3DSTuSvx91LBSFI6uYcKe38ltR/H/TQw4aytofVghQ1hR9sKpXRQA==
 
 react-transition-group@^4.4.0:
   version "4.4.2"


### PR DESCRIPTION
Signed-off-by: Mark Anderson <markande@redhat.com>

For story https://github.com/open-cluster-management/backlog/issues/14732 use version of `ui-components` with AcmHeader that has removed Visual Web Terminal.