### PR TITLE
url not found error case

### DIFF
--- a/@open-cluster-management/resources/src/utils/resource-request.ts
+++ b/@open-cluster-management/resources/src/utils/resource-request.ts
@@ -357,6 +357,8 @@ export async function fetchRetry<T>(options: {
                                 throw new ResourceError('Request timeout.', ResourceErrorCode.Timeout)
                             case 'ECONNRESET':
                                 throw new ResourceError('Request connection reset.', ResourceErrorCode.ConnectionReset)
+                            case 'ENOTFOUND':
+                                throw new ResourceError('Resource not found.', ResourceErrorCode.NotFound)
                             default:
                                 throw new ResourceError(
                                     `Unknown error. code: ${(err as any)?.code}`,
@@ -424,7 +426,8 @@ export async function fetchRetry<T>(options: {
                         }
                     }
                     throw new ResourceError('Unauthorized', ResourceErrorCode.Unauthorized)
-
+                case 404:
+                    throw new ResourceError('Unauthorized', ResourceErrorCode.NotFound)
                 case 408: // Request Timeout
                 case 429: // Too Many Requests
                 case 500: // Internal Server Error

--- a/frontend/public/locales/en/credentials.json
+++ b/frontend/public/locales/en/credentials.json
@@ -226,7 +226,7 @@
     "validate.kubernetesDnsName.startchar": "This value must start with an alphanumeric character",
     "validate.kubernetesDnsName.endchar": "This value must end with an alphanumeric character",
 
-    "validate.ansible.host": "The credential returned an unauthorized response from Ansible Tower. Please review the host and token.",
+    "validate.ansible.host": "The credential returned an error response from Ansible Tower. Please review the host and token.",
 
     "validate.publicSshKey": "Must be a valid public key",
 

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -23,7 +23,6 @@ import {
     replaceResource,
     unpackProviderConnection,
     listAnsibleTowerJobs,
-    ResourceError,
 } from '@open-cluster-management/resources'
 import { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -158,9 +157,8 @@ export function AnsibleAutomationsForm(props: {
                         setAnsibleTowerAuthError('')
                     }
                 })
-                .catch((err: ResourceError) => {
-                    if (err.code === 401) setAnsibleTowerAuthError('credentials:validate.ansible.host')
-                    else setAnsibleTowerAuthError(err.message)
+                .catch(() => {
+                    setAnsibleTowerAuthError('credentials:validate.ansible.host')
                     setAnsibleTowerJobTemplateList([])
                 })
         }


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Hey @chenz4027, I found that we actually were missing an error case, and added it to the branch. 
When the url itself is bad, a ENOTFOUND & 404 is returned, but fetchRetry was not catching 404's. 