### PR TITLE
spacing-fix-ansible

### DIFF
--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -525,7 +525,10 @@ function EditAnsibleJobModal(props: {
                     <AcmSubmit
                         variant="primary"
                         onClick={() => {
-                            if (ansibleJob) props.setAnsibleJob({ ...ansibleJob }, props.ansibleJob)
+                            if (ansibleJob) props.setAnsibleJob({
+                                name: ansibleJob.name.trim(),
+                                extra_vars: ansibleJob.extra_vars,
+                            }, props.ansibleJob)
                             props.setAnsibleJob()
                         }}
                     >

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -525,10 +525,14 @@ function EditAnsibleJobModal(props: {
                     <AcmSubmit
                         variant="primary"
                         onClick={() => {
-                            if (ansibleJob) props.setAnsibleJob({
-                                name: ansibleJob.name.trim(),
-                                extra_vars: ansibleJob.extra_vars,
-                            }, props.ansibleJob)
+                            if (ansibleJob)
+                                props.setAnsibleJob(
+                                    {
+                                        name: ansibleJob.name.trim(),
+                                        extra_vars: ansibleJob.extra_vars,
+                                    } as AnsibleJob,
+                                    props.ansibleJob
+                                )
                             props.setAnsibleJob()
                         }}
                     >


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

regarding: https://github.com/open-cluster-management/backlog/issues/14853

On submit, the modal now uses .trim() to remove leading and training spaces from the job name.