### PR TITLE
Region filter feature for Azure

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -69,7 +69,7 @@ const regions = [
     'westcentralus',
     'westindia',
 ]
-export const govRegions = ['usgovvirginia', 'usgovtexas']
+const govRegions = ['usgovvirginia', 'usgovtexas']
 
 //  List vm sizes in a location/region
 //    az vm list-sizes --location eastus --output table

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -33,7 +33,7 @@ const gp16Cpu8Gib = '16 vCPU, 64 GiB - General Purpose'
 
 // For this regions list, place recommeneded at the top
 // Recommended is top alphabetized list, others/optional is second alphabetixed list
-const regions = [
+export const regions = [
     'australiaeast',
     'brazilsouth',
     'canadacentral',
@@ -68,9 +68,8 @@ const regions = [
     'ukwest',
     'westcentralus',
     'westindia',
-    'usgovvirginia',
-    'usgovtexas',
 ]
+export const govRegions = ['usgovvirginia', 'usgovtexas']
 
 //  List vm sizes in a location/region
 //    az vm list-sizes --location eastus --output table
@@ -437,6 +436,23 @@ export const getControlDataAZR = (includeAutomation = true) => {
     return [...controlDataAZR]
 }
 
+const setRegions = (control, controlData) => {
+    const alterRegionData = (controlData, regions, active) => {
+        const regionObject = controlData.find((object) => object.name === 'Region')
+        regionObject.active = active
+        regionObject.available = regions
+    }
+
+    if (control.active) {
+        const connection = control.availableMap[control.active]
+        if (connection.replacements.cloudName === 'AzureUSGovernmentCloud')
+            alterRegionData(controlData, govRegions, govRegions[0])
+        else alterRegionData(controlData, regions, 'centralus')
+    } else {
+        alterRegionData(controlData, regions, 'centralus')
+    }
+}
+
 const controlDataAZR = [
     ///////////////////////  connection  /////////////////////////////////////
     {
@@ -444,6 +460,7 @@ const controlDataAZR = [
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',
         type: 'singleselect',
+        onSelect: setRegions,
         placeholder: 'creation.ocp.cloud.select.connection',
         providerId: 'azr',
         validation: {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -33,7 +33,7 @@ const gp16Cpu8Gib = '16 vCPU, 64 GiB - General Purpose'
 
 // For this regions list, place recommeneded at the top
 // Recommended is top alphabetized list, others/optional is second alphabetixed list
-export const regions = [
+const regions = [
     'australiaeast',
     'brazilsouth',
     'canadacentral',


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

regarding: https://github.com/open-cluster-management/backlog/issues/15932

To preview feature, simply create an Azure credential with a 'AzureUSGovernmentCloud' as the _cloudName_*
Then go to create cluster and and use that Azure gov credential. 
When you arrive at the Master Node step, the regions select will offer Azure-government specific regions. 
When you de-select the Azure government credential or replace it with a public credential, the public regions are swapped back in.

![Screen Shot 2021-09-15 at 11 02 33 AM](https://user-images.githubusercontent.com/21374229/133458789-4288e771-7bef-4182-b8f0-c4f633361425.png)

