### PR TITLE
Use c5d.large as default submariner gateway on AWS

### DIFF
--- a/frontend/public/locales/en/cluster.json
+++ b/frontend/public/locales/en/cluster.json
@@ -90,7 +90,7 @@
     "submariner.install.form.nattenable.labelHelp": "Submariner can use NAT Traversal for IPsec tunnels between clusters. Set this to true to enable NAT Traversal and false otherwise (default true)",
     "submariner.install.form.cabledriver.labelHelp": "The Submariner gateway cable driver, Available options are: libreswan (default) strongswan, wireguard, and vxlan.",
     "submariner.install.form.gateways.labelHelp": "The number of worker nodes  that will be used to deploy the Submariner gateway component on the managed cluster. If the value is greater than 1, the Submariner gateway HA will be enabled automatically. (default 1)",
-    "submariner.install.form.instancetype.labelHelp": "The Amazon Web Services EC2 instance type of the gateway node that will be created on the managed cluster. (default m5n.large)",
+    "submariner.install.form.instancetype.labelHelp": "The Amazon Web Services EC2 instance type of the gateway node that will be created on the managed cluster. (default c5d.large)",
     "submariner.update.form.title": "Edit Submariner configuration",
     "submariner.update.form.message": "Editing the <bold>SubmarinerConfig</bold> will update the configurations of the Submariner add-on on the managed cluster. It may take a few minutes for the changes to take effect.",
     "submariner.config.edit": "Edit configuration",

--- a/frontend/src/resources/submariner-config.ts
+++ b/frontend/src/resources/submariner-config.ts
@@ -55,5 +55,5 @@ export const submarinerConfigDefault: SubmarinerConfigDefaults = {
     nattEnable: true,
     cableDriver: CableDriver.libreswan,
     gateways: 1,
-    awsInstanceType: 'm5n.large',
+    awsInstanceType: 'c5d.large',
 }


### PR DESCRIPTION
In AWS clusters, moving from m5n.large to c5d.large instances
improves the GW to GW bandwidth significantly as it has better
CPU which is the bottleneck with Libreswan and wireguard cable
drivers.

Fixes issue: https://github.com/open-cluster-management/submariner-addon/issues/109
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>