### PR TITLE
Cluster pool cleanup fix

### DIFF
--- a/frontend/src/lib/delete-clusterpool.ts
+++ b/frontend/src/lib/delete-clusterpool.ts
@@ -1,0 +1,46 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import {
+    ClusterPool,
+    ClusterPoolApiVersion,
+    ClusterPoolKind,
+    IResource,
+    NamespaceApiVersion,
+    NamespaceKind,
+    ResourceError,
+} from '../resources'
+import { deleteResources } from './delete-resources'
+
+export function deleteClusterPool(clusterPool: ClusterPool) {
+    const resources: IResource[] = [
+        {
+            apiVersion: ClusterPoolApiVersion,
+            kind: ClusterPoolKind,
+            metadata: { name: clusterPool.metadata.name, namespace: clusterPool.metadata.namespace },
+        },{
+            apiVersion: NamespaceApiVersion,
+            kind: NamespaceKind,
+            metadata: { name: clusterPool.metadata.namespace! },
+        }
+    ]
+    console.log('in deletion function')
+    const deleteResourcesResult = deleteResources(resources)
+    return {
+        promise: new Promise((resolve, reject) => {
+            deleteResourcesResult.promise.then((promisesSettledResult) => {
+                if (promisesSettledResult[0]?.status === 'rejected') {
+                    const error = promisesSettledResult[0].reason
+                    if (error instanceof ResourceError) {
+                        reject(promisesSettledResult[0].reason)
+                    }
+                }
+                if (promisesSettledResult[1]?.status === 'rejected') {
+                    reject(promisesSettledResult[1].reason)
+                    return
+                }
+                resolve(promisesSettledResult)
+            })
+        }),
+        abort: deleteResourcesResult.abort,
+    }
+}

--- a/frontend/src/lib/delete-clusterpool.ts
+++ b/frontend/src/lib/delete-clusterpool.ts
@@ -60,7 +60,10 @@ export function deleteClusterPool(clusterPool: ClusterPool) {
             resources.push({
                 apiVersion: SecretApiVersion,
                 kind: SecretKind,
-                metadata: { name: `${clusterPool.metadata.name}-azure-creds`, namespace: clusterPool.metadata.namespace },
+                metadata: {
+                    name: `${clusterPool.metadata.name}-azure-creds`,
+                    namespace: clusterPool.metadata.namespace,
+                },
             })
             break
     }

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -35,12 +35,12 @@ import { TechPreviewAlert } from '../../../../components/TechPreviewAlert'
 import { DOC_LINKS } from '../../../../lib/doc-util'
 import { rbacCreate, rbacDelete, rbacPatch } from '../../../../lib/rbac-util'
 import { NavigationPath } from '../../../../NavigationPath'
+import {deleteClusterPool} from '../../../../lib/delete-clusterpool'
 import {
     Cluster,
     ClusterClaimDefinition,
     ClusterPool,
     ClusterStatus,
-    deleteResource,
     ResourceErrorCode,
 } from '../../../../resources'
 import { ClusterStatuses } from '../ClusterSets/components/ClusterStatuses'
@@ -363,7 +363,7 @@ export function ClusterPoolsTable(props: {
                                             description: t('bulk.message.destroyClusterPool'),
                                             columns: modalColumns,
                                             keyFn: mckeyFn,
-                                            actionFn: deleteResource,
+                                            actionFn: deleteClusterPool,
                                             confirmText: clusterPool.metadata.name!,
                                             close: () => setModalProps({ open: false }),
                                             isDanger: true,
@@ -414,7 +414,7 @@ export function ClusterPoolsTable(props: {
                                 description: t('bulk.message.destroyClusterPool'),
                                 columns: modalColumns,
                                 keyFn: mckeyFn,
-                                actionFn: deleteResource,
+                                actionFn: deleteClusterPool,
                                 close: () => setModalProps({ open: false }),
                                 isDanger: true,
                                 icon: 'warning',

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -35,14 +35,8 @@ import { TechPreviewAlert } from '../../../../components/TechPreviewAlert'
 import { DOC_LINKS } from '../../../../lib/doc-util'
 import { rbacCreate, rbacDelete, rbacPatch } from '../../../../lib/rbac-util'
 import { NavigationPath } from '../../../../NavigationPath'
-import {deleteClusterPool} from '../../../../lib/delete-clusterpool'
-import {
-    Cluster,
-    ClusterClaimDefinition,
-    ClusterPool,
-    ClusterStatus,
-    ResourceErrorCode,
-} from '../../../../resources'
+import { deleteClusterPool } from '../../../../lib/delete-clusterpool'
+import { Cluster, ClusterClaimDefinition, ClusterPool, ClusterStatus, ResourceErrorCode } from '../../../../resources'
 import { ClusterStatuses } from '../ClusterSets/components/ClusterStatuses'
 import { StatusField } from '../ManagedClusters/components/StatusField'
 import { useAllClusters } from '../ManagedClusters/components/useAllClusters'


### PR DESCRIPTION
regarding: https://github.com/open-cluster-management/backlog/issues/16134

removes the following secrets from the clusterpool namespace:
```
<clusterpool-name>-aws-cluster-pool-aws-creds        
<clusterpool-name>-aws-cluster-pool-install-config 
<clusterpool-name>-aws-cluster-pool-pull-secret
<clusterpool-name>-aws-cluster-pool-ssh-private-key 
```
...allowing for creation of a new clusterpool with the same name in the namespace.