### PR TITLE
Cluster pool cleanup

### DIFF
--- a/frontend/src/resources/cluster-pool.ts
+++ b/frontend/src/resources/cluster-pool.ts
@@ -57,3 +57,5 @@ export interface ClusterPool extends IResource {
         size?: number
     }
 }
+
+export const clusterPoolNamespaceLabels = Object.freeze({ 'open-cluster-management.io/managed-by': 'clusterpools' })

--- a/frontend/src/resources/project.ts
+++ b/frontend/src/resources/project.ts
@@ -1,8 +1,9 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { V1ObjectMeta } from '@kubernetes/client-node/dist/gen/model/v1ObjectMeta'
-import { createResource } from './utils/resource-request'
+import { createResource, replaceResource } from './utils/resource-request'
 import { IResource, IResourceDefinition } from './resource'
+import { Namespace, NamespaceApiVersion, NamespaceKind } from '.'
 
 export const ProjectApiVersion = 'project.openshift.io/v1'
 export type ProjectApiVersionType = 'project.openshift.io/v1'
@@ -38,11 +39,26 @@ export interface ProjectRequest extends IResource {
     metadata: V1ObjectMeta
 }
 
-export const createProject = (name: string | undefined) => {
+export const createProject = (name: string | undefined, labels?: V1ObjectMeta['labels']) => {
     if (!name) throw new Error('Project name is undefined')
-    return createResource<ProjectRequest, Project>({
+    const response = createResource<ProjectRequest, Project>({
         apiVersion: ProjectRequestApiVersion,
         kind: ProjectRequestKind,
         metadata: { name },
     })
+    if (labels) {
+        response.promise
+            .then((project) => {
+                const metadata = { ...project.metadata, labels }
+                return replaceResource<Namespace, Namespace>({
+                    apiVersion: NamespaceApiVersion,
+                    kind: NamespaceKind,
+                    metadata,
+                })
+            })
+            .catch(() => {
+                return undefined // ignore; namespace already existed or error creating namespace
+            })
+    }
+    return response
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.test.tsx
@@ -24,7 +24,7 @@ import { render } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import { managedClusterSetsState, namespacesState, secretsState } from '../../../../../atoms'
-import { nockCreate, nockIgnoreRBAC, nockList } from '../../../../../lib/nock-util'
+import { nockCreate, nockIgnoreRBAC, nockList, nockReplace } from '../../../../../lib/nock-util'
 import {
     clickByPlaceholderText,
     clickByTestId,
@@ -78,6 +78,15 @@ const mockNamespace: Namespace = {
     apiVersion: NamespaceApiVersion,
     kind: NamespaceKind,
     metadata: { name: 'test-namespace' },
+}
+
+const mockNamespaceUpdate: Namespace = {
+    apiVersion: NamespaceApiVersion,
+    kind: NamespaceKind,
+    metadata: {
+        name: mockNamespace.metadata.name,
+        labels: { 'open-cluster-management.io/managed-by': 'clusterpools' },
+    },
 }
 
 const mockCreateProject: ProjectRequest = {
@@ -280,6 +289,7 @@ describe('CreateClusterPool', () => {
         const createNocks = [
             // create the managed cluster
             nockCreate(mockCreateProject),
+            nockReplace(mockNamespaceUpdate),
             nockCreate(mockPullSecret),
             nockCreate(mockInstallConfigSecret),
             nockCreate(mockPrivateSecret),


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/15530

When a namespace is created for a ClusterPool, apply the `'open-cluster-management.io/managed-by': 'clusterpools'` label so that the namespace is deleted when the last ClusterPool is removed from it.