### PR TITLE
No longer creating ssh-privatekey secret for cluster-pools

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.test.tsx
@@ -115,19 +115,6 @@ const mockInstallConfigSecret: Secret = {
     },
 }
 
-const mockPrivateSecret: Secret = {
-    apiVersion: 'v1',
-    kind: 'Secret',
-    metadata: {
-        name: 'test-ssh-private-key',
-        namespace: mockNamespace.metadata.name!,
-    },
-    stringData: {
-        'ssh-privatekey': '-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n-----END OPENSSH PRIVATE KEY-----',
-    },
-    type: 'Opaque',
-}
-
 const mockCredentialSecret: Secret = {
     apiVersion: SecretApiVersion,
     kind: SecretKind,
@@ -282,7 +269,6 @@ describe('CreateClusterPool', () => {
             nockCreate(mockCreateProject),
             nockCreate(mockPullSecret),
             nockCreate(mockInstallConfigSecret),
-            nockCreate(mockPrivateSecret),
             nockCreate(mockCredentialSecret),
             nockCreate(mockClusterPool),
         ]

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
@@ -34,7 +34,7 @@ import { FeatureGates } from '../../../../../FeatureGates'
 import MonacoEditor from 'react-monaco-editor'
 import 'monaco-editor/esm/vs/editor/editor.all.js'
 import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js'
-import { has } from 'lodash'
+
 interface CreationStatus {
     status: string
     messages: any[] | null

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
@@ -34,6 +34,7 @@ import { FeatureGates } from '../../../../../FeatureGates'
 import MonacoEditor from 'react-monaco-editor'
 import 'monaco-editor/esm/vs/editor/editor.all.js'
 import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js'
+import { has } from 'lodash'
 interface CreationStatus {
     status: string
     messages: any[] | null
@@ -113,8 +114,14 @@ export function CreateClusterPool() {
     const createResource = async (resourceJSON: { createResources: any[] }) => {
         if (resourceJSON) {
             const { createResources } = resourceJSON
+            // removing unused ssh-privatekey yaml
+            const clusterPoolCreateResources = createResources.filter((resource) => {
+                if (has(resource, 'stringData.ssh-privatekey')) return false
+                return true
+            })
+
             setCreationStatus({ status: 'IN_PROGRESS', messages: [] })
-            const { status, messages } = await createCluster(createResources)
+            const { status, messages } = await createCluster(clusterPoolCreateResources)
             setCreationStatus({ status, messages })
 
             // redirect to created cluster

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
@@ -34,7 +34,6 @@ import { FeatureGates } from '../../../../../FeatureGates'
 import MonacoEditor from 'react-monaco-editor'
 import 'monaco-editor/esm/vs/editor/editor.all.js'
 import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js'
-
 interface CreationStatus {
     status: string
     messages: any[] | null
@@ -114,7 +113,6 @@ export function CreateClusterPool() {
     const createResource = async (resourceJSON: { createResources: any[] }) => {
         if (resourceJSON) {
             const { createResources } = resourceJSON
-
             setCreationStatus({ status: 'IN_PROGRESS', messages: [] })
             const { status, messages } = await createCluster(createResources)
             setCreationStatus({ status, messages })

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
@@ -114,14 +114,9 @@ export function CreateClusterPool() {
     const createResource = async (resourceJSON: { createResources: any[] }) => {
         if (resourceJSON) {
             const { createResources } = resourceJSON
-            // removing unused ssh-privatekey yaml
-            const clusterPoolCreateResources = createResources.filter((resource) => {
-                if (has(resource, 'stringData.ssh-privatekey')) return false
-                return true
-            })
 
             setCreationStatus({ status: 'IN_PROGRESS', messages: [] })
-            const { status, messages } = await createCluster(clusterPoolCreateResources)
+            const { status, messages } = await createCluster(createResources)
             setCreationStatus({ status, messages })
 
             // redirect to created cluster

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/templates/hive-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/templates/hive-template.hbs
@@ -109,25 +109,6 @@ type: Opaque
 data:
   # Base64 encoding of install-config yaml
   install-config.yaml: {{{install-config}}}
-{{#if ssh-privatekey}}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{{name}}}-ssh-private-key
-  namespace: '{{{namespace}}}'
-stringData:
-{{#if showSecrets}}
-  ssh-privatekey: |-
-{{#each ssh-privatekey}}
-    {{{.}}}
-{{/each}}
-{{else}}
-  ssh-privatekey: # injected on create
-{{/if}}
-type: Opaque
-{{/if}}
-
 {{#if_ne infrastructure 'BMC'}}
 ---
 apiVersion: v1
@@ -215,7 +196,7 @@ metadata:
 stringData:
   cloud: '{{{../../cloud}}}'
 {{#if ../../showSecrets}}
-  clouds.yaml: |- 
+  clouds.yaml: |-
     {{{../../clouds.yaml}}}
 {{else}}
   clouds.yaml: # injected on create


### PR DESCRIPTION
regarding: https://github.com/open-cluster-management/backlog/issues/16134
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Removes ssh-privatekey yaml from create resource array in cluster pools create code.