### PR TITLE
Fix for cluster set UI status, now surfaces failed ansible hook state

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/useClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/useClusters.tsx
@@ -18,6 +18,7 @@ import {
     managedClusterInfosState,
     managedClustersState,
     agentClusterInstallsState,
+    clusterCuratorsState,
 } from '../../../../../atoms'
 
 // returns the clusters assigned to a ManagedClusterSet
@@ -29,6 +30,7 @@ export function useClusters(managedClusterSet: ManagedClusterSet | undefined, cl
         certificateSigningRequests,
         managedClusterAddons,
         clusterClaims,
+        clusterCurators,
         agentClusterInstalls,
     ] = useRecoilValue(
         waitForAll([
@@ -38,6 +40,7 @@ export function useClusters(managedClusterSet: ManagedClusterSet | undefined, cl
             certificateSigningRequestsState,
             managedClusterAddonsState,
             clusterClaimsState,
+            clusterCuratorsState,
             agentClusterInstallsState,
         ])
     )
@@ -95,7 +98,7 @@ export function useClusters(managedClusterSet: ManagedClusterSet | undefined, cl
         groupManagedClusters,
         groupManagedClusterAddons,
         clusterClaims,
-        undefined,
+        clusterCurators,
         agentClusterInstalls
     )
 


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com
regarding: https://github.com/open-cluster-management/backlog/issues/15804

Cluster set UI now surfaces failed ansible hook status.

![Screen Shot 2021-09-21 at 12 51 11 PM](https://user-images.githubusercontent.com/21374229/134213644-0c588910-50c2-4aba-aee7-c56b53ad5225.png)
>