### PR TITLE
Added conditional logic to support failure case

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -774,7 +774,10 @@ export function getClusterStatus(
             } else if (provisionFailed) {
                 const provisionFailedCondition = cdConditions.find((c) => c.type === 'ProvisionFailed')
                 const currentProvisionRef = clusterDeployment.status?.provisionRef?.name ?? ''
-                if (provisionFailedCondition?.message?.includes(currentProvisionRef)) {
+                if (
+                    provisionFailedCondition?.message?.includes(currentProvisionRef) ||
+                    provisionFailedCondition?.reason === 'InvalidInstallConfig'
+                ) {
                     cdStatus = ClusterStatus.provisionfailed
                 } else {
                     cdStatus = ClusterStatus.creating


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>
regarding: https://github.com/open-cluster-management/backlog/issues/15413

Added conditional logic to support failure case when provisioning from cluster pool page.
Provision failure status via faulty region name now surfacing in cluster pool table.

![Screen Shot 2021-09-21 at 6 38 42 PM](https://user-images.githubusercontent.com/21374229/134256912-fa30df8a-9949-4b32-8790-7e4becb845e7.png)

