### PR TITLE
logic fix for cluster status in failed cluster

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -700,8 +700,9 @@ export function getClusterStatus(
             return { status: ccStatus, statusMessage }
         } else if (clusterDeployment) {
             // when curator is no longer installing, catch the prehook/posthook failure here
-
-            if (
+            if (clusterDeployment.metadata.deletionTimestamp) {
+                ccStatus = ClusterStatus.destroying
+            } else if (
                 checkCuratorConditionFailed(CuratorCondition.curatorjob, ccConditions) &&
                 checkCuratorLatestFailedOperation(CuratorCondition.install, ccConditions) &&
                 (checkCuratorConditionFailed(CuratorCondition.prehook, ccConditions) ||


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>
regarding: https://github.com/open-cluster-management/backlog/issues/15709

Status now picks up on when the failed Ansible cluster is destroying.
![Screen Shot 2021-09-30 at 1 16 45 PM](https://user-images.githubusercontent.com/21374229/135502761-51c98e6f-f8a0-4b22-91eb-00abd8252be2.png)


