### PR TITLE
azure hive template fix

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/hive-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/hive-template.hbs
@@ -77,6 +77,7 @@ spec:
       credentialsSecretRef:
         name: {{{../../name}}}-azure-creds
       region: {{{../../region}}}
+      cloudName: {{{../../cloudName}}}
   {{/case}}
 
   {{#case 'vSphere'}}


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>
regarding: https://github.com/open-cluster-management/backlog/issues/16552

Added `cd.spec.platform.azure.cloudName = "AzureUSGovernmentCloud"`

![Screen Shot 2021-10-01 at 10 47 42 AM](https://user-images.githubusercontent.com/21374229/135640369-16884a1f-fea5-470c-b020-36317a7fbdb7.png)

