### PR TITLE
azure credential form fix

### DIFF
--- a/frontend/src/routes/Credentials/CredentialsForm.tsx
+++ b/frontend/src/routes/Credentials/CredentialsForm.tsx
@@ -201,7 +201,7 @@ export function CredentialsForm(props: {
         AzureUSGovernmentCloud = 'AzureUSGovernmentCloud',
     }
 
-    const [cloudName, setCloudName] = useState<CloudNames | string>(CloudNames.AzurePublicCloud)
+    const [cloudName, setCloudName] = useState<CloudNames | string>(providerConnection?.stringData?.cloudName ?? CloudNames.AzurePublicCloud)
 
     let osServicePrincipalJson:
         | {


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Default value for `cloudName` has been set to the value found in the secret `providerConnection?.stringData?.cloudName` _**or**_ CloudNames.AzurePublicCloud, when the secret value is undefined (when there is no cloudName field provided, hive defaults to AzurePublicCloud).

This resolves bug wherein detail view for Azure credentials previews incorrect cloudName.
![Screen Shot 2021-10-01 at 11 36 29 AM](https://user-images.githubusercontent.com/21374229/135648374-6bcabfb2-e0e8-4079-858f-e4eb13640ca4.png)


After fix: 
![Screen Shot 2021-10-01 at 11 36 46 AM](https://user-images.githubusercontent.com/21374229/135648444-a7f0de49-8af2-4d0a-86da-af88f15ca616.png)


