### PR TITLE
Now using patternfly toggleID prop for wizard toggles

### DIFF
--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -1103,6 +1103,7 @@ export function AcmDataFormInput(props: { input: Input; validated?: 'error'; isR
             return (
                 <SelectWithToggle
                     {...inputProps}
+                    toggleId={`${input.id}-input-toggle`}
                     selections={selections}
                     onSelect={onSelect}
                     onClear={onClear}


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>
regarding: https://github.com/open-cluster-management/backlog/issues/15292

Now using patternfly Toggle ID for wizard toggles (to support more robust testing).

![Screen Shot 2021-10-01 at 6 44 36 PM](https://user-images.githubusercontent.com/21374229/135693678-2e4f4b15-d36a-42a3-a518-1ac4d94cbe66.png)


