### PR TITLE
Replace REACT_APP_BACKEND_HOST with JEST_DEFAULT_HOST

### DIFF
--- a/frontend/src/atoms.tsx
+++ b/frontend/src/atoms.tsx
@@ -5,6 +5,7 @@ import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react'
 import { atom, SetterOrUpdater, useRecoilState } from 'recoil'
 import { LoadingPage } from './components/LoadingPage'
 import {
+    backendUrl,
     AgentClusterInstallApiVersion,
     AgentClusterInstallKind,
     AgentClusterInstallVersion,
@@ -362,7 +363,7 @@ export function LoadData(props: { children?: ReactNode }) {
 
         let evtSource: EventSource | undefined
         function startWatch() {
-            evtSource = new EventSource(`${process.env.REACT_APP_BACKEND_PATH}/events`, { withCredentials: true })
+            evtSource = new EventSource(`${backendUrl}/events`, { withCredentials: true })
             evtSource.onmessage = processMessage
             evtSource.onerror = function () {
                 console.log('EventSource', 'error', 'readyState', evtSource?.readyState)
@@ -384,7 +385,7 @@ export function LoadData(props: { children?: ReactNode }) {
 
     useEffect(() => {
         function checkLoggedIn() {
-            fetch(`${process.env.REACT_APP_BACKEND_PATH}/authenticated`, {
+            fetch(`${backendUrl}/authenticated`, {
                 credentials: 'include',
                 headers: { accept: 'application/json' },
             })
@@ -396,7 +397,7 @@ export function LoadData(props: { children?: ReactNode }) {
                             if (process.env.NODE_ENV === 'production') {
                                 window.location.reload()
                             } else {
-                                window.location.href = `${process.env.REACT_APP_BACKEND_HOST}${process.env.REACT_APP_BACKEND_PATH}/login`
+                                window.location.href = `${backendUrl}/login`
                             }
                             break
                     }
@@ -405,7 +406,7 @@ export function LoadData(props: { children?: ReactNode }) {
                     if (process.env.NODE_ENV === 'production') {
                         window.location.reload()
                     } else {
-                        window.location.href = `${process.env.REACT_APP_BACKEND_HOST}${process.env.REACT_APP_BACKEND_PATH}/login`
+                        window.location.href = `${backendUrl}/login`
                     }
                 })
                 .finally(() => {

--- a/frontend/src/lib/nock-util.ts
+++ b/frontend/src/lib/nock-util.ts
@@ -24,7 +24,7 @@ export function nockGet<Resource extends IResource>(
     statusCode = 200,
     polling = true
 ) {
-    const nockScope = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true }).get(
+    const nockScope = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).get(
         getResourceNameApiPath(resource)
     )
     const finalNockScope = nockScope.reply(statusCode, response ?? resource, {
@@ -46,7 +46,7 @@ export function nockGet<Resource extends IResource>(
 }
 
 export function nockGetTextPlain(response: string, statusCode = 200, polling = true, customUri = '') {
-    const nockScope = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true }).get(customUri)
+    const nockScope = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).get(customUri)
     const finalNockScope = nockScope.reply(statusCode, response, {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -65,7 +65,7 @@ export function nockGetTextPlain(response: string, statusCode = 200, polling = t
 }
 
 export function nockOptions<Resource extends IResource>(resource: Resource, response?: IResource, statusCode = 200) {
-    return nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    return nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .options(getResourceNameApiPath(resource))
         .optionally()
         .reply(statusCode, response ?? resource, {
@@ -81,7 +81,7 @@ export function nockList<Resource extends IResource>(
     labels?: string[],
     query?: object
 ) {
-    let nockScope = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true }).get(
+    let nockScope = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).get(
         getResourceApiPath({ apiVersion: resource.apiVersion, kind: resource.kind })
     )
 
@@ -117,7 +117,7 @@ export function nockClusterList<Resource extends IResource>(
     polling = true
 ) {
     const data = Array.isArray(resources) ? { items: resources } : resources
-    let networkMock = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true }).get(
+    let networkMock = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).get(
         getResourceApiPath({ apiVersion: resource.apiVersion, kind: resource.kind })
     )
 
@@ -149,7 +149,7 @@ export function nockNamespacedList<Resource extends IResource>(
     polling = true
 ) {
     const data = Array.isArray(resources) ? { items: resources } : resources
-    let networkMock = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true }).get(
+    let networkMock = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).get(
         getResourceApiPath(resource)
     )
 
@@ -175,7 +175,7 @@ export function nockNamespacedList<Resource extends IResource>(
 }
 
 export function nockCreate(resource: IResource | ClusterRoleBinding, response?: IResource, statusCode = 201) {
-    const scope = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    const scope = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .post(getResourceApiPath(resource), (body) => {
             // if (!isEqual(body, resource)) {
             //     console.log(body)
@@ -192,7 +192,7 @@ export function nockCreate(resource: IResource | ClusterRoleBinding, response?: 
 }
 
 export function nockIgnoreRBAC() {
-    const scope = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    const scope = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .persist()
         .post('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', () => true)
         .optionally()
@@ -244,7 +244,7 @@ export function nockAnsibleTower(
     response: AnsibleTowerJobTemplateList,
     statusCode = 200
 ) {
-    return nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    return nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .post('/ansibletower', (body) => isEqual(body, data))
         .reply(statusCode, response, {
             'Access-Control-Allow-Origin': '*',
@@ -254,7 +254,7 @@ export function nockAnsibleTower(
 }
 
 export function nockPatch(resource: IResource, data: unknown[] | unknown, response?: IResource, statusCode = 204) {
-    return nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    return nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .options(getResourceNameApiPath(resource))
         .optionally()
         .reply(200, undefined, {
@@ -271,7 +271,7 @@ export function nockPatch(resource: IResource, data: unknown[] | unknown, respon
 }
 
 export function nockReplace(resource: IResource, response?: IResource, statusCode = 200) {
-    return nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    return nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .options(getResourceNameApiPath(resource))
         .optionally()
         .reply(204, undefined, {
@@ -288,7 +288,7 @@ export function nockReplace(resource: IResource, response?: IResource, statusCod
 }
 
 export function nockDelete(resource: IResource, response?: IResource) {
-    return nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    return nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .options(getResourceNameApiPath(resource))
         .optionally()
         .reply(204, undefined, {
@@ -305,7 +305,7 @@ export function nockDelete(resource: IResource, response?: IResource) {
 }
 
 export function nockSearch(query: SearchQuery, response?: ISearchResult, statusCode = 201, polling = true) {
-    nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true })
+    nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
         .options(apiSearchUrl)
         .optionally()
         .reply(204, undefined, {
@@ -314,7 +314,7 @@ export function nockSearch(query: SearchQuery, response?: ISearchResult, statusC
             'Access-Control-Allow-Credentials': 'true',
         })
 
-    const networkMock = nock(process.env.REACT_APP_BACKEND_HOST as string, { encodedQueryParams: true }).post(
+    const networkMock = nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).post(
         apiSearchUrl,
         JSON.stringify(query)
     )

--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -4,7 +4,7 @@ import { AnsibleTowerJobTemplateList } from '../ansible-job'
 import { getResourceApiPath, getResourceName, getResourceNameApiPath, IResource, ResourceList } from '../resource'
 import { Status, StatusKind } from '../status'
 
-export const backendUrl = `${process.env.REACT_APP_BACKEND_HOST}` + `${process.env.REACT_APP_BACKEND_PATH}`
+export const backendUrl = process.env.REACT_APP_BACKEND_PATH
 
 export interface IRequestResult<ResultType = unknown> {
     promise: Promise<ResultType>
@@ -403,7 +403,7 @@ export async function fetchRetry<T>(options: {
                         if (process.env.NODE_ENV === 'production') {
                             window.location.reload()
                         } else {
-                            window.location.href = `${process.env.REACT_APP_BACKEND_HOST}${process.env.REACT_APP_BACKEND_PATH}/login`
+                            window.location.href = `${backendUrl}/login`
                         }
                         throw new ResourceError(status.message as string, status.code as number)
                     } else if (ResourceErrorCodes.includes(status.code as number)) {
@@ -429,7 +429,7 @@ export async function fetchRetry<T>(options: {
                         if (process.env.NODE_ENV === 'production') {
                             window.location.reload()
                         } else {
-                            window.location.href = `${process.env.REACT_APP_BACKEND_HOST}${process.env.REACT_APP_BACKEND_PATH}/login`
+                            window.location.href = `${backendUrl}/login`
                         }
                     }
                     throw new ResourceError('Unauthorized', ResourceErrorCode.Unauthorized)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.tsx
@@ -17,7 +17,6 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BulkActionModel } from '../../../../../components/BulkActionModel'
 import './style.css'
-export const backendUrl = `${process.env.REACT_APP_BACKEND_PATH}`
 
 const isChannelSelectable = (c: Cluster) => {
     const isReadySelectChannels = c.distribution?.upgradeInfo?.isReadySelectChannels

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.tsx
@@ -18,7 +18,6 @@ import { useTranslation } from 'react-i18next'
 import { BulkActionModel } from '../../../../../components/BulkActionModel'
 import { ReleaseNotesLink } from './ReleaseNotesLink'
 import './style.css'
-export const backendUrl = `${process.env.REACT_APP_BACKEND_PATH}`
 
 // compare version
 const compareVersion = (a: string, b: string) => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -20,8 +20,6 @@ import { RbacButton } from '../../../../../components/Rbac'
 import { rbacCreate, rbacPatch } from '../../../../../lib/rbac-util'
 import { BatchUpgradeModal } from './BatchUpgradeModal'
 
-export const backendUrl = `${process.env.REACT_APP_BACKEND_PATH}`
-
 export function DistributionField(props: { cluster?: Cluster; clusterCurator?: ClusterCurator | undefined }) {
     const { t } = useTranslation(['cluster'])
     const [open, toggleOpen] = useState<boolean>(false)

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -9,15 +9,19 @@ import nock from 'nock'
 
 require('react')
 
+process.env.NODE_ENV = 'test'
+process.env.JEST_DEFAULT_HOST = 'http://localhost'
+process.env.REACT_APP_BACKEND_PATH = ''
+
 JestFetchMock.enableMocks()
 fetchMock.dontMock()
+// browser fetch works with relative URL; cross-fetch does not
+global.fetch = jest.fn((input, reqInit) =>
+    fetchMock(typeof input === 'string' ? new URL(input, process.env.JEST_DEFAULT_HOST).toString() : input, reqInit)
+)
 
 configure({ testIdAttribute: 'id' })
 jest.setTimeout(30 * 1000)
-
-process.env.NODE_ENV = 'test'
-process.env.REACT_APP_BACKEND_HOST = 'http://localhost'
-process.env.REACT_APP_BACKEND_PATH = ''
 
 async function setupBeforeAll(): Promise<void> {
     nock.disableNetConnect()

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -59,9 +59,6 @@ module.exports = function (_env: any, argv: { hot?: boolean; mode: string | unde
         plugins: [
             new webpack.DefinePlugin({
                 'process.env.NODE_ENV': isProduction ? JSON.stringify('production') : JSON.stringify('development'),
-                'process.env.REACT_APP_BACKEND_HOST': isProduction
-                    ? JSON.stringify('')
-                    : JSON.stringify('https://localhost:4000'),
                 'process.env.REACT_APP_BACKEND_PATH': JSON.stringify('/multicloud'),
             }) as unknown as webpack.WebpackPluginInstance,
             new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'], process: 'process' }),
@@ -115,6 +112,8 @@ module.exports = function (_env: any, argv: { hot?: boolean; mode: string | unde
                 '/multicloud/authenticated': { target: 'https://localhost:4000', secure: false },
                 '/multicloud/common': { target: 'https://localhost:4000', secure: false },
                 '/multicloud/version': { target: 'https://localhost:4000', secure: false },
+                '/multicloud/login': { target: 'https://localhost:4000', secure: false },
+                '/multicloud/logout': { target: 'https://localhost:4000', secure: false },
             },
             open: true,
             historyApiFallback: true,


### PR DESCRIPTION
Signed-off-by: Kevin Cormier <kcormier@redhat.com>

A bit of refactoring to remove REACT_APP_BACKEND_HOST from runtime code. Allows search-api queries to work in local development.