### PR TITLE
Fix InfraEnv details routes

### DIFF
--- a/frontend/src/routes/Infrastructure/InfraEnvironments/InfraEnvironments.tsx
+++ b/frontend/src/routes/Infrastructure/InfraEnvironments/InfraEnvironments.tsx
@@ -8,7 +8,7 @@ import InfraEnvironmentsPage from './InfraEnvironmentsPage'
 export default function InfraEnvironments() {
     return (
         <Switch>
-            <Route exact path={NavigationPath.infraEnvironmentDetails} component={InfraEnvironmentDetailsPage} />
+            <Route path={NavigationPath.infraEnvironmentDetails} component={InfraEnvironmentDetailsPage} />
             <Route exact path={NavigationPath.createInfraEnv} component={CreateInfraEnv} />
             <Route exact path={NavigationPath.infraEnvironments} component={InfraEnvironmentsPage} />
             <Route path="*">


### PR DESCRIPTION
InfraEnvs, Clusters and ClusterSets have nested routes. Using exact prop
on the parent 'detail' route prevents the nested routes from working because
they don't exactly match the parent route.