### PR TITLE
Fix discovery page crash when secret missing label [2.4]

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
@@ -160,7 +160,7 @@ export function DiscoveredClustersPageContent() {
 
     const RHOCMCredentials: ProviderConnection[] = []
     credentials.forEach((credential) => {
-        const provider = credential.metadata.labels!['cluster.open-cluster-management.io/type']
+        const provider = credential.metadata.labels?.['cluster.open-cluster-management.io/type']
         if (provider === Provider.redhatcloud) {
             RHOCMCredentials.push(credential)
         }

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.tsx
@@ -108,8 +108,8 @@ export function AddDiscoveryConfigData() {
     useEffect(() => {
         const CRHCredentials: Secret[] = []
         secrets.forEach((credential) => {
-            const labels = credential.metadata.labels!['cluster.open-cluster-management.io/type']
-            if (labels === Provider.redhatcloud) {
+            const provider = credential.metadata.labels?.['cluster.open-cluster-management.io/type']
+            if (provider === Provider.redhatcloud) {
                 CRHCredentials.push(credential)
             }
         })


### PR DESCRIPTION
Replace bang operator with optional chaining when checking for secret
provider type.

Issue: https://github.com/open-cluster-management/backlog/issues/18148

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>