### PR TITLE
Update search routes to multicloud/home/search

### DIFF
--- a/frontend/src/routes/Applications/AdvancedConfiguration.tsx
+++ b/frontend/src/routes/Applications/AdvancedConfiguration.tsx
@@ -8,31 +8,30 @@ import {
 } from '@open-cluster-management/ui-components'
 import {
     Card,
-    CardTitle,
     CardBody,
+    CardTitle,
     PageSection,
     Split,
     Stack,
     StackItem,
-    TextContent,
     Text,
+    TextContent,
     TextVariants,
     ToggleGroup,
     ToggleGroupItem,
 } from '@patternfly/react-core'
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { cellWidth } from '@patternfly/react-table'
-import { DOC_LINKS } from '../../lib/doc-util'
-import { useCallback, useMemo } from 'react'
+import _ from 'lodash'
 import queryString from 'query-string'
-import { useHistory } from 'react-router-dom'
+import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useHistory } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
 import { channelsState, placementRulesState, placementsState, subscriptionsState } from '../../atoms'
-import { IResource, SubscriptionApiVersion, PlacementApiVersion } from '../../resources'
+import { DOC_LINKS } from '../../lib/doc-util'
+import { IResource, PlacementApiVersion, SubscriptionApiVersion } from '../../resources'
 import { getAge, getEditLink } from './helpers/resource-helper'
-
-import _ from 'lodash'
 
 export default function AdvancedConfiguration() {
     const { t } = useTranslation()
@@ -197,11 +196,13 @@ export default function AdvancedConfiguration() {
                                 const { name, namespace } = resource.metadata
                                 if (name) {
                                     const searchParams: any = {
-                                        name,
-                                        namespace,
-                                        kind: 'placement',
-                                        cluster: 'local-cluster',
-                                        apiversion: PlacementApiVersion,
+                                        properties: {
+                                            name,
+                                            namespace,
+                                            kind: 'placement',
+                                            cluster: 'local-cluster',
+                                            apiversion: PlacementApiVersion,
+                                        },
                                     }
                                     const placementLink = getEditLink(searchParams)
                                     return <a href={placementLink}>{name}</a>

--- a/frontend/src/routes/Applications/helpers/resource-helper.ts
+++ b/frontend/src/routes/Applications/helpers/resource-helper.ts
@@ -1,9 +1,9 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import _ from 'lodash'
-import { useTranslation } from 'react-i18next'
-import queryString from 'query-string'
 import moment from 'moment'
+import queryString from 'query-string'
+import { useTranslation } from 'react-i18next'
 import { IResource } from '../../../resources'
 
 export const CHANNEL_TYPES = ['git', 'helmrepo', 'namespace', 'objectbucket']
@@ -68,18 +68,22 @@ export const getSearchLink = (params: any) => {
     if (showRelated) {
         queryParams.push(`showrelated=${showRelated}`)
     }
-    return `/search${queryParams.length ? '?' : ''}${queryParams.join('&')}`
+    return `/multicloud/home/search${queryParams.length ? '?' : ''}${queryParams.join('&')}`
 }
 
 export const getEditLink = (params: {
-    name: string
-    namespace: string
-    kind: string
-    apiversion: string
-    cluster: string
+    properties: {
+        name: string
+        namespace: string
+        kind: string
+        apiversion: string
+        cluster: string
+    }
 }) => {
-    const { name, namespace, kind, apiversion, cluster } = params
-    return `/resources?${queryString.stringify({
+    const {
+        properties: { name, namespace, kind, apiversion, cluster },
+    } = params
+    return `/multicloud/home/search/resources?${queryString.stringify({
         cluster,
         name,
         namespace,

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -390,8 +390,8 @@ export default function OverviewPage() {
     function buildSummaryLinks(kind: string, localCluster?: boolean) {
         const localClusterFilter: string = localCluster === true ? `%20cluster%3Alocal-cluster` : ''
         return selectedCloud === ''
-            ? `/multicloud/search?filters={"textsearch":"kind%3A${kind}${localClusterFilter}"}`
-            : `/multicloud/search?filters={"textsearch":"kind%3Acluster${cloudLabelFilter}"}&showrelated=${kind}`
+            ? `/multicloud/home/search?filters={"textsearch":"kind%3A${kind}${localClusterFilter}"}`
+            : `/multicloud/home/search?filters={"textsearch":"kind%3Acluster${cloudLabelFilter}"}&showrelated=${kind}`
     }
     const summary =
         searchLoading || searchPolicyReportLoading
@@ -408,7 +408,7 @@ export default function OverviewPage() {
                       description: 'Clusters',
                       count:
                           selectedClusterNames.length > 0 ? selectedClusterNames.length : managedClusters.length || 0,
-                      href: `/multicloud/search?filters={"textsearch":"kind%3Acluster${cloudLabelFilter}"}`,
+                      href: `/multicloud/home/search?filters={"textsearch":"kind%3Acluster${cloudLabelFilter}"}`,
                   },
                   { isPrimary: false, description: 'Kubernetes type', count: kubernetesTypes?.size },
                   { isPrimary: false, description: 'Region', count: regions?.size },
@@ -437,25 +437,25 @@ export default function OverviewPage() {
                   {
                       key: 'Failed',
                       value: searchResult[4]?.count || 0,
-                      link: `/multicloud/search?filters={"textsearch":"kind%3Apod%20status%3ACrashLoopBackOff%2CFailed%2CImagePullBackOff%2CRunContainerError%2CTerminated%2CUnknown%2COOMKilled${urlClusterFilter}"}`,
+                      link: `/multicloud/home/search?filters={"textsearch":"kind%3Apod%20status%3ACrashLoopBackOff%2CFailed%2CImagePullBackOff%2CRunContainerError%2CTerminated%2CUnknown%2COOMKilled${urlClusterFilter}"}`,
                   },
                   {
                       key: 'Pending',
                       value: searchResult[3]?.count || 0,
-                      link: `/multicloud/search?filters={"textsearch":"kind%3Apod%20status%3AContainerCreating%2CPending%2CTerminating%2CWaiting${urlClusterFilter}"}`,
+                      link: `/multicloud/home/search?filters={"textsearch":"kind%3Apod%20status%3AContainerCreating%2CPending%2CTerminating%2CWaiting${urlClusterFilter}"}`,
                   },
                   {
                       key: 'Running',
                       value: searchResult[2]?.count || 0,
                       isPrimary: true,
-                      link: `/multicloud/search?filters={"textsearch":"kind%3Apod%20status%3ARunning%2CCompleted${urlClusterFilter}"}`,
+                      link: `/multicloud/home/search?filters={"textsearch":"kind%3Apod%20status%3ARunning%2CCompleted${urlClusterFilter}"}`,
                   },
               ]
 
     // TODO: Breaks url if length of selectedClustersFilter is too big.
     // Issue: https://github.com/open-cluster-management/backlog/issues/7087
     function buildClusterComplianceLinks(clusterNames: Array<string> = []): string {
-        return `/multicloud/search?filters={"textsearch":"kind:cluster${
+        return `/multicloud/home/search?filters={"textsearch":"kind:cluster${
             clusterNames.length > 0 ? `%20name:${clusterNames.join(',')}` : ''
         }"}&showrelated=policy`
     }
@@ -483,13 +483,13 @@ export default function OverviewPage() {
                   {
                       key: 'Offline',
                       value: offline,
-                      link: `/multicloud/search?filters={"textsearch":"kind%3Acluster%20ManagedClusterConditionAvailable%3A!True${cloudLabelFilter}"}`,
+                      link: `/multicloud/home/search?filters={"textsearch":"kind%3Acluster%20ManagedClusterConditionAvailable%3A!True${cloudLabelFilter}"}`,
                   },
                   {
                       key: 'Ready',
                       value: ready,
                       isPrimary: true,
-                      link: `/multicloud/search?filters={"textsearch":"kind%3Acluster%20ManagedClusterConditionAvailable%3ATrue${cloudLabelFilter}"}`,
+                      link: `/multicloud/home/search?filters={"textsearch":"kind%3Acluster%20ManagedClusterConditionAvailable%3ATrue${cloudLabelFilter}"}`,
                   },
               ]
 
@@ -503,7 +503,7 @@ export default function OverviewPage() {
                       isPrimary: true,
                       link:
                           policyReportCriticalCount > 0
-                              ? `/multicloud/search?filters={"textsearch":"kind%3Apolicyreport%20critical%3A>0"}`
+                              ? `/multicloud/home/search?filters={"textsearch":"kind%3Apolicyreport%20critical%3A>0"}`
                               : undefined,
                   },
                   {
@@ -511,7 +511,7 @@ export default function OverviewPage() {
                       value: policyReportImportantCount,
                       link:
                           policyReportImportantCount > 0
-                              ? `/multicloud/search?filters={"textsearch":"kind%3Apolicyreport%20important%3A>0"}`
+                              ? `/multicloud/home/search?filters={"textsearch":"kind%3Apolicyreport%20important%3A>0"}`
                               : undefined,
                   },
                   {
@@ -519,7 +519,7 @@ export default function OverviewPage() {
                       value: policyReportModerateCount,
                       link:
                           policyReportModerateCount > 0
-                              ? `/multicloud/search?filters={"textsearch":"kind%3Apolicyreport%20moderate%3A>0"}`
+                              ? `/multicloud/home/search?filters={"textsearch":"kind%3Apolicyreport%20moderate%3A>0"}`
                               : undefined,
                   },
                   {
@@ -527,7 +527,7 @@ export default function OverviewPage() {
                       value: policyReportLowCount,
                       link:
                           policyReportLowCount > 0
-                              ? `/multicloud/search?filters={"textsearch":"kind%3Apolicyreport%20low%3A>0"}`
+                              ? `/multicloud/home/search?filters={"textsearch":"kind%3Apolicyreport%20low%3A>0"}`
                               : undefined,
                   },
               ]

--- a/frontend/src/routes/Home/Search/Details/DetailsPage.test.tsx
+++ b/frontend/src/routes/Home/Search/Details/DetailsPage.test.tsx
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => {
         __esModule: true,
         ...originalModule,
         useLocation: () => ({
-            pathname: '/multicloud/resources',
+            pathname: '/multicloud/home/search/resources',
             search: '?cluster=testCluster&kind=pods&apiversion=v1&namespace=testNamespace&name=testPod',
         }),
         useHistory: () => ({
@@ -26,7 +26,7 @@ jest.mock('react-router-dom', () => {
 })
 Object.defineProperty(window, 'location', {
     value: {
-        pathname: '/multicloud/resources',
+        pathname: '/multicloud/home/search/resources',
         search: '?cluster=testCluster&kind=pods&apiversion=v1&namespace=testNamespace&name=testPod',
     },
 })

--- a/frontend/src/routes/Home/Search/Details/DetailsPage.tsx
+++ b/frontend/src/routes/Home/Search/Details/DetailsPage.tsx
@@ -102,12 +102,12 @@ export default function DetailsPage() {
                             variant={'link'}
                             onClick={() => {
                                 const prevLocState = window.history?.state?.state
-                                if (prevLocState && prevLocState.from === '/multicloud/search') {
+                                if (prevLocState && prevLocState.from === '/multicloud/home/search') {
                                     // If we came to resources page from search - return to search with previous search filters
                                     history.goBack()
                                 } else {
                                     // If we were redirected to search from elsewhere (ex: application page) - go to blank search page
-                                    window.location.href = '/multicloud/search'
+                                    window.location.href = '/multicloud/home/search'
                                 }
                             }}
                         >
@@ -118,16 +118,27 @@ export default function DetailsPage() {
                         title={name}
                         navigation={
                             <AcmSecondaryNav>
-                                <AcmSecondaryNavItem isActive={location.pathname === '/multicloud/resources'}>
-                                    <Link replace to={`/multicloud/resources?${encodeURIComponent(resourceUrlParams)}`}>
+                                <AcmSecondaryNavItem
+                                    isActive={location.pathname === '/multicloud/home/search/resources'}
+                                >
+                                    <Link
+                                        replace
+                                        to={`/multicloud/home/search/resources?${encodeURIComponent(
+                                            resourceUrlParams
+                                        )}`}
+                                    >
                                         YAML
                                     </Link>
                                 </AcmSecondaryNavItem>
                                 {(kind.toLowerCase() === 'pod' || kind.toLowerCase() === 'pods') && (
-                                    <AcmSecondaryNavItem isActive={location.pathname === '/multicloud/resources/logs'}>
+                                    <AcmSecondaryNavItem
+                                        isActive={location.pathname === '/multicloud/home/search/resources/logs'}
+                                    >
                                         <Link
                                             replace
-                                            to={`/multicloud/resources/logs?${encodeURIComponent(resourceUrlParams)}`}
+                                            to={`/multicloud/home/search/resources/logs?${encodeURIComponent(
+                                                resourceUrlParams
+                                            )}`}
                                         >
                                             Logs
                                         </Link>
@@ -140,7 +151,7 @@ export default function DetailsPage() {
             }
         >
             <Switch>
-                <Route exact path={'/multicloud/resources'}>
+                <Route exact path={'/multicloud/home/search/resources'}>
                     <YAMLPage
                         resource={resource}
                         loading={!resource && resourceError !== ''}
@@ -153,7 +164,7 @@ export default function DetailsPage() {
                     />
                 </Route>
                 {(kind.toLowerCase() === 'pod' || kind.toLowerCase() === 'pods') && (
-                    <Route path={'/multicloud/resources/logs'}>
+                    <Route path={'/multicloud/home/search/resources/logs'}>
                         <LogsPage
                             resourceError={resourceError}
                             containers={_.get(resource, 'spec.containers', []).map((container: any) => container.name)}

--- a/frontend/src/routes/Home/Search/SearchPage.tsx
+++ b/frontend/src/routes/Home/Search/SearchPage.tsx
@@ -21,6 +21,12 @@ import React, { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilState } from 'recoil'
 import { acmRouteState } from '../../../atoms'
+import HeaderWithNotification from './components/HeaderWithNotification'
+import { SaveAndEditSearchModal } from './components/Modals/SaveAndEditSearchModal'
+import { SearchInfoModal } from './components/Modals/SearchInfoModal'
+import SavedSearchQueries from './components/SavedSearchQueries'
+import SearchResults from './components/SearchResults'
+import { convertStringToQuery, formatSearchbarSuggestions, getSearchCompleteString } from './search-helper'
 import { searchClient } from './search-sdk/search-client'
 import {
     useGetMessagesQuery,
@@ -29,12 +35,6 @@ import {
     useSearchCompleteQuery,
     useSearchSchemaQuery,
 } from './search-sdk/search-sdk'
-import HeaderWithNotification from './components/HeaderWithNotification'
-import { SaveAndEditSearchModal } from './components/Modals/SaveAndEditSearchModal'
-import { SearchInfoModal } from './components/Modals/SearchInfoModal'
-import SavedSearchQueries from './components/SavedSearchQueries'
-import SearchResults from './components/SearchResults'
-import { convertStringToQuery, formatSearchbarSuggestions, getSearchCompleteString } from './search-helper'
 import { transformBrowserUrlToSearchString, updateBrowserUrl } from './urlQuery'
 
 const operators = ['=', '<', '>', '<=', '>=', '!=', '!']
@@ -224,7 +224,7 @@ function RenderDropDownAndNewTab(props: {
                     savedSearchQueries={props.savedSearchQueries}
                 />
                 <AcmButton
-                    href={'/multicloud/search'}
+                    href={'/multicloud/home/search'}
                     variant={ButtonVariant.link}
                     component="a"
                     target="_blank"

--- a/frontend/src/routes/Home/Search/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/Home/Search/__snapshots__/searchDefinitions.test.ts.snap
@@ -22,10 +22,10 @@ exports[`Correctly returns CreateDetailsLink - Default 1`] = `
 <Link
   to={
     Object {
-      "pathname": "/multicloud/resources",
+      "pathname": "/multicloud/home/search/resources",
       "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestPodNamespace%26name%3DtestPodName",
       "state": Object {
-        "from": "/multicloud/search",
+        "from": "/multicloud/home/search",
       },
     }
   }
@@ -46,10 +46,10 @@ exports[`Correctly returns CreateDetailsLink - Managed-Policy 1`] = `
 <Link
   to={
     Object {
-      "pathname": "/multicloud/resources",
+      "pathname": "/multicloud/home/search/resources",
       "search": "?cluster%3DtestCluster%26kind%3Dpolicy%26namespace%3DtestPolicyNamespace%26name%3DtestPolicyName",
       "state": Object {
-        "from": "/multicloud/search",
+        "from": "/multicloud/home/search",
       },
     }
   }
@@ -62,10 +62,10 @@ exports[`Correctly returns CreateDetailsLink - NON-Application 1`] = `
 <Link
   to={
     Object {
-      "pathname": "/multicloud/resources",
+      "pathname": "/multicloud/home/search/resources",
       "search": "?cluster%3DtestCluster%26kind%3Dapplication%26namespace%3DtestApplicationNamespace%26name%3DtestApplicationName",
       "state": Object {
-        "from": "/multicloud/search",
+        "from": "/multicloud/home/search",
       },
     }
   }
@@ -100,10 +100,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -150,10 +150,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -210,10 +210,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -270,10 +270,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -345,10 +345,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -395,10 +395,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -465,10 +465,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -540,10 +540,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -595,10 +595,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -665,10 +665,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -715,10 +715,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -785,10 +785,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -850,10 +850,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -900,10 +900,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -965,10 +965,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1045,10 +1045,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1115,10 +1115,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1170,10 +1170,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1225,10 +1225,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1280,10 +1280,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1350,10 +1350,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1415,10 +1415,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1472,10 +1472,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1524,10 +1524,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1584,10 +1584,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1639,10 +1639,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1704,10 +1704,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }
@@ -1764,10 +1764,10 @@ Array [
     "cell": <Link
       to={
         Object {
-          "pathname": "/multicloud/resources",
+          "pathname": "/multicloud/home/search/resources",
           "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
           "state": Object {
-            "from": "/multicloud/search",
+            "from": "/multicloud/home/search",
           },
         }
       }

--- a/frontend/src/routes/Home/Search/components/HeaderWithNotification.tsx
+++ b/frontend/src/routes/Home/Search/components/HeaderWithNotification.tsx
@@ -34,7 +34,7 @@ export default function HeaderWithNotification(props: { messages: Message[] }) {
                                     headerContent: displayShortText,
                                     bodyContent: displayLongText,
                                     footerContent: msg.id === 'S20' && (
-                                        <a href='/multicloud/search?filters={"textsearch":"kind%3Acluster%20addon%3Asearch-collector%3Dfalse%20name%3A!local-cluster"}'>
+                                        <a href='/multicloud/home/search?filters={"textsearch":"kind%3Acluster%20addon%3Asearch-collector%3Dfalse%20name%3A!local-cluster"}'>
                                             {footerText}
                                         </a>
                                     ),

--- a/frontend/src/routes/Home/Search/searchDefinitions.tsx
+++ b/frontend/src/routes/Home/Search/searchDefinitions.tsx
@@ -1397,10 +1397,10 @@ export function CreateDetailsLink(item: any) {
             return (
                 <Link
                     to={{
-                        pathname: '/multicloud/resources',
+                        pathname: '/multicloud/home/search/resources',
                         search: GetUrlSearchParam(item),
                         state: {
-                            from: '/multicloud/search',
+                            from: '/multicloud/home/search',
                         },
                     }}
                 >
@@ -1416,10 +1416,10 @@ export function CreateDetailsLink(item: any) {
             return (
                 <Link
                     to={{
-                        pathname: '/multicloud/resources',
+                        pathname: '/multicloud/home/search/resources',
                         search: GetUrlSearchParam(item),
                         state: {
-                            from: '/multicloud/search',
+                            from: '/multicloud/home/search',
                         },
                     }}
                 >
@@ -1440,10 +1440,10 @@ export function CreateDetailsLink(item: any) {
             return (
                 <Link
                     to={{
-                        pathname: '/multicloud/resources',
+                        pathname: '/multicloud/home/search/resources',
                         search: GetUrlSearchParam(item),
                         state: {
-                            from: '/multicloud/search',
+                            from: '/multicloud/home/search',
                         },
                     }}
                 >

--- a/frontend/src/routes/Home/Search/urlQuery.ts
+++ b/frontend/src/routes/Home/Search/urlQuery.ts
@@ -18,8 +18,8 @@ export function updateBrowserUrl(currentQuery: string) {
 
 // This function handles navigation to search page with a predefined searchquery in browsers url
 export function transformBrowserUrlToSearchString(urlQuery: string) {
-    // Example browser url string
-    // .../multicloud/search?filters={"textsearch":"kind%3Adeployment%20name%3Asearch-prod-df8fa-search-api"}&showrelated=pod
+    // Example browser url string:
+    // .../multicloud/home/search?filters={"textsearch":"kind%3Adeployment%20name%3Asearch-prod-df8fa-search-api"}&showrelated=pod
     const prefillSearchQuery = ''
     const preSelectedRelatedResources: string[] = []
     if (urlQuery !== '') {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -218,7 +218,9 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
                 id: 'search-cluster',
                 text: t('managed.search'),
                 click: (cluster: Cluster) =>
-                    window.location.assign(`/multicloud/search?filters={"textsearch":"cluster%3A${cluster?.name}"}`),
+                    window.location.assign(
+                        `/multicloud/home/search?filters={"textsearch":"cluster%3A${cluster?.name}"}`
+                    ),
             },
             {
                 id: 'import-cluster',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
@@ -15,7 +15,9 @@ import { ClusterPolicySidebar } from './ClusterPolicySidebar'
 const buildSearchLink = (filters: Record<string, string>, relatedKind?: string) => {
     let query = ''
     Object.keys(filters).forEach((key) => (query += `${query ? '%20' : ''}${key}:${filters[key]}`))
-    return `/multicloud/search?filters={"textsearch":"${query}"}${relatedKind ? `&showrelated=${relatedKind}` : ''}`
+    return `/multicloud/home/search?filters={"textsearch":"${query}"}${
+        relatedKind ? `&showrelated=${relatedKind}` : ''
+    }`
 }
 
 export function StatusSummaryCount() {


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/17364

Updated routes:
`multicloud/search` -> `multicloud/home/search`
`multicloud/resources` -> `multicloud/home/search/resources`