### PR TITLE
[ACM-21036] Fix unexpected API error on vm snapshots

### DIFF
--- a/frontend/src/routes/Search/Details/SnapshotsTab.tsx
+++ b/frontend/src/routes/Search/Details/SnapshotsTab.tsx
@@ -88,25 +88,26 @@ export default function SnapshotsTab() {
       </PageSection>
     )
   }
-  if (error) {
-    return (
-      <PageSection>
-        <Alert variant={'danger'} isInline={true} title={t('An unexpected error occurred.')}>
-          {error.message}
-        </Alert>
-      </PageSection>
-    )
-  }
-
-  if (!loading && !error && snapshotItems.length === 0) {
+  if (
+    (!loading && !error && snapshotItems.length === 0) ||
+    // check error message - this message is only found if no snapshots have been created and the sourceName property is not initialized in search db.
+    error?.message.includes('fetching data type for property: [sourceName]')
+  ) {
     return (
       <PageSection>
         <Alert
           variant={'info'}
           isInline={true}
           title={t('No VirtualMachineSnapshots found. Take a snapshot of the VirtualMachine to view snapshots here.')}
-        >
-          {error}
+        />
+      </PageSection>
+    )
+  }
+  if (error) {
+    return (
+      <PageSection>
+        <Alert variant={'danger'} isInline={true} title={t('An unexpected error occurred.')}>
+          {error.message}
         </Alert>
       </PageSection>
     )


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Fixes vague API error shown on snapshots tab when no VM snapshots are present in env.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-21036

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->