### PR TITLE
Add kubevirt flag to disallow vm list page programmatically

### DIFF
--- a/frontend/plugins/mce/console-extensions.ts
+++ b/frontend/plugins/mce/console-extensions.ts
@@ -132,6 +132,9 @@ const virtualMachinesRoute: EncodedExtension<RoutePage> = {
     path: '/multicloud/infrastructure/virtualmachines',
     component: { $codeRef: 'virtualmachines.default' },
   },
+  flags: {
+    disallowed: ['KUBEVIRT_DYNAMIC_ACM'],
+  },
 }
 
 // Credentials Navigation Item - type: 'console.navigation/href'


### PR DESCRIPTION
we'll use in kubevirt this flag to disable the acm vm list and use our list component in hte same url 