### PR TITLE
Disable download configuration dropdown is user doesn't have access to Secret resource.

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DownloadConfigurationDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DownloadConfigurationDropdown.tsx
@@ -41,20 +41,18 @@ export function DownloadConfigurationDropdown({
     dropdownItems.push({
       id: 'install-config.yaml',
       text: 'install-config',
-      isAriaDisabled: !canGetSecret,
-      tooltip: !canGetSecret ? t('rbac.unauthorized') : undefined,
     })
   }
   if (cluster?.kubeconfig) {
     dropdownItems.push({
       id: 'kubeconfig',
       text: 'kubeconfig',
-      isAriaDisabled: !canGetSecret,
-      tooltip: !canGetSecret ? t('rbac.unauthorized') : undefined,
     })
   }
   return (
     <AcmDropdown
+      isDisabled={!canGetSecret}
+      tooltip={!canGetSecret ? t('rbac.unauthorized') : ''}
       isPlain={true}
       dropdownItems={dropdownItems}
       onSelect={(id: string) => downloadConfig(id)}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Disable download configuration dropdown is user doesn't have access to Secret resource.

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->