### PR TITLE
Manual cherrypick - Fix HCP upgrade version not displaying 2.14

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -1129,7 +1129,7 @@ describe('DistributionField hypershift clusters', () => {
       'managedclusterpage'
     )
 
-    expect(queryAllByText(/upgrading to 4\.11\.22-x86_64/i).length).toBe(1)
+    expect(queryAllByText(/upgrading to 4\.11\.22/i).length).toBe(1)
     expect(queryByRole('progressbar')).toBeTruthy()
   })
 
@@ -1145,7 +1145,7 @@ describe('DistributionField hypershift clusters', () => {
       'hostedcluster'
     )
 
-    expect(queryAllByText(/upgrading to 4\.11\.22-x86_64/i).length).toBe(1)
+    expect(queryAllByText(/upgrading to 4\.11\.22/i).length).toBe(1)
     expect(queryByRole('progressbar')).toBeTruthy()
   })
 
@@ -1200,7 +1200,7 @@ describe('DistributionField hypershift clusters', () => {
       'nodepool'
     )
 
-    expect(queryAllByText(/upgrading to 4\.11\.22-x86_64/i).length).toBe(0)
+    expect(queryAllByText(/upgrading to 4\.11\.22/i).length).toBe(0)
     expect(queryByRole('progressbar')).toBeFalsy()
   })
 
@@ -1274,11 +1274,11 @@ describe('DistributionField hypershift clusters', () => {
       false
     )
 
-    await userEvent.click(screen.getByRole('button', { name: /upgrading to 4\.11\.22-x86_64/i }))
+    await userEvent.click(screen.getByRole('button', { name: /upgrading to 4\.11\.22/i }))
     await waitFor(() =>
-      expect(getByText(/upgrading hypershift-cluster1 to openshift 4\.11\.22-x86_64\./i)).toBeInTheDocument()
+      expect(getByText(/upgrading hypershift-cluster1 to openshift 4\.11\.22\./i)).toBeInTheDocument()
     )
-    expect(queryAllByText(/upgrading to 4\.11\.22-x86_64/i).length).toBe(1)
+    expect(queryAllByText(/upgrading to 4\.11\.22/i).length).toBe(1)
     expect(queryByRole('progressbar')).toBeTruthy()
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -18,7 +18,7 @@ import { rbacCreate, rbacPatch } from '../../../../../lib/rbac-util'
 import { BatchUpgradeModal } from './BatchUpgradeModal'
 import { useAgentClusterInstall } from '../CreateCluster/components/assisted-installer/utils'
 import { HypershiftUpgradeModal } from './HypershiftUpgradeModal'
-import { getVersionFromReleaseImage, HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
+import { HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
 import { useSharedAtoms, useRecoilValue } from '../../../../../shared-recoil'
 import { Link } from 'react-router-dom-v5-compat'
 import { getSearchLink } from '../../../../Applications/helpers/resource-helper'
@@ -45,6 +45,13 @@ const isUpdateVersionAcceptable = (currentVersion: string, newVersion: string) =
   }
 
   return false
+}
+
+export const getVersionFromReleaseImage = (releaseImage = '') => {
+  const match = /.+:(\d+\.\d+(?:\.\d+)?)/gm.exec(releaseImage)
+  if (match && match.length > 1 && match[1]) {
+    return match[1]
+  }
 }
 
 export function DistributionField(props: {


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
This is a manual cherrypick for this PR https://github.com/stolostron/console/pull/4939 to the 2.14 release as the automated cherrypick failed.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-23688

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->