### PR TITLE
Maxsocket and network-concurrency limits for npm ci in konflux

### DIFF
--- a/.tekton/console-acm-215-pull-request.yaml
+++ b/.tekton/console-acm-215-pull-request.yaml
@@ -29,6 +29,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Containerfile.acm.konflux
   - name: path-context

--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -7,14 +7,14 @@ WORKDIR /app
 COPY . .
 
 # Running installs concurrently fails on aarch64
-RUN npm ci --omit=optional --unsafe-perm --ignore-scripts
-RUN cd backend && npm ci --omit=optional  --unsafe-perm --ignore-scripts
-RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm --ignore-scripts
+RUN npm ci --omit=optional --unsafe-perm --ignore-scripts --maxsockets=5 --network-concurrency=3
+RUN cd backend && npm ci --omit=optional  --unsafe-perm --ignore-scripts --maxsockets=5 --network-concurrency=3
+RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm --ignore-scripts --maxsockets=5 --network-concurrency=3
 RUN npm run build:backend
-RUN cd frontend && npm run build:plugin:acm
+RUN cd frontend && npm run build:plugin:acm --maxsockets=5 --network-concurrency=3
 
 # Remove build-time dependencies before packaging
-RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
+RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts --maxsockets=5 --network-concurrency=3
 
 FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:8d786ab1cda0930d8a040b35a125a2e04fe6446b73af397b20291478141fe244
 


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Regarding intermittent breakages with 232 error (too many files open). This commit introduces stricter limitations to the number of concurrent network sockets and network request allowed while executing `npm ci`. 

**NOTE:** We are also enabling testing on all platforms for the _pull request_ pipeline run, this means `Red Hat Konflux / console-acm-215-on-pull-request` tests will take more time than usual to be completed within our pull requests.

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://redhat-internal.slack.com/archives/C06TJJ3E0MU/p1757341131662649

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [x] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->