### PR TITLE
ACM-23648: Custom ACM feedback modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,6 @@
         "@patternfly/react-styles": "^5.4.1",
         "@patternfly/react-table": "^5.4.11",
         "@patternfly/react-topology": "^5.4.1",
-        "@patternfly/react-user-feedback": "^5.0.0",
         "@react-hook/resize-observer": "1.2.5",
         "@redhat-cloud-services/rule-components": "^3.2.31",
         "@reduxjs/toolkit": "1.8.x",
@@ -6715,20 +6714,6 @@
         "react-measure": "^2.3.0",
         "tslib": "^2.0.0",
         "webcola": "3.4.0"
-      },
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
-      }
-    },
-    "node_modules/@patternfly/react-user-feedback": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-user-feedback/-/react-user-feedback-5.0.0.tgz",
-      "integrity": "sha512-E28AC87z9A2X5blf9ih9YVoHsAo68tDM6fLrOWFU447v3QHmWwBIViHT7/BL+M2B7ZORQ+LtM9M4bn0lq7/Ezw==",
-      "license": "MIT",
-      "dependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -47071,15 +47056,6 @@
         "react-measure": "^2.3.0",
         "tslib": "^2.0.0",
         "webcola": "3.4.0"
-      }
-    },
-    "@patternfly/react-user-feedback": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-user-feedback/-/react-user-feedback-5.0.0.tgz",
-      "integrity": "sha512-E28AC87z9A2X5blf9ih9YVoHsAo68tDM6fLrOWFU447v3QHmWwBIViHT7/BL+M2B7ZORQ+LtM9M4bn0lq7/Ezw==",
-      "requires": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0"
       }
     },
     "@pkgjs/parseargs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,6 @@
     "@patternfly/react-styles": "^5.4.1",
     "@patternfly/react-table": "^5.4.11",
     "@patternfly/react-topology": "^5.4.1",
-    "@patternfly/react-user-feedback": "^5.0.0",
     "@react-hook/resize-observer": "1.2.5",
     "@redhat-cloud-services/rule-components": "^3.2.31",
     "@reduxjs/toolkit": "1.8.x",

--- a/frontend/src/components/AcmFeedbackModal.tsx
+++ b/frontend/src/components/AcmFeedbackModal.tsx
@@ -1,27 +1,39 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { FeedbackLocale, FeedbackModal } from '@patternfly/react-user-feedback'
-import feedbackImage from './feedback_illo.png'
 import { useTranslation } from '../lib/acm-i18next'
 import { AcmButton } from '../ui-components'
-import { OutlinedCommentsIcon } from '@patternfly/react-icons'
+import { OutlinedCommentsIcon, ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { useState } from 'react'
 import { DOC_VERSION } from '../lib/doc-util'
+import feedbackImage from './feedback_illo.png'
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  Card,
+  CardTitle,
+  CardBody,
+  TextContent,
+  Text,
+  TextVariants,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core'
 
 export const AcmFeedbackModal = () => {
   const { t } = useTranslation()
-  const i18nStrings = {
-    getSupport: t('Get support'),
-    cancel: t('Cancel'),
-    helpUsImproveHCC: t('Help us improve Red Hat Advanced Cluster Management for Kubernetes.'),
-    howIsConsoleExperience: t('What has your console experience been like so far?'),
-    openSupportCase: t('Support Case'),
-    shareFeedback: t('Share feedback'),
-    tellAboutExperience: t('Tell us about your experience'),
-  }
-
   const [toggleOpen, setToggleOpen] = useState<boolean>(false)
   const toggle = () => setToggleOpen(!toggleOpen)
+
+  const handleShareFeedback = () => {
+    window.open(`https://console.redhat.com/self-managed-feedback-form?source=acm&version=${DOC_VERSION}`, '_blank')
+    setToggleOpen(false)
+  }
+
+  const handleOpenSupportCase = () => {
+    window.open('https://access.redhat.com/support/cases/#/case/new/open-case?caseCreate=true', '_blank')
+    setToggleOpen(false)
+  }
 
   return (
     <>
@@ -43,15 +55,54 @@ export const AcmFeedbackModal = () => {
       >
         {t('Feedback')}
       </AcmButton>
-      <FeedbackModal
-        feedbackLocale={i18nStrings as unknown as FeedbackLocale}
-        email="test@redhat.com"
-        onShareFeedback={`https://console.redhat.com/self-managed-feedback-form?source=acm&version=${DOC_VERSION}`}
-        onOpenSupportCase="https://access.redhat.com/support/cases/#/case/new/open-case?caseCreate=true"
+
+      <Modal
+        variant={ModalVariant.medium}
+        title={t('Tell us about your experience')}
         isOpen={toggleOpen}
-        feedbackImg={feedbackImage}
         onClose={() => setToggleOpen(false)}
-      />
+        actions={[
+          <Button key="cancel" variant="link" onClick={() => setToggleOpen(false)}>
+            {t('Cancel') || 'Cancel'}
+          </Button>,
+        ]}
+      >
+        <Grid hasGutter>
+          <GridItem span={8}>
+            <TextContent>
+              <Text component={TextVariants.p}>
+                {t('Help us improve Red Hat Advanced Cluster Management for Kubernetes.')}
+              </Text>
+              <Text component={TextVariants.p}>{t('What has your console experience been like so far?')}</Text>
+            </TextContent>
+
+            <div style={{ marginTop: '1rem' }}>
+              <Card
+                isSelectableRaised
+                isCompact
+                onClick={handleShareFeedback}
+                style={{ cursor: 'pointer', marginBottom: '1rem' }}
+              >
+                <CardTitle>
+                  {t('Share feedback')} <ExternalLinkAltIcon />
+                </CardTitle>
+                <CardBody>{t('What has your console experience been like so far?')}</CardBody>
+              </Card>
+
+              <Card isSelectableRaised isCompact onClick={handleOpenSupportCase} style={{ cursor: 'pointer' }}>
+                <CardTitle>
+                  {t('Support Case')} <ExternalLinkAltIcon />
+                </CardTitle>
+                <CardBody>{t('Get support')}</CardBody>
+              </Card>
+            </div>
+          </GridItem>
+
+          <GridItem span={4} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <img alt="feedback illustration" src={feedbackImage} style={{ maxWidth: '100%', height: 'auto' }} />
+          </GridItem>
+        </Grid>
+      </Modal>
     </>
   )
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Feedback Modal Crashes with TypeError
The Feedback model ('@patternfly/react-user-feedback') from Pattern Fly is suffering from dependency issues from PatternFly. Upgrading to the most recent release works for OCP 4.20 (as it is running on PatternFly 6, but on earlier platforms this results in breakage).

My thinking here is that a more version agnostic implementation would be preferable until we off-ramp PatternFly 5 from ACM console's current support matrix. With this new implementation we are still using react components for the modal but we avoid directly using the react-user-feedback component.

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-23648

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->