### PR TITLE
Add repository url label to container images

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -27,6 +27,7 @@ USER 1001
 CMD ["node", "backend.mjs"]
 
 LABEL com.redhat.component="console-container" \
+      url="https://github.com/stolostron/console" \
       name="rhacm2/console-rhel9" \
       summary="console" \
       io.openshift.expose-services="" \

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -27,6 +27,7 @@ USER 1001
 CMD ["node", "backend.mjs"]
 
 LABEL com.redhat.component="multicluster-engine-console-mce-container" \
+      url="https://github.com/stolostron/console" \
       name="multicluster-engine/console-mce-rhel9" \
       summary="multicluster-engine-console-mce" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** console

**Branch details:** console (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/console

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.