### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for console-mce-mce-29

### DIFF
--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -27,6 +27,7 @@ USER 1001
 CMD ["node", "backend.mjs"]
 
 LABEL com.redhat.component="multicluster-engine-console-mce-container" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       name="multicluster-engine/console-mce-rhel9" \
       summary="multicluster-engine-console-mce" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
