### PR TITLE
ACM-29933 Add channel to compliance-operator policy

### DIFF
--- a/frontend/src/wizards/Governance/Policy/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/frontend/src/wizards/Governance/Policy/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -3,7 +3,7 @@
 #
 # If set to "enforce" it'll install the operator.
 #
-# Note that OpenShift 4.6 is required.
+# Note that OpenShift 4.6+ is required.
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -51,6 +51,7 @@ spec:
             namespace: openshift-compliance
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+            channel: stable
             # Conditionally configure a nodeSelector for installing on ROSA hosted control planes
             config: '{{ if and (eq "ROSA" (lookup "cluster.open-cluster-management.io/v1alpha1"
               "ClusterClaim" "" "product.open-cluster-management.io").spec.value) (eq "true"


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
If there are multiple catalogs that provide the compliance-operator, then the OperatorPolicy may give an error while determining the default channel for the operator. Providing the channel directly prevents this issue.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-29933

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenShift version requirement to 4.6+ for Compliance Operator policy.

* **Chores**
  * Configured Compliance Operator to use stable release channel during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->