### PR TITLE
ACM-30321 Fix AWS instance type

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2880,7 +2880,7 @@
   "submariner.install.form.gateways.labelHelp": "The number of worker nodes used to deploy the Submariner gateway component on the managed cluster. If the value is greater than 1, the Submariner gateway HA is enabled automatically (default 1).",
   "submariner.install.form.gateways.placeholder": "Enter gateway count",
   "submariner.install.form.instancetype": "Enter instance type",
-  "submariner.install.form.instancetype.labelHelp.aws": "The Amazon Web Services EC2 instance type of the gateway node that will be created on the managed cluster (default c5d.large).",
+  "submariner.install.form.instancetype.labelHelp.aws": "The Amazon Web Services EC2 instance type of the gateway node that will be created on the managed cluster (default m5.xlarge).",
   "submariner.install.form.instancetype.labelHelp.azure": "The Azure instance type of the gateway node that will be created on the managed cluster (default Standard_F4s_v2).",
   "submariner.install.form.instancetype.placeholder": "Select instance type",
   "submariner.install.form.nattenable": "Enable NAT-T",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -2873,7 +2873,7 @@
   "submariner.install.form.gateways.labelHelp": "La cantidad de nodos trabajadores utilizados para implementar el componente de puerta de enlace de Submariner en el clúster gestionado. Si el valor es mayor que 1, la puerta de enlace HA de Submariner se habilita automáticamente (1 predeterminado).",
   "submariner.install.form.gateways.placeholder": "Ingresar el recuento de puertas de enlace",
   "submariner.install.form.instancetype": "Ingresar el tipo de instancia",
-  "submariner.install.form.instancetype.labelHelp.aws": "El tipo de instancia EC2 de Amazon Web Services del nodo de puerta de enlace que se creará en el clúster gestionado (c5d.large predeterminado).",
+  "submariner.install.form.instancetype.labelHelp.aws": "El tipo de instancia EC2 de Amazon Web Services del nodo de puerta de enlace que se creará en el clúster gestionado (m5.xlarge predeterminado).",
   "submariner.install.form.instancetype.labelHelp.azure": "El tipo de instancia de Azure del nodo de puerta de enlace que se creará en el clúster gestionado (Standard_F4s_v2 predeterminado).",
   "submariner.install.form.instancetype.placeholder": "Seleccionar tipo de instancia",
   "submariner.install.form.nattenable": "Habilitar NAT-T",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -2873,7 +2873,7 @@
   "submariner.install.form.gateways.labelHelp": "Nombre de nœuds worker utilisés pour déployer le composant de passerelle Submariner sur le cluster géré. Si la valeur est supérieure à 1, le mode HA de la passerelle Submariner est automatiquement activé (valeur par défaut : 1).",
   "submariner.install.form.gateways.placeholder": "Saisir le nombre de passerelles",
   "submariner.install.form.instancetype": "Saisir le type d’instance",
-  "submariner.install.form.instancetype.labelHelp.aws": "Type d’instance Amazon Web Services EC2 du nœud de passerelle qui sera créé sur le cluster géré (valeur par défaut : c5d.large).",
+  "submariner.install.form.instancetype.labelHelp.aws": "Type d’instance Amazon Web Services EC2 du nœud de passerelle qui sera créé sur le cluster géré (valeur par défaut : m5.xlarge).",
   "submariner.install.form.instancetype.labelHelp.azure": "Type d’instance Azure du nœud de passerelle qui sera créé sur le cluster géré (valeur par défaut : Standard_F4s_v2).",
   "submariner.install.form.instancetype.placeholder": "Sélectionner le type d’instance",
   "submariner.install.form.nattenable": "Activer NAT-T",

--- a/frontend/public/locales/ja/translation.json
+++ b/frontend/public/locales/ja/translation.json
@@ -2844,7 +2844,7 @@
   "submariner.install.form.gateways.labelHelp": "マネージドクラスターに Submariner ゲートウェイコンポーネントをデプロイするために使用されるワーカーノードの数。値が 1 より大きい場合、Submariner ゲートウェイの HA は自動的に有効化されます (デフォルト 1)。",
   "submariner.install.form.gateways.placeholder": "ゲートウェイ数を入力します",
   "submariner.install.form.instancetype": "インスタンスタイプを入力します",
-  "submariner.install.form.instancetype.labelHelp.aws": "マネージドクラスター上に作成されるゲートウェイノードの Amazon Web Services EC2 インスタンスタイプ (デフォルト c5d.large)。",
+  "submariner.install.form.instancetype.labelHelp.aws": "マネージドクラスター上に作成されるゲートウェイノードの Amazon Web Services EC2 インスタンスタイプ (デフォルト m5.xlarge)。",
   "submariner.install.form.instancetype.labelHelp.azure": "マネージドクラスター上に作成されるゲートウェイノードの Azure インスタンスタイプ (デフォルト Standard_F4s_v2)。",
   "submariner.install.form.instancetype.placeholder": "インスタンスタイプの選択",
   "submariner.install.form.nattenable": "NAT-T の有効化",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -2844,7 +2844,7 @@
   "submariner.install.form.gateways.labelHelp": "관리형 클러스터에 Submariner 게이트웨이 구성 요소를 배포하는 데 사용되는 작업자 노드 수입니다. 값이 1보다 크면 Submariner 게이트웨이 HA가 자동으로 활성화됩니다. (기본값 1)",
   "submariner.install.form.gateways.placeholder": "게이트웨이 수 입력",
   "submariner.install.form.instancetype": "인스턴스 유형 입력",
-  "submariner.install.form.instancetype.labelHelp.aws": "관리되는 클러스터에서 생성될 게이트웨이 노드의 Amazon Web Services EC2 인스턴스 유형입니다. (기본값 c5d.large)",
+  "submariner.install.form.instancetype.labelHelp.aws": "관리되는 클러스터에서 생성될 게이트웨이 노드의 Amazon Web Services EC2 인스턴스 유형입니다. (기본값 m5.xlarge)",
   "submariner.install.form.instancetype.labelHelp.azure": "관리형 클러스터에서 생성될 게이트웨이 노드의 Azure 인스턴스 유형입니다. (기본값 Standard_F4s_v2).",
   "submariner.install.form.instancetype.placeholder": "인스턴스 유형 선택",
   "submariner.install.form.nattenable": "NAT-T 활성화",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2844,7 +2844,7 @@
   "submariner.install.form.gateways.labelHelp": "用于在受管集群中部署 Submariner 网关组件的 worker 节点的数量。如果值大于 1，则 Submariner 网关 HA 将自动启用。（默认为 1）。",
   "submariner.install.form.gateways.placeholder": "输入网关数",
   "submariner.install.form.instancetype": "输入实例类型",
-  "submariner.install.form.instancetype.labelHelp.aws": "将在受管集群上创建的网关节点的 Amazon Web Services EC2 实例类型（默认 c5d.large）。",
+  "submariner.install.form.instancetype.labelHelp.aws": "将在受管集群上创建的网关节点的 Amazon Web Services EC2 实例类型（默认 m5.xlarge）。",
   "submariner.install.form.instancetype.labelHelp.azure": "将在受管集群上创建的网关节点的 Azure 实例类型（默认 Standard_F4s_v2）。",
   "submariner.install.form.instancetype.placeholder": "选择实例类型",
   "submariner.install.form.nattenable": "启用 NAT-T",

--- a/frontend/src/resources/submariner-config.ts
+++ b/frontend/src/resources/submariner-config.ts
@@ -87,7 +87,7 @@ export const submarinerConfigDefault: SubmarinerConfigDefaults = {
   nattEnable: true,
   cableDriver: CableDriver.libreswan,
   gateways: 1,
-  awsInstanceType: 'c5d.large',
+  awsInstanceType: 'm5.xlarge',
   azureInstanceType: 'Standard_F4s_v2',
   openStackInstanceType: 'PnTAE.CPU_4_Memory_8192_Disk_50',
   loadBalancerEnable: false,


### PR DESCRIPTION
c5d.large is not working so changed to m5.xlarge

# 📝 Summary
"subctl cloud prepare aws" creates machine that will not be provisioned as node
**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-30321
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AWS instance type configuration for Submariner gateway nodes across all supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->