### PR TITLE
ACM-32046: Fix search prefill on policy details results tab

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -251,6 +251,7 @@ describe('Export from policy details results table', () => {
 
 describe('Search prefill from URL query string', () => {
   beforeEach(async () => {
+    localStorage.clear()
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
   })

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -248,3 +248,58 @@ describe('Export from policy details results table', () => {
     )
   })
 })
+
+describe('Search prefill from URL query string', () => {
+  beforeEach(async () => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+  })
+
+  test('Should prefill search bar when location.search contains a search param', async () => {
+    const context: PolicyDetailsContext = { policy: mockPolicy[0] }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, mockPolicy)
+        }}
+      >
+        <MemoryRouter initialEntries={['?search=local-cluster']}>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<PolicyDetailsResults />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForText('Clusters')
+
+    const searchInput = screen.getByPlaceholderText('Find clusters')
+    expect(searchInput).toHaveValue('local-cluster')
+  })
+
+  test('Should have empty search bar when location.search is empty', async () => {
+    const context: PolicyDetailsContext = { policy: mockPolicy[0] }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, mockPolicy)
+        }}
+      >
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<PolicyDetailsResults />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForText('Clusters')
+
+    const searchInput = screen.getByPlaceholderText('Find clusters')
+    expect(searchInput).toHaveValue('')
+  })
+})

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -2,7 +2,7 @@
 import { Icon, PageSection, Title, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { AcmEmptyState, AcmTable, AcmTableStateProvider, compareStrings } from '../../../../ui-components'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { Link, generatePath, useLocation } from 'react-router-dom-v5-compat'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { useTranslation } from '../../../../lib/acm-i18next'
@@ -87,13 +87,6 @@ export default function PolicyDetailsResults() {
   const { t } = useTranslation()
   const location = useLocation()
   const filterPresets = transformBrowserUrlToFilterPresets(location.search)
-  const [search, setSearch] = useState(filterPresets.initialSearch)
-
-  useEffect(() => {
-    setSearch(filterPresets.initialSearch)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.search])
-
   const { policy } = usePolicyDetailsContext()
   const { policiesState } = useSharedAtoms()
   const policies = useRecoilValue(policiesState)
@@ -344,8 +337,7 @@ export default function PolicyDetailsResults() {
                 }
               : filterPresets.initialSort
           }
-          search={search}
-          setSearch={setSearch}
+          initialSearch={filterPresets.initialSearch}
           searchPlaceholder={t('Find clusters')}
           fuseThreshold={0}
         />

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -2,8 +2,8 @@
 import { Icon, PageSection, Title, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { AcmEmptyState, AcmTable, AcmTableStateProvider, compareStrings } from '../../../../ui-components'
-import { ReactNode, useMemo } from 'react'
-import { Link, generatePath } from 'react-router-dom-v5-compat'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { Link, generatePath, useLocation } from 'react-router-dom-v5-compat'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../../lib/rbac-util'
@@ -85,7 +85,15 @@ function getTemplateName(item: ResultsTableData, canCreatePolicy: boolean, t: TF
 
 export default function PolicyDetailsResults() {
   const { t } = useTranslation()
-  const filterPresets = transformBrowserUrlToFilterPresets(window.location.search)
+  const location = useLocation()
+  const filterPresets = transformBrowserUrlToFilterPresets(location.search)
+  const [search, setSearch] = useState(filterPresets.initialSearch)
+
+  useEffect(() => {
+    setSearch(filterPresets.initialSearch)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search])
+
   const { policy } = usePolicyDetailsContext()
   const { policiesState } = useSharedAtoms()
   const policies = useRecoilValue(policiesState)
@@ -329,14 +337,15 @@ export default function PolicyDetailsResults() {
           columns={columns}
           keyFn={(item) => `${item.cluster}.${item.templateName}`}
           initialSort={
-            window.location.search === ''
+            location.search === ''
               ? {
                   index: 1,
                   direction: 'desc',
                 }
               : filterPresets.initialSort
           }
-          initialSearch={filterPresets.initialSearch}
+          search={search}
+          setSearch={setSearch}
           searchPlaceholder={t('Find clusters')}
           fuseThreshold={0}
         />

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react'
 import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 import { AcmEmptyState } from '../AcmEmptyState'
 import { AcmTable } from './AcmTable'
-import { AcmTableStateProvider } from './AcmTableStateProvider'
+import { AcmTableStateProvider, setItemWithExpiration } from './AcmTableStateProvider'
 import { AcmTableProps, ExportableIRow, ITableAdvancedFilter } from './AcmTableTypes'
 
 import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat'
@@ -824,6 +824,74 @@ describe('AcmTable', () => {
 
     // verify pagination changes on both tables
     await waitFor(() => expect(container.querySelectorAll('tbody tr')).toHaveLength(200))
+  })
+  test('initialSearch is used when no cached search exists in localStorage', async () => {
+    const storageKey = 'initial-search-no-cache-test'
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <AcmTableStateProvider localStorageKey={storageKey}>
+                <Table useRouter={false} initialSearch="url-query" />
+              </AcmTableStateProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(getByPlaceholderText(placeholderString)).toHaveValue('url-query')
+    })
+  })
+  test('initialSearch takes precedence over cached search in localStorage', async () => {
+    const storageKey = 'initial-beats-cached-test'
+    setItemWithExpiration(`${storageKey}-search`, 'cached-query')
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <AcmTableStateProvider localStorageKey={storageKey}>
+                <Table useRouter={false} initialSearch="url-query" />
+              </AcmTableStateProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(getByPlaceholderText(placeholderString)).toHaveValue('url-query')
+    })
+  })
+  test('cached search from localStorage is used when no initialSearch is provided', async () => {
+    const storageKey = 'cached-search-test'
+    setItemWithExpiration(`${storageKey}-search`, 'cached-query')
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <AcmTableStateProvider localStorageKey={storageKey}>
+                <Table useRouter={false} />
+              </AcmTableStateProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(getByPlaceholderText(placeholderString)).toHaveValue('cached-query')
+    })
   })
   test('has zero accessibility defects', async () => {
     const { container } = render(<Table />)

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -193,8 +193,8 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
   const sort = props.sort || storedSort || stateSort
   const setSort = props.setSort || setStoredSort || stateSetSort
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'test') {
-      setInternalSearch(storedSearch || '')
+    if (process.env.NODE_ENV !== 'test' && storedSearch !== undefined) {
+      setInternalSearch(storedSearch)
     }
   }, [storedSearch])
 

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -63,12 +63,15 @@ const AcmTableStateContext: React.Context<{
 export function AcmTableStateProvider(props: { children: ReactNode; localStorageKey?: string }) {
   const location = useLocation()
   const { localStorageKey = `${location.pathname.split('/').pop() || 'default'}-table-state` } = props
-  const [search, setSearch] = useState('')
+  const [search, setSearch] = useState<string | undefined>(undefined)
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(DEFAULT_ITEMS_PER_PAGE)
   const [sort, setSort] = useState<ISortBy>(DEFAULT_SORT)
   useEffect(() => {
-    setSearch(getItemWithExpiration(`${localStorageKey}-search`) || '')
+    const cachedSearch = getItemWithExpiration(`${localStorageKey}-search`)
+    if (cachedSearch) {
+      setSearch(cachedSearch)
+    }
     setPage(Number.parseInt(getItemWithExpiration(`${localStorageKey}-page`) || '0', 10) || 1)
     setPerPage(Number.parseInt(localStorage.getItem(`${localStorageKey}-perPage`) || '0', 10) || DEFAULT_ITEMS_PER_PAGE)
     setSort(

--- a/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
@@ -339,6 +339,13 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
   const search = props.search ?? storedSearch ?? stateSearch
   const setSearch = props.setSearch ?? stateSetSearch
 
+  useEffect(() => {
+    if (initialSearch) {
+      setStoredSearch(initialSearch)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSearch])
+
   const searchPlaceholder = props.searchPlaceholder ?? t('Search')
   const hasSearch = useMemo(() => columns.some((column) => column.search), [columns])
   const [isExportMenuOpen, setIsExportMenuOpen] = useState(false)


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Policy details results tab search box may not prefilled from ?search= query parameter

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32046

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

## 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

**Details:**
AcmTable has three layers of search state, resolved in priority order:

  props.search → storedSearch (from localStorage via context) → stateSearch (from useState)

  The old code used initialSearch, which only feeds into stateSearch (lowest priority). But AcmTableStateProvider always provides storedSearch (even
   as ''), and ?? treats '' as a valid value — so stateSearch was never reached.

  The fix:

  Instead of relying on initialSearch (uncontrolled, lowest priority), we pass search + setSearch as controlled props (highest priority). The search
   value is initialized from the URL param via useState, and setSearch lets the clear button and typing work normally.

  Also swapped window.location.search for React Router's useLocation().search so it reacts to client-side navigation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Policy details page now reads filter, search, and sort from the router URL and keeps the visible search field synced; table sort falls back to default only when no sort preference exists.
  * Table state now preserves an “unset” search (no forced empty string) until a value is provided or persisted, and initial search is stored when supplied.

* **Tests**
  * Added tests for search prefill from URL, and for various search-initialization and persistence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->