### PR TITLE
ACM-32046 table state updates

### DIFF
--- a/frontend/src/lib/urlQuery.test.ts
+++ b/frontend/src/lib/urlQuery.test.ts
@@ -8,7 +8,7 @@ describe('UrlQuery', () => {
     // These are the default values
     expect(result).toEqual({
       initialFilters: {},
-      initialSearch: '',
+      initialSearch: undefined,
       initialSort: { index: 0, direction: 'asc' },
       initialPage: 1,
       initialPerPage: 10,

--- a/frontend/src/lib/urlQuery.tsx
+++ b/frontend/src/lib/urlQuery.tsx
@@ -26,7 +26,7 @@
  * */
 export function transformBrowserUrlToFilterPresets(urlSearch: string) {
   const initialFilters: { [key: string]: string[] } = {}
-  let initialSearch = ''
+  let initialSearch = undefined
   let initialSort: { index: number; direction: 'asc' | 'desc' } = { index: 0, direction: 'asc' }
   let initialPage = 1
   let initialPerPage = 10

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -251,6 +251,7 @@ describe('Export from policy details results table', () => {
 
 describe('Search prefill from URL query string', () => {
   beforeEach(async () => {
+    localStorage.clear()
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
   })

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -248,3 +248,58 @@ describe('Export from policy details results table', () => {
     )
   })
 })
+
+describe('Search prefill from URL query string', () => {
+  beforeEach(async () => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+  })
+
+  test('Should prefill search bar when location.search contains a search param', async () => {
+    const context: PolicyDetailsContext = { policy: mockPolicy[0] }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, mockPolicy)
+        }}
+      >
+        <MemoryRouter initialEntries={['?search=local-cluster']}>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<PolicyDetailsResults />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForText('Clusters')
+
+    const searchInput = screen.getByPlaceholderText('Find clusters')
+    expect(searchInput).toHaveValue('local-cluster')
+  })
+
+  test('Should have empty search bar when location.search is empty', async () => {
+    const context: PolicyDetailsContext = { policy: mockPolicy[0] }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, mockPolicy)
+        }}
+      >
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<PolicyDetailsResults />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForText('Clusters')
+
+    const searchInput = screen.getByPlaceholderText('Find clusters')
+    expect(searchInput).toHaveValue('')
+  })
+})

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -2,7 +2,7 @@
 import { Icon, PageSection, Title, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { AcmEmptyState, AcmTable, AcmTableStateProvider, compareStrings } from '../../../../ui-components'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { Link, generatePath, useLocation } from 'react-router-dom-v5-compat'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { useTranslation } from '../../../../lib/acm-i18next'
@@ -87,13 +87,6 @@ export default function PolicyDetailsResults() {
   const { t } = useTranslation()
   const location = useLocation()
   const filterPresets = transformBrowserUrlToFilterPresets(location.search)
-  const [search, setSearch] = useState(filterPresets.initialSearch)
-
-  useEffect(() => {
-    setSearch(filterPresets.initialSearch)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.search])
-
   const { policy } = usePolicyDetailsContext()
   const { policiesState } = useSharedAtoms()
   const policies = useRecoilValue(policiesState)
@@ -344,8 +337,7 @@ export default function PolicyDetailsResults() {
                 }
               : filterPresets.initialSort
           }
-          search={search}
-          setSearch={setSearch}
+          initialSearch={filterPresets.initialSearch}
           searchPlaceholder={t('Find clusters')}
           fuseThreshold={0}
         />

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -2,8 +2,8 @@
 import { Icon, PageSection, Title, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { AcmEmptyState, AcmTable, AcmTableStateProvider, compareStrings } from '../../../../ui-components'
-import { ReactNode, useMemo } from 'react'
-import { Link, generatePath } from 'react-router-dom-v5-compat'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { Link, generatePath, useLocation } from 'react-router-dom-v5-compat'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../../lib/rbac-util'
@@ -85,7 +85,15 @@ function getTemplateName(item: ResultsTableData, canCreatePolicy: boolean, t: TF
 
 export default function PolicyDetailsResults() {
   const { t } = useTranslation()
-  const filterPresets = transformBrowserUrlToFilterPresets(window.location.search)
+  const location = useLocation()
+  const filterPresets = transformBrowserUrlToFilterPresets(location.search)
+  const [search, setSearch] = useState(filterPresets.initialSearch)
+
+  useEffect(() => {
+    setSearch(filterPresets.initialSearch)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search])
+
   const { policy } = usePolicyDetailsContext()
   const { policiesState } = useSharedAtoms()
   const policies = useRecoilValue(policiesState)
@@ -329,14 +337,15 @@ export default function PolicyDetailsResults() {
           columns={columns}
           keyFn={(item) => `${item.cluster}.${item.templateName}`}
           initialSort={
-            window.location.search === ''
+            location.search === ''
               ? {
                   index: 1,
                   direction: 'desc',
                 }
               : filterPresets.initialSort
           }
-          initialSearch={filterPresets.initialSearch}
+          search={search}
+          setSearch={setSearch}
           searchPlaceholder={t('Find clusters')}
           fuseThreshold={0}
         />

--- a/frontend/src/routes/Governance/policy-sets/PolicySets.tsx
+++ b/frontend/src/routes/Governance/policy-sets/PolicySets.tsx
@@ -53,7 +53,7 @@ function getPresetURIFilters(initialSearch: string | undefined) {
   let presetNames: string[] = [],
     presetNs: string[] = []
   const urlParams = initialSearch?.replace('?', '')?.split('&') ?? []
-  if (urlParams[0] !== '') {
+  if (urlParams[0]) {
     const parsed = JSON.parse(urlParams[0])
     presetNames = parsed.name
     presetNs = parsed.namespace

--- a/frontend/src/ui-components/AcmSearchInput/AcmSearchInput.tsx
+++ b/frontend/src/ui-components/AcmSearchInput/AcmSearchInput.tsx
@@ -92,7 +92,7 @@ export function AcmSearchInput(props: Readonly<AcmSearchInputProps>) {
   }, [fuzzySearchOnClear, setActiveConstraints, setPendingConstraints])
 
   const onChange = useCallback(
-    (value: any) => {
+    (value: string) => {
       fuzzySearchOnChange?.(value)
     },
     [fuzzySearchOnChange]
@@ -195,7 +195,7 @@ export function AcmSearchInput(props: Readonly<AcmSearchInputProps>) {
                 placeholder={placeholder}
                 value={fuzzySearchValue}
                 validation={() => 'Required'}
-                onChange={(value) => {
+                onChange={(_event, value) => {
                   onChange(value)
                 }}
               />

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react'
 import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 import { AcmEmptyState } from '../AcmEmptyState'
 import { AcmTable } from './AcmTable'
-import { AcmTableStateProvider } from './AcmTableStateProvider'
+import { AcmTableStateProvider, setItemWithExpiration } from './AcmTableStateProvider'
 import { AcmTableProps, ExportableIRow, ITableAdvancedFilter } from './AcmTableTypes'
 
 import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat'
@@ -824,6 +824,74 @@ describe('AcmTable', () => {
 
     // verify pagination changes on both tables
     await waitFor(() => expect(container.querySelectorAll('tbody tr')).toHaveLength(200))
+  })
+  test('initialSearch is used when no cached search exists in localStorage', async () => {
+    const storageKey = 'initial-search-no-cache-test'
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <AcmTableStateProvider localStorageKey={storageKey}>
+                <Table useRouter={false} initialSearch="url-query" />
+              </AcmTableStateProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(getByPlaceholderText(placeholderString)).toHaveValue('url-query')
+    })
+  })
+  test('initialSearch takes precedence over cached search in localStorage', async () => {
+    const storageKey = 'initial-beats-cached-test'
+    setItemWithExpiration(`${storageKey}-search`, 'cached-query')
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <AcmTableStateProvider localStorageKey={storageKey}>
+                <Table useRouter={false} initialSearch="url-query" />
+              </AcmTableStateProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(getByPlaceholderText(placeholderString)).toHaveValue('url-query')
+    })
+  })
+  test('cached search from localStorage is used when no initialSearch is provided', async () => {
+    const storageKey = 'cached-search-test'
+    setItemWithExpiration(`${storageKey}-search`, 'cached-query')
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/*"
+            element={
+              <AcmTableStateProvider localStorageKey={storageKey}>
+                <Table useRouter={false} />
+              </AcmTableStateProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(getByPlaceholderText(placeholderString)).toHaveValue('cached-query')
+    })
   })
   test('has zero accessibility defects', async () => {
     const { container } = render(<Table />)

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -801,30 +801,6 @@ describe('AcmTable', () => {
       )
     ).toHaveTextContent('Arabela')
   })
-  test('can use saved pagination', async () => {
-    const { getAllByLabelText, getByText, container } = render(
-      <MemoryRouter>
-        <Routes>
-          <Route
-            path="/*"
-            element={
-              <AcmTableStateProvider localStorageKey="my-table">
-                <Table useRouter={false} />
-                <Table useRouter={false} />
-              </AcmTableStateProvider>
-            }
-          />
-        </Routes>
-      </MemoryRouter>
-    )
-    // set pagination on first table
-    userEvent.click(getAllByLabelText('items per page')[0])
-    await waitFor(() => expect(getByText('100 per page')).toBeVisible())
-    userEvent.click(getByText('100 per page'))
-
-    // verify pagination changes on both tables
-    await waitFor(() => expect(container.querySelectorAll('tbody tr')).toHaveLength(200))
-  })
   test('initialSearch is used when no cached search exists in localStorage', async () => {
     const storageKey = 'initial-search-no-cache-test'
 

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -193,8 +193,8 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
   const sort = props.sort || storedSort || stateSort
   const setSort = props.setSort || setStoredSort || stateSetSort
   useEffect(() => {
-    if (process.env.NODE_ENV !== 'test') {
-      setInternalSearch(storedSearch || '')
+    if (process.env.NODE_ENV !== 'test' && storedSearch !== undefined) {
+      setInternalSearch(storedSearch)
     }
   }, [storedSearch])
 

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -42,6 +42,7 @@ import useResizeObserver from '@react-hook/resize-observer'
 import Fuse from 'fuse.js'
 import get from 'get-value'
 import { mergeWith } from 'lodash'
+import { debounce } from 'debounce'
 import {
   cloneElement,
   FormEvent,
@@ -101,6 +102,8 @@ const BREAKPOINT_SIZES = [
   { name: TableGridBreakpoint.grid2xl, size: 1450 },
   { name: TableGridBreakpoint.grid, size: Infinity },
 ]
+
+const SEARCH_DEBOUNCE_TIME = 500
 
 function mergeProps(...props: any) {
   const firstProps = props[0]
@@ -198,6 +201,15 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     initialSort ?? storedPreFilterSort ?? DEFAULT_SORT
   )
   const [stateSearch, setStateSearch] = useState(initialSearch ?? storedSearch ?? '')
+  const [internalSearch, setInternalSearch] = useState(propsSearch ?? storedSearch ?? '')
+
+  // Dependencies cannot be determined without inline function
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const setInternalSearchWithDebounce = useCallback<
+    ReturnType<typeof debounce<typeof setInternalSearch>> | typeof setInternalSearch
+  >(process.env.NODE_ENV === 'test' ? setInternalSearch : debounce(setInternalSearch, SEARCH_DEBOUNCE_TIME), [
+    setInternalSearch,
+  ])
 
   const perPage = statePerPage
   const setPerPage = useCallback(
@@ -255,6 +267,22 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     },
     [propsSetSearch, setStoredSearch]
   )
+
+  // Debounce the search input to prevent excessive re-renders while typing
+  useEffect(() => {
+    if (search !== internalSearch) {
+      if (search === '') {
+        setInternalSearch('')
+      } else {
+        setInternalSearchWithDebounce(search)
+      }
+    }
+    return () => {
+      if ('clear' in setInternalSearchWithDebounce) {
+        setInternalSearchWithDebounce.clear()
+      }
+    }
+  }, [internalSearch, setInternalSearchWithDebounce, search])
 
   const [activeAdvancedFilters, setActiveAdvancedFilters] = useState<SearchConstraint[]>([])
 
@@ -433,12 +461,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       setRequestView({
         page,
         perPage,
-        search,
+        search: internalSearch,
         filters: JSON.parse(filterSelectionsStr),
         sortBy: sort,
       })
     }
-  }, [filterSelectionsStr, search, isPreProcessed, page, perPage, setRequestView, sort])
+  }, [filterSelectionsStr, internalSearch, isPreProcessed, page, perPage, setRequestView, sort])
 
   const { tableItems, totalCount, allTableItems } = useMemo<{
     tableItems: ITableItem<T>[]
@@ -515,7 +543,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       threshold = props.fuseThreshold
     }
     // if using a result view from backend, the items have already been searched
-    if (!isPreProcessed && search && search !== '') {
+    if (!isPreProcessed && internalSearch && internalSearch !== '') {
       const fuse = new Fuse(tableItems, {
         ignoreLocation: true,
         threshold: threshold,
@@ -524,12 +552,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
           .filter((value) => value !== undefined),
         // TODO use FuseOptionKeyObject to allow for weights
       })
-      const filtered = fuse.search<ITableItem<T>>(search).map((result) => result.item)
+      const filtered = fuse.search<ITableItem<T>>(internalSearch).map((result) => result.item)
       return { filtered, filteredCount: filtered.length }
     } else {
       return { filtered: tableItems, filteredCount: totalCount }
     }
-  }, [props.fuseThreshold, isPreProcessed, search, tableItems, columns, totalCount])
+  }, [props.fuseThreshold, isPreProcessed, internalSearch, tableItems, columns, totalCount])
   const { sorted, itemCount } = useMemo<{
     sorted: ITableItem<T>[]
     itemCount: number
@@ -672,7 +700,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       selectedSortedCols.map((column) => {
         return typeof column.cell === 'string'
           ? get(item as Record<string, unknown>, column.cell)
-          : { title: <Fragment key={key}>{column.cell(item, search)}</Fragment> }
+          : { title: <Fragment key={key}>{column.cell(item, internalSearch)}</Fragment> }
       })
     let addedSubRowCount = 0
     paged.forEach((tableItem, i) => {
@@ -703,7 +731,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       addedSubRows: newSubRows,
       addedSubRowCount,
     }
-  }, [paged, selectedSortedCols, search, expanded, selected, disabled])
+  }, [paged, selectedSortedCols, internalSearch, expanded, selected, disabled])
 
   const onCollapse = useMemo<((_event: unknown, rowIndex: number, isOpen: boolean) => void) | undefined>(() => {
     if (addSubRows && addedSubRowCount) {
@@ -755,12 +783,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
           direction: newSort && newSort.direction ? newSort.direction : undefined,
         })
       }
-      if (search) {
+      if (internalSearch) {
         // sort changed while filtering; forget previous setting
         setPreFilterSort(undefined)
       }
     },
-    [filtered.length, search, setPreFilterSort, setSort]
+    [filtered.length, internalSearch, setPreFilterSort, setSort]
   )
 
   const updatePerPage = useCallback(
@@ -960,6 +988,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             filteredCount,
             hasFilter,
             hasSelectionColumn,
+            internalSearch,
             page,
             paged,
             perPage,

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -64,7 +64,7 @@ import { AcmButton } from '../AcmButton/AcmButton'
 import { AcmEmptyState } from '../AcmEmptyState/AcmEmptyState'
 import { SearchConstraint } from '../AcmSearchInput'
 import { AcmManageColumn } from './AcmManageColumn'
-import { AcmTableStateContext, DEFAULT_ITEMS_PER_PAGE, DEFAULT_SORT } from './AcmTableStateProvider'
+import { AcmTableStateContext, DEFAULT_ITEMS_PER_PAGE, DEFAULT_PAGE, DEFAULT_SORT } from './AcmTableStateProvider'
 import { AcmTableToolbar, applyFilters, ToolbarRef, useTableFilterSelections } from './AcmTableToolbar'
 import {
   AcmTableProps,
@@ -130,25 +130,33 @@ function mergeProps(...props: any) {
 
 export function AcmTable<T>(props: AcmTableProps<T>) {
   const {
-    id,
-    items,
-    columns,
     addSubRows,
-    keyFn,
-    tableActions = [],
-    rowActions = [],
-    rowActionResolver,
-    filters = [],
     advancedFilters = [],
-    gridBreakPoint,
-    initialSelectedItems,
-    onSelect: propsOnSelect,
-    showColumnManagement,
+    columns,
     exportFilePrefix,
-    setRequestView,
-    resultView,
-    resultCounts,
     fetchExport,
+    filters = [],
+    gridBreakPoint,
+    id,
+    initialSearch,
+    initialSelectedItems,
+    initialSort,
+    items,
+    keyFn,
+    onSelect: propsOnSelect,
+    page: propsPage,
+    resultCounts,
+    resultView,
+    rowActionResolver,
+    rowActions = [],
+    search: propsSearch,
+    setPage: propsSetPage,
+    setRequestView,
+    setSearch: propsSetSearch,
+    setSort: propsSetSort,
+    sort: propsSort,
+    showColumnManagement,
+    tableActions = [],
   } = props
 
   // a ref forwarded from toolbar to access its methods
@@ -171,34 +179,83 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
   }, [items, loading, loadStarted, loadCompleted, resultView])
 
   // State that can come from context or component state (search, sort, page, perPage)
-  const initialSort = props.initialSort ?? DEFAULT_SORT
-  const initialSearch = props.initialSearch ?? ''
-  const [statePerPage, stateSetPerPage] = useState(props.initialPerPage || DEFAULT_ITEMS_PER_PAGE)
-  const [statePage, stateSetPage] = useState(props.initialPage || 1)
-  const [stateSort, stateSetSort] = useState<ISortBy | undefined>(initialSort)
-  const [internalSearch, setInternalSearch] = useState(props.search ?? initialSearch)
   const {
     search: storedSearch,
+    setSearch: setStoredSearch,
     sort: storedSort,
     setSort: setStoredSort,
+    preFilterSort: storedPreFilterSort,
+    setPreFilterSort: setStoredPreFilterSort,
     page: storedPage,
     setPage: setStoredPage,
     perPage: storedPerPage,
     setPerPage: setStoredPerPage,
   } = useContext(AcmTableStateContext)
-  const perPage = storedPerPage || statePerPage
-  const setPerPage = setStoredPerPage || stateSetPerPage
-  const page = props.page || storedPage || statePage
-  const setPage = props.setPage || setStoredPage || stateSetPage
-  const sort = props.sort || storedSort || stateSort
-  const setSort = props.setSort || setStoredSort || stateSetSort
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'test' && storedSearch !== undefined) {
-      setInternalSearch(storedSearch)
-    }
-  }, [storedSearch])
+  const [statePerPage, setStatePerPage] = useState(props.initialPerPage ?? storedPerPage ?? DEFAULT_ITEMS_PER_PAGE)
+  const [statePage, setStatePage] = useState(props.initialPage ?? storedPage ?? DEFAULT_PAGE)
+  const [stateSort, setStateSort] = useState<ISortBy | undefined>(initialSort ?? storedSort ?? DEFAULT_SORT)
+  const [statePreFilterSort, setStatePreFilterSort] = useState<ISortBy | undefined>(
+    initialSort ?? storedPreFilterSort ?? DEFAULT_SORT
+  )
+  const [stateSearch, setStateSearch] = useState(initialSearch ?? storedSearch ?? '')
 
-  const [preFilterSort, setPreFilterSort] = useState<ISortBy | undefined>(initialSort)
+  const perPage = statePerPage
+  const setPerPage = useCallback(
+    (perPage: number) => {
+      setStoredPerPage?.(perPage)
+      setStatePerPage(perPage)
+    },
+    [setStoredPerPage]
+  )
+
+  const page = propsPage ?? statePage
+  const setPage = useCallback(
+    (page: number) => {
+      if (propsSetPage) {
+        propsSetPage(page)
+      } else {
+        setStoredPage?.(page)
+        setStatePage(page)
+      }
+    },
+    [propsSetPage, setStoredPage]
+  )
+
+  const sort = propsSort ?? stateSort
+  const setSort = useCallback(
+    (sort: ISortBy) => {
+      if (propsSetSort) {
+        propsSetSort(sort)
+      } else {
+        setStoredSort?.(sort)
+        setStateSort(sort)
+      }
+    },
+    [propsSetSort, setStoredSort]
+  )
+
+  const preFilterSort = statePreFilterSort
+  const setPreFilterSort = useCallback(
+    (preFilterSort: ISortBy) => {
+      setStoredPreFilterSort?.(preFilterSort)
+      setStatePreFilterSort(preFilterSort)
+    },
+    [setStoredPreFilterSort]
+  )
+
+  const search = propsSearch ?? stateSearch
+  const setSearch = useCallback(
+    (search: string) => {
+      if (propsSetSearch) {
+        propsSetSearch(search)
+      } else {
+        setStoredSearch?.(search)
+        setStateSearch(search)
+      }
+    },
+    [propsSetSearch, setStoredSearch]
+  )
+
   const [activeAdvancedFilters, setActiveAdvancedFilters] = useState<SearchConstraint[]>([])
 
   // State that is only stored in the component state
@@ -376,12 +433,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       setRequestView({
         page,
         perPage,
-        search: internalSearch,
+        search,
         filters: JSON.parse(filterSelectionsStr),
         sortBy: sort,
       })
     }
-  }, [filterSelectionsStr, internalSearch, isPreProcessed, page, perPage, setRequestView, sort])
+  }, [filterSelectionsStr, search, isPreProcessed, page, perPage, setRequestView, sort])
 
   const { tableItems, totalCount, allTableItems } = useMemo<{
     tableItems: ITableItem<T>[]
@@ -458,7 +515,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       threshold = props.fuseThreshold
     }
     // if using a result view from backend, the items have already been searched
-    if (!isPreProcessed && internalSearch && internalSearch !== '') {
+    if (!isPreProcessed && search && search !== '') {
       const fuse = new Fuse(tableItems, {
         ignoreLocation: true,
         threshold: threshold,
@@ -467,12 +524,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
           .filter((value) => value !== undefined),
         // TODO use FuseOptionKeyObject to allow for weights
       })
-      const filtered = fuse.search<ITableItem<T>>(internalSearch).map((result) => result.item)
+      const filtered = fuse.search<ITableItem<T>>(search).map((result) => result.item)
       return { filtered, filteredCount: filtered.length }
     } else {
       return { filtered: tableItems, filteredCount: totalCount }
     }
-  }, [props.fuseThreshold, isPreProcessed, internalSearch, tableItems, columns, totalCount])
+  }, [props.fuseThreshold, isPreProcessed, search, tableItems, columns, totalCount])
   const { sorted, itemCount } = useMemo<{
     sorted: ITableItem<T>[]
     itemCount: number
@@ -615,7 +672,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       selectedSortedCols.map((column) => {
         return typeof column.cell === 'string'
           ? get(item as Record<string, unknown>, column.cell)
-          : { title: <Fragment key={key}>{column.cell(item, internalSearch)}</Fragment> }
+          : { title: <Fragment key={key}>{column.cell(item, search)}</Fragment> }
       })
     let addedSubRowCount = 0
     paged.forEach((tableItem, i) => {
@@ -646,7 +703,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       addedSubRows: newSubRows,
       addedSubRowCount,
     }
-  }, [paged, selectedSortedCols, internalSearch, expanded, selected, disabled])
+  }, [paged, selectedSortedCols, search, expanded, selected, disabled])
 
   const onCollapse = useMemo<((_event: unknown, rowIndex: number, isOpen: boolean) => void) | undefined>(() => {
     if (addSubRows && addedSubRowCount) {
@@ -698,12 +755,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
           direction: newSort && newSort.direction ? newSort.direction : undefined,
         })
       }
-      if (internalSearch) {
+      if (search) {
         // sort changed while filtering; forget previous setting
         setPreFilterSort(undefined)
       }
     },
-    [filtered.length, internalSearch, setSort]
+    [filtered.length, search, setSort]
   )
 
   const updatePerPage = useCallback(
@@ -896,26 +953,27 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         <AcmTableToolbar
           {...{
             ...props,
-            hasFilter,
-            hasSelectionColumn,
             commonPaginationProps,
-            sort,
-            setPage,
-            setSort,
-            preFilterSort,
-            setPreFilterSort,
-            selected,
-            setSelected,
             disabled,
-            internalSearch,
-            setInternalSearch,
             exportTable,
-            renderColumnManagement,
-            setActiveAdvancedFilters,
-            perPage,
-            paged,
             filtered,
             filteredCount,
+            hasFilter,
+            hasSelectionColumn,
+            page,
+            paged,
+            perPage,
+            preFilterSort,
+            renderColumnManagement,
+            search,
+            selected,
+            setActiveAdvancedFilters,
+            setPage,
+            setPreFilterSort,
+            setSearch,
+            setSelected,
+            setSort,
+            sort,
             totalCount,
           }}
           ref={toolbarRef}

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -201,7 +201,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     initialSort ?? storedPreFilterSort ?? DEFAULT_SORT
   )
   const [stateSearch, setStateSearch] = useState(initialSearch ?? storedSearch ?? '')
-  const [internalSearch, setInternalSearch] = useState(propsSearch ?? storedSearch ?? '')
+  const [internalSearch, setInternalSearch] = useState(propsSearch ?? initialSearch ?? storedSearch ?? '')
 
   // Dependencies cannot be determined without inline function
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -236,7 +236,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
 
   const preFilterSort = statePreFilterSort
   const setPreFilterSort = useCallback(
-    (preFilterSort: ISortBy) => {
+    (preFilterSort?: ISortBy) => {
       setStoredPreFilterSort?.(preFilterSort)
       setStatePreFilterSort(preFilterSort)
     },
@@ -760,7 +760,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         setPreFilterSort(undefined)
       }
     },
-    [filtered.length, search, setSort]
+    [filtered.length, search, setPreFilterSort, setSort]
   )
 
   const updatePerPage = useCallback(

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.test.tsx
@@ -164,43 +164,6 @@ describe('AcmTableStateProvider', () => {
       expect(getItemWithExpiration(`${TEST_KEY}-search`)).toBe('my-query')
       expect(getItemWithExpiration(`${TEST_KEY}-page`)).toBe('3')
     })
-
-    test('when localStorageKey changes, state is rehydrated from new key', async () => {
-      setItemWithExpiration(`${TEST_KEY}-search`, 'first-query')
-      setItemWithExpiration(`${TEST_KEY}-sort`, JSON.stringify(DEFAULT_SORT))
-
-      const otherKey = 'other-table-state'
-      setItemWithExpiration(`${otherKey}-search`, 'second-query')
-      setItemWithExpiration(`${otherKey}-sort`, JSON.stringify({ index: 1, direction: SortByDirection.desc }))
-
-      const { rerender } = render(
-        <MemoryRouter>
-          <AcmTableStateProvider localStorageKey={TEST_KEY}>
-            <TestConsumer />
-          </AcmTableStateProvider>
-        </MemoryRouter>
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('search')).toHaveTextContent('first-query')
-        expect(screen.getByTestId('sort')).toHaveTextContent(JSON.stringify(DEFAULT_SORT))
-      })
-
-      rerender(
-        <MemoryRouter>
-          <AcmTableStateProvider localStorageKey={otherKey}>
-            <TestConsumer />
-          </AcmTableStateProvider>
-        </MemoryRouter>
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('search')).toHaveTextContent('second-query')
-        expect(screen.getByTestId('sort')).toHaveTextContent(
-          JSON.stringify({ index: 1, direction: SortByDirection.desc })
-        )
-      })
-    })
   })
 
   describe('exports', () => {

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -63,12 +63,15 @@ const AcmTableStateContext: React.Context<{
 export function AcmTableStateProvider(props: { children: ReactNode; localStorageKey?: string }) {
   const location = useLocation()
   const { localStorageKey = `${location.pathname.split('/').pop() || 'default'}-table-state` } = props
-  const [search, setSearch] = useState('')
+  const [search, setSearch] = useState<string | undefined>(undefined)
   const [page, setPage] = useState(1)
   const [perPage, setPerPage] = useState(DEFAULT_ITEMS_PER_PAGE)
   const [sort, setSort] = useState<ISortBy>(DEFAULT_SORT)
   useEffect(() => {
-    setSearch(getItemWithExpiration(`${localStorageKey}-search`) || '')
+    const cachedSearch = getItemWithExpiration(`${localStorageKey}-search`)
+    if (cachedSearch) {
+      setSearch(cachedSearch)
+    }
     setPage(Number.parseInt(getItemWithExpiration(`${localStorageKey}-page`) || '0', 10) || 1)
     setPerPage(Number.parseInt(localStorage.getItem(`${localStorageKey}-perPage`) || '0', 10) || DEFAULT_ITEMS_PER_PAGE)
     setSort(

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -21,11 +21,15 @@ interface StorageItem {
 }
 
 export function setItemWithExpiration(key: string, value: string): void {
-  const item: StorageItem = {
-    value,
-    timestamp: Date.now(),
+  if (value === undefined) {
+    localStorage.removeItem(key)
+  } else {
+    const item: StorageItem = {
+      value,
+      timestamp: Date.now(),
+    }
+    localStorage.setItem(key, JSON.stringify(item))
   }
-  localStorage.setItem(key, JSON.stringify(item))
 }
 
 export function getItemWithExpiration(key: string): string | null {
@@ -130,7 +134,7 @@ export function AcmTableStateProvider(props: { children: ReactNode; localStorage
 
   const wrappedSetPerPage = useCallback(
     (perPage: number) => {
-      setItemWithExpiration(`${localStorageKey}-perPage`, String(perPage))
+      localStorage.setItem(`${localStorageKey}-perPage`, String(perPage))
       setPerPage(perPage)
     },
     [localStorageKey]

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -57,7 +57,7 @@ export const AcmTableStateContext: React.Context<{
   sort?: ISortBy
   setSort?: (sort: ISortBy) => void
   preFilterSort?: ISortBy
-  setPreFilterSort?: (preFilterSort: ISortBy) => void
+  setPreFilterSort?: (preFilterSort?: ISortBy) => void
   page?: number
   setPage?: (page: number) => void
   perPage?: number
@@ -94,7 +94,7 @@ export function AcmTableStateProvider(props: { children: ReactNode; localStorage
   const [page, setPage] = useState(intialSort)
   const [perPage, setPerPage] = useState(initialPerPage)
   const [sort, setSort] = useState<ISortBy>(initialSort)
-  const [preFilterSort, setPreFilterSort] = useState<ISortBy>(initialPreFilterSort)
+  const [preFilterSort, setPreFilterSort] = useState<ISortBy | undefined>(initialPreFilterSort)
 
   const wrappedSetSearch = useCallback(
     (search: string) => {
@@ -113,7 +113,7 @@ export function AcmTableStateProvider(props: { children: ReactNode; localStorage
   )
 
   const wrappedSetPreFilterSort = useCallback(
-    (preFilterSort: ISortBy) => {
+    (preFilterSort?: ISortBy) => {
       setItemWithExpiration(`${localStorageKey}-preFilterSort`, JSON.stringify(preFilterSort))
       setPreFilterSort(preFilterSort)
     },

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -1,16 +1,18 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { ISortBy, SortByDirection } from '@patternfly/react-table'
-import { createContext, ReactNode, useEffect, useMemo, useState } from 'react'
+import { createContext, ReactNode, useCallback, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom-v5-compat'
 
-const DEFAULT_ITEMS_PER_PAGE = 10
-const STORAGE_EXPIRATION_MS = 30 * 60 * 1000 // 30 minutes in milliseconds
+export const DEFAULT_PAGE = 1
+export const DEFAULT_ITEMS_PER_PAGE = 10
 
-const DEFAULT_SORT: ISortBy = {
+export const DEFAULT_SORT: ISortBy = {
   index: 0,
   direction: SortByDirection.asc,
 }
+
+const STORAGE_EXPIRATION_MS = 30 * 60 * 1000 // 30 minutes in milliseconds
 
 // Helper functions for localStorage with expiration
 interface StorageItem {
@@ -49,11 +51,13 @@ export function getItemWithExpiration(key: string): string | null {
   }
 }
 
-const AcmTableStateContext: React.Context<{
+export const AcmTableStateContext: React.Context<{
   search?: string
   setSearch?: (search: string) => void
   sort?: ISortBy
   setSort?: (sort: ISortBy) => void
+  preFilterSort?: ISortBy
+  setPreFilterSort?: (preFilterSort: ISortBy) => void
   page?: number
   setPage?: (page: number) => void
   perPage?: number
@@ -63,52 +67,100 @@ const AcmTableStateContext: React.Context<{
 export function AcmTableStateProvider(props: { children: ReactNode; localStorageKey?: string }) {
   const location = useLocation()
   const { localStorageKey = `${location.pathname.split('/').pop() || 'default'}-table-state` } = props
-  const [search, setSearch] = useState<string | undefined>(undefined)
-  const [page, setPage] = useState(1)
-  const [perPage, setPerPage] = useState(DEFAULT_ITEMS_PER_PAGE)
-  const [sort, setSort] = useState<ISortBy>(DEFAULT_SORT)
-  useEffect(() => {
-    const cachedSearch = getItemWithExpiration(`${localStorageKey}-search`)
-    if (cachedSearch) {
-      setSearch(cachedSearch)
+  const { initialSearch, intialSort, initialPreFilterSort, initialPerPage, initialSort } = useMemo(() => {
+    let initialSort = DEFAULT_SORT
+    let initialPreFilterSort = DEFAULT_SORT
+    try {
+      initialSort = JSON.parse(getItemWithExpiration(`${localStorageKey}-sort`) || '')
+    } catch {
+      // corrupted sort JSON in local storage; ignore and use default
     }
-    setPage(Number.parseInt(getItemWithExpiration(`${localStorageKey}-page`) || '0', 10) || 1)
-    setPerPage(Number.parseInt(localStorage.getItem(`${localStorageKey}-perPage`) || '0', 10) || DEFAULT_ITEMS_PER_PAGE)
-    setSort(
-      (() => {
-        const sortValue = getItemWithExpiration(`${localStorageKey}-sort`)
-        return (sortValue && JSON.parse(sortValue)) ?? DEFAULT_SORT
-      })()
-    )
-  }, [localStorageKey, setSearch, setPage, setPerPage, setSort])
+    try {
+      initialPreFilterSort = JSON.parse(getItemWithExpiration(`${localStorageKey}-preFilterSort`) || '')
+    } catch {
+      // corrupted sort JSON in local storage; ignore and use default
+    }
+    return {
+      initialSearch: getItemWithExpiration(`${localStorageKey}-search`) || '',
+      // NaN on parseInt failure is falsy - will use default instead (DO NOT change || to ?? here!)
+      intialSort: Number.parseInt(getItemWithExpiration(`${localStorageKey}-page`) || '0', 10) || DEFAULT_PAGE,
+      initialPerPage:
+        Number.parseInt(localStorage.getItem(`${localStorageKey}-perPage`) || '0', 10) || DEFAULT_ITEMS_PER_PAGE,
+      initialSort,
+      initialPreFilterSort,
+    }
+  }, [localStorageKey])
+  const [search, setSearch] = useState<string>(initialSearch)
+  const [page, setPage] = useState(intialSort)
+  const [perPage, setPerPage] = useState(initialPerPage)
+  const [sort, setSort] = useState<ISortBy>(initialSort)
+  const [preFilterSort, setPreFilterSort] = useState<ISortBy>(initialPreFilterSort)
+
+  const wrappedSetSearch = useCallback(
+    (search: string) => {
+      setItemWithExpiration(`${localStorageKey}-search`, search)
+      setSearch(search)
+    },
+    [localStorageKey]
+  )
+
+  const wrappedSetSort = useCallback(
+    (sort: ISortBy) => {
+      setItemWithExpiration(`${localStorageKey}-sort`, JSON.stringify(sort))
+      setSort(sort)
+    },
+    [localStorageKey]
+  )
+
+  const wrappedSetPreFilterSort = useCallback(
+    (preFilterSort: ISortBy) => {
+      setItemWithExpiration(`${localStorageKey}-preFilterSort`, JSON.stringify(preFilterSort))
+      setPreFilterSort(preFilterSort)
+    },
+    [localStorageKey]
+  )
+
+  const wrappedSetPage = useCallback(
+    (page: number) => {
+      setItemWithExpiration(`${localStorageKey}-page`, String(page))
+      setPage(page)
+    },
+    [localStorageKey]
+  )
+
+  const wrappedSetPerPage = useCallback(
+    (perPage: number) => {
+      setItemWithExpiration(`${localStorageKey}-perPage`, String(perPage))
+      setPerPage(perPage)
+    },
+    [localStorageKey]
+  )
 
   const stateContext = useMemo(
     () => ({
       search,
-      setSearch: (search: string) => {
-        setItemWithExpiration(`${localStorageKey}-search`, search)
-        setSearch(search)
-      },
+      setSearch: wrappedSetSearch,
       sort,
-      setSort: (sort: ISortBy) => {
-        const newSort = sort ?? DEFAULT_SORT
-        setItemWithExpiration(`${localStorageKey}-sort`, JSON.stringify(newSort))
-        setSort(newSort)
-      },
+      setSort: wrappedSetSort,
+      preFilterSort,
+      setPreFilterSort: wrappedSetPreFilterSort,
       page,
-      setPage: (page: number) => {
-        setItemWithExpiration(`${localStorageKey}-page`, String(page))
-        setPage(page)
-      },
+      setPage: wrappedSetPage,
       perPage,
-      setPerPage: (perPage: number) => {
-        localStorage.setItem(`${localStorageKey}-perPage`, String(perPage))
-        setPerPage(perPage)
-      },
+      setPerPage: wrappedSetPerPage,
     }),
-    [search, setSearch, sort, setSort, page, setPage, perPage, setPerPage, localStorageKey]
+    [
+      search,
+      wrappedSetSearch,
+      sort,
+      wrappedSetSort,
+      preFilterSort,
+      wrappedSetPreFilterSort,
+      page,
+      wrappedSetPage,
+      perPage,
+      wrappedSetPerPage,
+    ]
   )
   return <AcmTableStateContext.Provider value={stateContext}>{props.children}</AcmTableStateContext.Provider>
 }
-
-export { AcmTableStateContext, DEFAULT_ITEMS_PER_PAGE, DEFAULT_SORT }

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -67,7 +67,7 @@ export const AcmTableStateContext: React.Context<{
 export function AcmTableStateProvider(props: { children: ReactNode; localStorageKey?: string }) {
   const location = useLocation()
   const { localStorageKey = `${location.pathname.split('/').pop() || 'default'}-table-state` } = props
-  const { initialSearch, intialSort, initialPreFilterSort, initialPerPage, initialSort } = useMemo(() => {
+  const { initialSearch, initialPage, initialPreFilterSort, initialPerPage, initialSort } = useMemo(() => {
     let initialSort = DEFAULT_SORT
     let initialPreFilterSort = DEFAULT_SORT
     try {
@@ -83,7 +83,7 @@ export function AcmTableStateProvider(props: { children: ReactNode; localStorage
     return {
       initialSearch: getItemWithExpiration(`${localStorageKey}-search`) || '',
       // NaN on parseInt failure is falsy - will use default instead (DO NOT change || to ?? here!)
-      intialSort: Number.parseInt(getItemWithExpiration(`${localStorageKey}-page`) || '0', 10) || DEFAULT_PAGE,
+      initialPage: Number.parseInt(getItemWithExpiration(`${localStorageKey}-page`) || '0', 10) || DEFAULT_PAGE,
       initialPerPage:
         Number.parseInt(localStorage.getItem(`${localStorageKey}-perPage`) || '0', 10) || DEFAULT_ITEMS_PER_PAGE,
       initialSort,
@@ -91,7 +91,7 @@ export function AcmTableStateProvider(props: { children: ReactNode; localStorage
     }
   }, [localStorageKey])
   const [search, setSearch] = useState<string>(initialSearch)
-  const [page, setPage] = useState(intialSort)
+  const [page, setPage] = useState(initialPage)
   const [perPage, setPerPage] = useState(initialPerPage)
   const [sort, setSort] = useState<ISortBy>(initialSort)
   const [preFilterSort, setPreFilterSort] = useState<ISortBy | undefined>(initialPreFilterSort)

--- a/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableStateProvider.tsx
@@ -20,7 +20,7 @@ interface StorageItem {
   timestamp: number
 }
 
-export function setItemWithExpiration(key: string, value: string): void {
+export function setItemWithExpiration(key: string, value?: string): void {
   if (value === undefined) {
     localStorage.removeItem(key)
   } else {
@@ -68,22 +68,28 @@ export const AcmTableStateContext: React.Context<{
   setPerPage?: (perPage: number) => void
 }> = createContext({})
 
+function parseSortBy(raw: string | null): ISortBy | undefined {
+  if (!raw) return undefined
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+    const obj = parsed as Record<string, unknown>
+    if (obj.index !== undefined && typeof obj.index !== 'number') return undefined
+    if (obj.direction !== undefined && obj.direction !== 'asc' && obj.direction !== 'desc') return undefined
+    if (obj.defaultDirection !== undefined && obj.defaultDirection !== 'asc' && obj.defaultDirection !== 'desc')
+      return undefined
+    return parsed as ISortBy
+  } catch {
+    return undefined
+  }
+}
+
 export function AcmTableStateProvider(props: { children: ReactNode; localStorageKey?: string }) {
   const location = useLocation()
   const { localStorageKey = `${location.pathname.split('/').pop() || 'default'}-table-state` } = props
   const { initialSearch, initialPage, initialPreFilterSort, initialPerPage, initialSort } = useMemo(() => {
-    let initialSort = DEFAULT_SORT
-    let initialPreFilterSort = DEFAULT_SORT
-    try {
-      initialSort = JSON.parse(getItemWithExpiration(`${localStorageKey}-sort`) || '')
-    } catch {
-      // corrupted sort JSON in local storage; ignore and use default
-    }
-    try {
-      initialPreFilterSort = JSON.parse(getItemWithExpiration(`${localStorageKey}-preFilterSort`) || '')
-    } catch {
-      // corrupted sort JSON in local storage; ignore and use default
-    }
+    const initialSort = parseSortBy(getItemWithExpiration(`${localStorageKey}-sort`)) ?? DEFAULT_SORT
+    const initialPreFilterSort = parseSortBy(getItemWithExpiration(`${localStorageKey}-preFilterSort`)) ?? DEFAULT_SORT
     return {
       initialSearch: getItemWithExpiration(`${localStorageKey}-search`) || '',
       // NaN on parseInt failure is falsy - will use default instead (DO NOT change || to ?? here!)

--- a/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
@@ -339,6 +339,13 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
   const search = props.search ?? storedSearch ?? stateSearch
   const setSearch = props.setSearch ?? stateSetSearch
 
+  useEffect(() => {
+    if (initialSearch) {
+      setStoredSearch(initialSearch)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSearch])
+
   const searchPlaceholder = props.searchPlaceholder ?? t('Search')
   const hasSearch = useMemo(() => columns.some((column) => column.search), [columns])
   const [isExportMenuOpen, setIsExportMenuOpen] = useState(false)

--- a/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
@@ -17,7 +17,6 @@ import {
 } from '@patternfly/react-core'
 import { ExportIcon } from '@patternfly/react-icons'
 import { ISortBy } from '@patternfly/react-table'
-import { debounce } from 'debounce'
 import { parse, ParsedQuery, stringify } from 'query-string'
 import {
   forwardRef,
@@ -61,8 +60,6 @@ const SPLIT_FILTER_THRESHOLD = 30
 // with the assumption that if the user is looking for an option
 // they will use filter to find it
 const MAXIMUM_OPTIONS = 200
-
-export const SEARCH_DEBOUNCE_TIME = 500
 
 const createFilterSelectOptionObject = (filterId: string, value: string): FilterSelectOptionObject => ({
   filterId,
@@ -273,6 +270,7 @@ export type AcmTableToolbarProps<T> = Pick<
     exportTable: () => Promise<void>
     hasFilter: boolean
     hasSelectionColumn: boolean
+    internalSearch: string
     preFilterSort: ISortBy | undefined
     renderColumnManagement: () => JSX.Element | undefined
     selected: { [uid: string]: boolean }
@@ -292,45 +290,44 @@ export interface ToolbarRef {
 const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<ToolbarRef>) => {
   useImperativeHandle(ref, () => ({ clearSearchAndFilters }))
   const {
-    id,
-    items,
-    columns,
-    keyFn,
-    tableActions = [],
-    customTableAction,
     additionalToolbarItems,
-    filters = [],
-    secondaryFilterIds,
     advancedFilters = [],
-    onSelect: propsOnSelect,
-    resultCounts,
-    renderColumnManagement,
-    showExportButton,
-    hasFilter,
-    hasSelectionColumn,
+    columns,
     commonPaginationProps,
-    search,
-    setSearch,
-    sort,
-    setPage,
-    setSort,
-    setPreFilterSort,
-    selected,
-    setSelected,
+    customTableAction,
     disabled,
-    preFilterSort,
     exportTable,
-    setActiveAdvancedFilters,
-    perPage,
-    paged,
     filtered,
     filteredCount,
+    filters = [],
+    hasFilter,
+    hasSelectionColumn,
+    id,
+    internalSearch,
+    items,
+    keyFn,
+    onSelect: propsOnSelect,
+    paged,
+    perPage,
+    preFilterSort,
+    renderColumnManagement,
+    resultCounts,
+    search,
+    secondaryFilterIds,
+    selected,
+    setActiveAdvancedFilters,
+    setPage,
+    setPreFilterSort,
+    setSearch,
+    setSelected,
+    setSort,
+    showExportButton,
+    sort,
+    tableActions = [],
     totalCount,
   } = props
 
   const { t } = useTranslation()
-
-  const [stateSearch, setStateSearch] = useState(search ?? '')
 
   const searchPlaceholder = props.searchPlaceholder ?? t('Search')
   const hasSearch = useMemo(() => columns.some((column) => column.search), [columns])
@@ -342,35 +339,13 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
     { operator: undefined, value: '', columnId: '' },
   ])
 
-  // Dependencies cannot be determined without inline function
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const setSearchWithDebounce = useCallback<ReturnType<typeof debounce<typeof setSearch>> | typeof setSearch>(
-    process.env.NODE_ENV === 'test' ? setSearch : debounce(setSearch, SEARCH_DEBOUNCE_TIME),
-    [setSearch]
-  )
-
-  useEffect(() => {
-    if (stateSearch !== search) {
-      setSearchWithDebounce(stateSearch)
-    }
-    return () => {
-      if ('clear' in setSearchWithDebounce) {
-        setSearchWithDebounce.clear()
-      }
-    }
-  }, [search, setSearchWithDebounce, stateSearch])
-
   const clearSearch = useCallback(() => {
-    if ('clear' in setSearchWithDebounce) {
-      setSearchWithDebounce.clear()
-    }
-    setStateSearch('')
     setSearch('')
     setPage(1)
     if (preFilterSort) {
       setSort(preFilterSort)
     }
-  }, [setSearch, setStateSearch, setPage, preFilterSort, setSearchWithDebounce, setSort])
+  }, [setSearch, setPage, preFilterSort, setSort])
 
   const clearSearchAndFilters = useCallback(() => {
     clearSearch()
@@ -381,20 +356,20 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
 
   const updateSearch = useCallback(
     (newSearch: string) => {
-      setStateSearch(newSearch)
+      setSearch(newSearch)
       setPage(1)
       if (!newSearch) {
         // clearing filtered state; restore previous sorting if applicable
         if (preFilterSort) {
           setSort(preFilterSort)
         }
-      } else if (!stateSearch) {
+      } else if (!search) {
         // entering a filtered state; save sort setting use fuzzy match sort
         setPreFilterSort(sort)
         setSort({})
       }
     },
-    [setPage, stateSearch, preFilterSort, setSort, setPreFilterSort, sort]
+    [setSearch, setPage, search, preFilterSort, setSort, setPreFilterSort, sort]
   )
 
   return (
@@ -452,7 +427,7 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
                 <AcmSearchInput
                   placeholder={searchPlaceholder}
                   spellCheck={false}
-                  resultsCount={`${stateSearch === search ? filteredCount : '-'} / ${totalCount}`}
+                  resultsCount={`${search === internalSearch ? filteredCount : '-'} / ${totalCount}`}
                   canAddConstraints
                   useAdvancedSearchPopper={advancedFilters.length > 0}
                   setActiveConstraints={setActiveAdvancedFilters}
@@ -463,7 +438,7 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
                     columnDisplayName: filter.label,
                     availableOperators: filter.availableOperators,
                   }))}
-                  fuzzySearchValue={stateSearch}
+                  fuzzySearchValue={search}
                   fuzzySearchOnChange={updateSearch}
                   fuzzySearchOnClear={clearSearch}
                 />

--- a/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
@@ -380,8 +380,7 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
   }, [clearSearch, clearFilters, setActiveAdvancedFilters, setPendingConstraints])
 
   const updateSearch = useCallback(
-    (input: string) => {
-      const newSearch = input
+    (newSearch: string) => {
       setStateSearch(newSearch)
       setPage(1)
       if (!newSearch) {

--- a/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
@@ -277,7 +277,7 @@ export type AcmTableToolbarProps<T> = Pick<
     renderColumnManagement: () => JSX.Element | undefined
     selected: { [uid: string]: boolean }
     setActiveAdvancedFilters: React.Dispatch<React.SetStateAction<SearchConstraint[]>>
-    setPreFilterSort: (sort: ISortBy) => void
+    setPreFilterSort: (sort?: ISortBy) => void
     setSelected: React.Dispatch<React.SetStateAction<{ [uid: string]: boolean }>>
     perPage: number
     paged: ITableItem<T>[]
@@ -342,13 +342,10 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
     { operator: undefined, value: '', columnId: '' },
   ])
 
+  // Dependencies cannot be determined without inline function
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const setSearchWithDebounce = useCallback(
-    process.env.NODE_ENV !== 'test'
-      ? debounce((search: string) => {
-          setSearch(search)
-        }, SEARCH_DEBOUNCE_TIME)
-      : setSearch,
+  const setSearchWithDebounce = useCallback<ReturnType<typeof debounce<typeof setSearch>> | typeof setSearch>(
+    process.env.NODE_ENV === 'test' ? setSearch : debounce(setSearch, SEARCH_DEBOUNCE_TIME),
     [setSearch]
   )
 
@@ -358,15 +355,14 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
     }
     return () => {
       if ('clear' in setSearchWithDebounce) {
-        ;(setSearchWithDebounce as any).clear()
+        setSearchWithDebounce.clear()
       }
     }
   }, [search, setSearchWithDebounce, stateSearch])
 
   const clearSearch = useCallback(() => {
-    /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'test') {
-      ;(setSearchWithDebounce as unknown as ReturnType<typeof debounce>).clear()
+    if ('clear' in setSearchWithDebounce) {
+      setSearchWithDebounce.clear()
     }
     setStateSearch('')
     setSearch('')
@@ -384,12 +380,8 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
   }, [clearSearch, clearFilters, setActiveAdvancedFilters, setPendingConstraints])
 
   const updateSearch = useCallback(
-    (input: any) => {
-      // **Note: PatternFly change the fn signature
-      // From: (value: string, event: React.FormEvent<HTMLInputElement>) => void
-      // To: (_event: React.FormEvent<HTMLInputElement>, value: string) => void
-      // both cases need to be handled for backwards compatibility
-      const newSearch = typeof input === 'string' ? input : (input.target as HTMLInputElement).value
+    (input: string) => {
+      const newSearch = input
       setStateSearch(newSearch)
       setPage(1)
       if (!newSearch) {

--- a/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableToolbar.tsx
@@ -18,7 +18,6 @@ import {
 import { ExportIcon } from '@patternfly/react-icons'
 import { ISortBy } from '@patternfly/react-table'
 import { debounce } from 'debounce'
-import { noop } from 'lodash'
 import { parse, ParsedQuery, stringify } from 'query-string'
 import {
   forwardRef,
@@ -26,7 +25,6 @@ import {
   Ref,
   RefObject,
   useCallback,
-  useContext,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -39,7 +37,6 @@ import { matchesFilterValue, parseLabel } from '../../resources/utils'
 import { AcmButton } from '../AcmButton'
 import { AcmDropdown, AcmDropdownItems } from '../AcmDropdown'
 import { AcmSearchInput, SearchConstraint } from '../AcmSearchInput'
-import { AcmTableStateContext } from './AcmTableStateProvider'
 import {
   AcmTableProps,
   CommonPaginationPropsType,
@@ -266,28 +263,28 @@ export const applyFilters = <T, S>(
   )
 }
 
-export type AcmTableToolbarProps<T> = Pick<AcmTableProps<T>, Exclude<keyof AcmTableProps<T>, 'setPage' | 'setSort'>> & {
-  hasFilter: boolean
-  hasSelectionColumn: boolean
-  commonPaginationProps: CommonPaginationPropsType
-  preFilterSort: ISortBy | undefined
-  setPage: (page: number) => void
-  setSort: (sort: ISortBy) => void
-  setPreFilterSort: React.Dispatch<React.SetStateAction<ISortBy | undefined>>
-  selected: { [uid: string]: boolean }
-  setSelected: React.Dispatch<React.SetStateAction<{ [uid: string]: boolean }>>
-  disabled: { [uid: string]: boolean }
-  internalSearch: string
-  setInternalSearch: React.Dispatch<React.SetStateAction<string>>
-  exportTable: () => Promise<void>
-  renderColumnManagement: () => JSX.Element | undefined
-  setActiveAdvancedFilters: React.Dispatch<React.SetStateAction<SearchConstraint[]>>
-  perPage: number
-  paged: ITableItem<T>[]
-  filtered: ITableItem<T>[]
-  filteredCount: number
-  totalCount: number
-}
+export type AcmTableToolbarProps<T> = Pick<
+  AcmTableProps<T>,
+  Exclude<keyof AcmTableProps<T>, 'setPage' | 'setSearch' | 'setSort'>
+> &
+  Required<Pick<AcmTableProps<T>, 'setPage' | 'setSearch' | 'setSort'>> & {
+    commonPaginationProps: CommonPaginationPropsType
+    disabled: { [uid: string]: boolean }
+    exportTable: () => Promise<void>
+    hasFilter: boolean
+    hasSelectionColumn: boolean
+    preFilterSort: ISortBy | undefined
+    renderColumnManagement: () => JSX.Element | undefined
+    selected: { [uid: string]: boolean }
+    setActiveAdvancedFilters: React.Dispatch<React.SetStateAction<SearchConstraint[]>>
+    setPreFilterSort: (sort: ISortBy) => void
+    setSelected: React.Dispatch<React.SetStateAction<{ [uid: string]: boolean }>>
+    perPage: number
+    paged: ITableItem<T>[]
+    filtered: ITableItem<T>[]
+    filteredCount: number
+    totalCount: number
+  }
 
 export interface ToolbarRef {
   clearSearchAndFilters: () => void
@@ -312,6 +309,8 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
     hasFilter,
     hasSelectionColumn,
     commonPaginationProps,
+    search,
+    setSearch,
     sort,
     setPage,
     setSort,
@@ -319,8 +318,6 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
     selected,
     setSelected,
     disabled,
-    internalSearch,
-    setInternalSearch,
     preFilterSort,
     exportTable,
     setActiveAdvancedFilters,
@@ -332,19 +329,8 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
   } = props
 
   const { t } = useTranslation()
-  const initialSearch = props.initialSearch ?? ''
 
-  const [stateSearch, stateSetSearch] = useState(initialSearch)
-  const { search: storedSearch, setSearch: setStoredSearch = noop } = useContext(AcmTableStateContext)
-  const search = props.search ?? storedSearch ?? stateSearch
-  const setSearch = props.setSearch ?? stateSetSearch
-
-  useEffect(() => {
-    if (initialSearch) {
-      setStoredSearch(initialSearch)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialSearch])
+  const [stateSearch, setStateSearch] = useState(search ?? '')
 
   const searchPlaceholder = props.searchPlaceholder ?? t('Search')
   const hasSearch = useMemo(() => columns.some((column) => column.search), [columns])
@@ -357,37 +343,38 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
   ])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const setInternalSearchWithDebounce = useCallback(
+  const setSearchWithDebounce = useCallback(
     process.env.NODE_ENV !== 'test'
       ? debounce((search: string) => {
-          setInternalSearch(search)
+          setSearch(search)
         }, SEARCH_DEBOUNCE_TIME)
-      : setInternalSearch,
-    [setInternalSearch]
+      : setSearch,
+    [setSearch]
   )
 
   useEffect(() => {
-    setInternalSearchWithDebounce(search)
+    if (stateSearch !== search) {
+      setSearchWithDebounce(stateSearch)
+    }
     return () => {
-      if ('clear' in setInternalSearchWithDebounce) {
-        ;(setInternalSearchWithDebounce as any).clear()
+      if ('clear' in setSearchWithDebounce) {
+        ;(setSearchWithDebounce as any).clear()
       }
     }
-  }, [search, setInternalSearchWithDebounce])
+  }, [search, setSearchWithDebounce, stateSearch])
 
   const clearSearch = useCallback(() => {
     /* istanbul ignore if */
     if (process.env.NODE_ENV !== 'test') {
-      ;(setInternalSearchWithDebounce as unknown as ReturnType<typeof debounce>).clear()
+      ;(setSearchWithDebounce as unknown as ReturnType<typeof debounce>).clear()
     }
+    setStateSearch('')
     setSearch('')
-    setInternalSearch('')
-    setStoredSearch('')
     setPage(1)
     if (preFilterSort) {
       setSort(preFilterSort)
     }
-  }, [setSearch, setStoredSearch, setInternalSearch, setPage, preFilterSort, setInternalSearchWithDebounce, setSort])
+  }, [setSearch, setStateSearch, setPage, preFilterSort, setSearchWithDebounce, setSort])
 
   const clearSearchAndFilters = useCallback(() => {
     clearSearch()
@@ -403,23 +390,20 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
       // To: (_event: React.FormEvent<HTMLInputElement>, value: string) => void
       // both cases need to be handled for backwards compatibility
       const newSearch = typeof input === 'string' ? input : (input.target as HTMLInputElement).value
-      setSearch(newSearch)
-      setStoredSearch(newSearch)
+      setStateSearch(newSearch)
       setPage(1)
       if (!newSearch) {
         // clearing filtered state; restore previous sorting if applicable
         if (preFilterSort) {
           setSort(preFilterSort)
         }
-      } else if (!search) {
+      } else if (!stateSearch) {
         // entering a filtered state; save sort setting use fuzzy match sort
         setPreFilterSort(sort)
         setSort({})
       }
     },
-    // setSort/setSearch/setPage can come from props, but setPreFilterSort is only from state and therefore
-    // guaranteed stable - not needed in dependency list
-    [setSearch, setStoredSearch, setPage, search, preFilterSort, setSort, setPreFilterSort, sort]
+    [setPage, stateSearch, preFilterSort, setSort, setPreFilterSort, sort]
   )
 
   return (
@@ -477,7 +461,7 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
                 <AcmSearchInput
                   placeholder={searchPlaceholder}
                   spellCheck={false}
-                  resultsCount={`${search === internalSearch ? filteredCount : '-'} / ${totalCount}`}
+                  resultsCount={`${stateSearch === search ? filteredCount : '-'} / ${totalCount}`}
                   canAddConstraints
                   useAdvancedSearchPopper={advancedFilters.length > 0}
                   setActiveConstraints={setActiveAdvancedFilters}
@@ -488,7 +472,7 @@ const AcmTableToolbarBase = <T,>(props: AcmTableToolbarProps<T>, ref: Ref<Toolba
                     columnDisplayName: filter.label,
                     availableOperators: filter.availableOperators,
                   }))}
-                  fuzzySearchValue={search}
+                  fuzzySearchValue={stateSearch}
                   fuzzySearchOnChange={updateSearch}
                   fuzzySearchOnClear={clearSearch}
                 />

--- a/frontend/src/ui-components/AcmTable/AcmTableTypes.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTableTypes.tsx
@@ -183,47 +183,47 @@ export type CurrentFilters<S> = {
 }
 
 export type AcmTableProps<T> = {
-  items?: T[]
   addSubRows?: (item: T) => IRow[] | undefined
-  initialSelectedItems?: T[]
-  disabledItems?: T[]
-  columns: IAcmTableColumn<T>[]
-  keyFn: (item: T) => string
-  customTableAction?: ReactNode
-  tableActionButtons?: IAcmTableButtonAction[]
-  tableActions?: IAcmTableAction<T>[]
-  rowActions?: IAcmRowAction<T>[]
-  rowActionResolver?: (item: T) => IAcmRowAction<T>[]
-  extraToolbarControls?: ReactNode
   additionalToolbarItems?: ReactNode
+  advancedFilters?: ITableAdvancedFilter<T>[]
+  autoHidePagination?: boolean
+  columns: IAcmTableColumn<T>[]
+  customTableAction?: ReactNode
+  disabledItems?: T[]
   emptyState: ReactNode
-  onSelect?: (items: T[]) => void
-  initialPage?: number
-  page?: number
-  setPage?: (page: number) => void
-  setRequestView?: (requestedView: IRequestListView) => void
-  resultView?: IResultListView
-  resultCounts?: IResultStatuses
+  exportFilePrefix?: string
+  extraToolbarControls?: ReactNode
   fetchExport?: (requestedExport: IRequestListView) => Promise<IResultListView | undefined>
+  filters?: ITableFilter<T>[]
+  fuseThreshold?: number
+  gridBreakPoint?: TableGridBreakpoint
+  id?: string
+  initialPage?: number
   initialPerPage?: number
   initialSearch?: string
-  search?: string
-  setSearch?: (search: string) => void
-  searchPlaceholder?: string
+  initialSelectedItems?: T[]
   initialSort?: ISortBy | undefined
-  sort?: ISortBy | undefined
-  setSort?: (sort: ISortBy) => void
-  showToolbar?: boolean
-  gridBreakPoint?: TableGridBreakpoint
-  perPageOptions?: PerPageOptions[]
-  autoHidePagination?: boolean
+  items?: T[]
+  keyFn: (item: T) => string
   noBorders?: boolean
-  fuseThreshold?: number
-  filters?: ITableFilter<T>[]
+  onSelect?: (items: T[]) => void
+  page?: number
+  perPageOptions?: PerPageOptions[]
+  resultCounts?: IResultStatuses
+  resultView?: IResultListView
+  rowActionResolver?: (item: T) => IAcmRowAction<T>[]
+  rowActions?: IAcmRowAction<T>[]
+  search?: string
+  searchPlaceholder?: string
   secondaryFilterIds?: string[]
-  advancedFilters?: ITableAdvancedFilter<T>[]
-  id?: string
+  setPage?: (page: number) => void
+  setRequestView?: (requestedView: IRequestListView) => void
+  setSearch?: (search: string) => void
+  setSort?: (sort: ISortBy) => void
   showColumnManagement?: boolean
   showExportButton?: boolean
-  exportFilePrefix?: string
+  showToolbar?: boolean
+  sort?: ISortBy | undefined
+  tableActionButtons?: IAcmTableButtonAction[]
+  tableActions?: IAcmTableAction<T>[]
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Policy details results tab search box may not prefilled from ?search= query parameter

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32046

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

## 🗒️ Notes for Reviewers

Larger refactoring of the stored table state support to simplify operation.
- Removes useEffect hooks that synchronize state between the context and table components
- Changes the model so that state stored in local storage is only used as an initial value for the table; after that changes are recorded in local storage but not synchronized back to the table, as that is already happening in response to user actions. Also, if properties of the table are controlled, this bypasses local storage entirely. I removed 2 test cases that were testing that changing the local storage key would reset the table state, or that causing changes in the stored state would affect a second table inside the same AcmTableStateProvider. This sort of behaviour is not required for our use cases.
- Adds preFilterSort to the cache so that if a user enters search text, navigates to another page, then returns and clears the search text, the sort state can be restored rather than reverting to the default sort state
- Fixes a bug where bad JSON in the local storage would cause a page crash
- Generates AcmTableStateProvider setter functions with useCallback so they are stable for dependency lists (although useEffect is generally avoided now anyway)
- Removes interaction with the AcmTableStateProvider from the AcmTableToolbar. The AcmTableToolbar now only interacts with values and setters passed down from AcmTable.
- Removes unneeded code for dealing with different PF versions (we only ever work with 1 version)
- Moves debounce logic to AcmTable so that it applies even when controlling the search prop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search inputs reliably initialize from the URL, respect cached vs. initial-search precedence, and clearing/updating search/sort behave more predictably.

* **Refactor**
  * Table and toolbar derive URL state from the router and use a debounced, controlled search for smoother interactions and consistent sorting/pagination.

* **Tests**
  * Added/updated tests verifying URL-driven search initialization and persisted-search precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->