### PR TITLE
ACM-4246 Fallback to HostedCluster percentage if not found from ClusterCurator

### DIFF
--- a/frontend/src/resources/utils/get-cluster.test.ts
+++ b/frontend/src/resources/utils/get-cluster.test.ts
@@ -2107,5 +2107,27 @@ describe('getProvider', () => {
       }
       expect(getCCUpgradePercent(curator, undefined)).toBe('42%')
     })
+
+    it('should fallback to HC percentage when curator message has no percentage', () => {
+      const curator: ClusterCurator = {
+        apiVersion: ClusterCuratorApiVersion,
+        kind: ClusterCuratorKind,
+        metadata: { name: 'test' },
+        spec: {},
+        status: {
+          conditions: [{ type: 'monitor-upgrade', status: 'True', reason: '', message: 'Upgrade in progress' }],
+        },
+      }
+      const hc: HostedClusterK8sResource = {
+        apiVersion: HostedClusterApiVersion,
+        kind: HostedClusterKind,
+        metadata: { name: 'test', namespace: 'clusters' },
+        spec: {} as any,
+        status: {
+          conditions: [{ type: 'ClusterVersionProgressing', status: 'True', message: 'Working towards (60%)' }],
+        } as any,
+      }
+      expect(getCCUpgradePercent(curator, hc)).toBe('(60%)')
+    })
   })
 })

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -1660,7 +1660,10 @@ export function getCCUpgradePercent(clusterCurator?: ClusterCurator, hostedClust
     const curatorConditions = clusterCurator.status?.conditions ?? []
     const upgradeDetailedMessage = getConditionMessage('monitor-upgrade', curatorConditions) || ''
     const percentageMatch = upgradeDetailedMessage.match(/\d+%/) || []
-    return percentageMatch.length > 0 ? percentageMatch[0] : ''
+    if (percentageMatch.length > 0) {
+      return percentageMatch[0]
+    }
   }
-  return getHCUpgradePercent(hostedCluster)
+  const hcPercentage = getHCUpgradePercent(hostedCluster)
+  return hcPercentage !== '' ? hcPercentage : ''
 }

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -1665,5 +1665,5 @@ export function getCCUpgradePercent(clusterCurator?: ClusterCurator, hostedClust
     }
   }
   const hcPercentage = getHCUpgradePercent(hostedCluster)
-  return hcPercentage !== '' ? hcPercentage : ''
+  return hcPercentage
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Upgrading control plane of hosted cluster doesn't get reflected in UI right away

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-4246

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade progress now falls back to the hosted-cluster's reported percentage when the curator's message doesn't contain a percentage, ensuring users see the correct upgrade percent.
* **Tests**
  * Added a unit test to validate the fallback behavior so upgrade progress displays reliably in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->