### PR TITLE
ACM-29843 Prepare version checks for 5.0 compatibility

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -1588,6 +1588,99 @@ describe('DistributionField hypershift clusters', () => {
     expect(queryAllByText('Update available').length).toBe(0)
   })
 
+  it('should detect update available when minor version requires numeric comparison (4.9 vs 4.10)', async () => {
+    const mockCluster: Cluster = {
+      name: 'hypershift-cluster1',
+      displayName: 'hypershift-cluster1',
+      namespace: 'clusters',
+      uid: 'hypershift-cluster1-uid',
+      provider: undefined,
+      status: ClusterStatus.ready,
+      distribution: {
+        ocp: {
+          version: '4.10.0',
+          availableUpdates: [],
+          desiredVersion: '4.10.0',
+          upgradeFailed: false,
+        },
+        displayVersion: 'OpenShift 4.10.0',
+        isManagedOpenShift: false,
+      },
+      labels: { abc: '123' },
+      nodes: undefined,
+      kubeApiServer: '',
+      consoleURL: '',
+      hasAutomationTemplate: false,
+      hive: {
+        isHibernatable: true,
+        clusterPool: undefined,
+        secrets: {
+          installConfig: '',
+        },
+      },
+      hypershift: {
+        agent: false,
+        hostingNamespace: 'clusters',
+        nodePools: mockNodepools,
+        secretNames: ['feng-hs-bug-ssh-key', 'feng-hs-bug-pull-secret'],
+      },
+      isHive: false,
+      isManaged: true,
+      isCurator: true,
+      isHostedCluster: true,
+      isHypershift: true,
+      isSNOCluster: false,
+      owner: {},
+      kubeadmin: '',
+      kubeconfig: '',
+      isRegionalHubCluster: false,
+    }
+
+    const testNodepool: NodePool = {
+      apiVersion: 'hypershift.openshift.io/v1beta1',
+      kind: 'NodePool',
+      metadata: {
+        name: 'test-nodepool',
+        namespace: 'clusters',
+      },
+      spec: {
+        management: { upgradeType: 'Replace' },
+        clusterName: 'hypershift-cluster1',
+        platform: {
+          aws: {
+            instanceProfile: '',
+            instanceType: '',
+            rootVolume: { size: 1, type: '' },
+            securityGroups: [],
+            subnet: { id: '' },
+          },
+          type: '',
+        },
+        release: { image: '' },
+        replicas: 1,
+      },
+      status: {
+        conditions: [{ message: '', reason: 'AsExpected', status: 'True', type: 'Ready' }],
+        version: '4.9.5',
+      },
+    }
+
+    const { queryAllByText } = await renderDistributionInfoField(
+      mockCluster,
+      true,
+      false,
+      undefined,
+      testNodepool,
+      undefined,
+      false,
+      'nodepool'
+    )
+
+    expect(queryAllByText('OpenShift 4.9.5').length).toBe(1)
+    // String comparison "4.9.5" < "4.10.0" is false lexicographically, but numerically 4.9 < 4.10
+    expect(queryAllByText('Update available').length).toBe(1)
+  })
+
   // Channel warning tests for HostedClusters
   describe('HostedCluster channel warning', () => {
     // Hosted cluster without channel set

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { HostedClusterK8sResourceWithChannel } from '../../../../../resources/hosted-cluster'
+import { compareVersions } from './utils/version-utils'
 import { Button, ButtonVariant } from '@patternfly/react-core'
 import { ArrowCircleUpIcon, ExclamationTriangleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react'
@@ -69,7 +70,7 @@ export function DistributionField(props: {
     if (props.resource != null && props.resource === 'nodepool' && props.nodepool) {
       if (
         getNodepoolStatus(props.nodepool) == 'Ready' &&
-        (props.nodepool?.status?.version || '') < (props.cluster?.distribution?.ocp?.version || '')
+        compareVersions(props.nodepool?.status?.version, props.cluster?.distribution?.ocp?.version) < 0
       ) {
         return true
       }
@@ -83,8 +84,10 @@ export function DistributionField(props: {
         for (let i = 0; i < props.cluster?.hypershift?.nodePools.length; i++) {
           if (
             getNodepoolStatus(props.cluster?.hypershift?.nodePools[i]) == 'Ready' &&
-            (props.cluster?.hypershift?.nodePools[i].status?.version || '') <
-              (props.cluster.distribution?.ocp?.version || '')
+            compareVersions(
+              props.cluster?.hypershift?.nodePools[i].status?.version,
+              props.cluster.distribution?.ocp?.version
+            ) < 0
           ) {
             updateAvailable = true
             break

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.test.tsx
@@ -3530,10 +3530,10 @@ describe('HypershiftUpgradeModal - ClusterCurator Integration', () => {
     const npGroupToggle = getNodepoolGroupToggle()
     userEvent.click(npGroupToggle)
 
-    // 4.10 is 1 minor version ahead of 4.9, so isVersionGreater should be true
-    // (old string comparison "4.10" > "4.9" was correct by accident, but the
-    // independent-segment comparison bug in the old isVersionGreater is gone)
+    // 4.10 > 4.9 numerically, so isVersionGreater auto-checks the nodepool.
+    // A string comparison would evaluate "4.10" < "4.9" (lexicographic), so
+    // a regression in isVersionGreater would leave the checkbox unchecked.
     const npGroupCheckbox = screen.getByTestId('nodepoolgroup-checkbox')
-    expect(npGroupCheckbox).toBeTruthy()
+    expect(npGroupCheckbox).toHaveProperty('checked', true)
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.test.tsx
@@ -3462,4 +3462,78 @@ describe('HypershiftUpgradeModal - ClusterCurator Integration', () => {
     userEvent.click(upgradeButton)
     await new Promise((resolve) => setTimeout(resolve, 600))
   })
+
+  it('should auto-check nodepools when CP is a major version ahead (5.0 vs 4.x)', async () => {
+    const mockClusterMajorVersion: Cluster = {
+      ...mockClusterForCurator,
+      distribution: {
+        ocp: {
+          version: '5.0.0',
+          availableUpdates: ['5.0.1'],
+          desiredVersion: '5.0.0',
+          upgradeFailed: false,
+        },
+        isManagedOpenShift: false,
+      },
+    }
+
+    const mockNPsOldMajor: NodePool[] = [
+      {
+        ...mockNodepoolsForCurator[0],
+        status: { version: '4.19.10' },
+      },
+    ]
+
+    const crossMajorUpdates: Record<string, string> = {
+      '5.0.0': 'quay.io/openshift-release-dev/ocp-release:5.0.0-multi',
+      '5.0.1': 'quay.io/openshift-release-dev/ocp-release:5.0.1-multi',
+    }
+
+    await renderHypershiftUpgradeModal(mockClusterMajorVersion, mockNPsOldMajor, crossMajorUpdates)
+
+    const npGroupToggle = getNodepoolGroupToggle()
+    userEvent.click(npGroupToggle)
+
+    const npGroupCheckbox = screen.getByTestId('nodepoolgroup-checkbox')
+    expect(npGroupCheckbox).toHaveProperty('checked', true)
+  })
+
+  it('should correctly identify version ordering with multi-digit minors (4.9 vs 4.10)', async () => {
+    const mockClusterMinor10: Cluster = {
+      ...mockClusterForCurator,
+      distribution: {
+        ocp: {
+          version: '4.10.0',
+          availableUpdates: ['4.10.1'],
+          desiredVersion: '4.10.0',
+          upgradeFailed: false,
+        },
+        isManagedOpenShift: false,
+      },
+    }
+
+    const mockNPsMinor9: NodePool[] = [
+      {
+        ...mockNodepoolsForCurator[0],
+        status: { version: '4.9.5' },
+      },
+    ]
+
+    const updatesFor410: Record<string, string> = {
+      '4.9.6': 'quay.io/openshift-release-dev/ocp-release:4.9.6-multi',
+      '4.10.0': 'quay.io/openshift-release-dev/ocp-release:4.10.0-multi',
+      '4.10.1': 'quay.io/openshift-release-dev/ocp-release:4.10.1-multi',
+    }
+
+    await renderHypershiftUpgradeModal(mockClusterMinor10, mockNPsMinor9, updatesFor410)
+
+    const npGroupToggle = getNodepoolGroupToggle()
+    userEvent.click(npGroupToggle)
+
+    // 4.10 is 1 minor version ahead of 4.9, so isVersionGreater should be true
+    // (old string comparison "4.10" > "4.9" was correct by accident, but the
+    // independent-segment comparison bug in the old isVersionGreater is gone)
+    const npGroupCheckbox = screen.getByTestId('nodepoolgroup-checkbox')
+    expect(npGroupCheckbox).toBeTruthy()
+  })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.tsx
@@ -37,7 +37,7 @@ import { useRecoilValue, useSharedAtoms } from '../../../../../shared-recoil'
 import { AcmAlert, AcmForm, AcmModal, AcmSelect, AcmSubmit, AcmTable } from '../../../../../ui-components'
 import { getNodepoolAgents } from '../utils/nodepool'
 import { ReleaseNotesLink } from './ReleaseNotesLink'
-import { isMinorOrMajorUpgrade } from './utils/version-utils'
+import { compareVersions, isMinorOrMajorUpgrade } from './utils/version-utils'
 import { HypershiftUpgradeModalNodePoolCheckbox } from './HypershiftUpgradeModalNodePoolCheckbox'
 
 // Helper: Check if version is within supported range
@@ -456,37 +456,22 @@ export function HypershiftUpgradeModal(props: {
     if (!cpVersion || !npVersion) {
       return false
     }
-    const cpVersionParts = cpVersion.split('.')
-    const npVersionParts = npVersion.split('.')
+    const cpParts = cpVersion.split('.')
+    const npParts = npVersion.split('.')
+    const cpMajor = Number(cpParts[0])
+    const npMajor = Number(npParts[0])
 
-    if (cpVersionParts[0] > npVersionParts[0]) {
-      return true
+    if (cpMajor !== npMajor) {
+      return cpMajor > npMajor
     }
-    if (Number(cpVersionParts[1]) - Number(npVersionParts[1]) > 2) {
-      return true
-    }
-
-    return false
+    return Number(cpParts[1]) - Number(npParts[1]) > 2
   }
 
   const isVersionGreater = (cpVersion: string | undefined, npVersion: string | undefined) => {
     if (!cpVersion || !npVersion) {
       return false
     }
-    const cpVersionParts = cpVersion.split('.')
-    const npVersionParts = npVersion.split('.')
-
-    if (cpVersionParts[0] > npVersionParts[0]) {
-      return true
-    }
-    if (Number(cpVersionParts[1]) > Number(npVersionParts[1])) {
-      return true
-    }
-    if (Number(cpVersionParts[2]) > Number(npVersionParts[2])) {
-      return true
-    }
-
-    return false
+    return compareVersions(cpVersion, npVersion) > 0
   }
 
   const handleNodepoolsChecked = (name: string) => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.test.tsx
@@ -1,7 +1,8 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { HostedClusterK8sResource, OpenshiftVersionOptionType } from '@openshift-assisted/ui-lib/cim'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import { clickByRole, waitForRole } from '../../../../../lib/test-util'
 import { Cluster, ClusterStatus, HypershiftCloudPlatformType } from '../../../../../resources/utils'
 import { Provider } from '../../../../../ui-components'
 import { NodePoolForm } from './NodePoolForm'
@@ -71,10 +72,6 @@ function fakeClusterImageSets(versions: string[]) {
   }))
 }
 
-function getVersionToggle() {
-  return screen.getByRole('combobox', { name: /openshift version/i })
-}
-
 function renderNodePoolForm(clusterVersion: string, imageVersions: string[]) {
   getOCPVersions.mockReturnValue(makeImageVersions(imageVersions))
   return render(
@@ -87,49 +84,69 @@ function renderNodePoolForm(clusterVersion: string, imageVersions: string[]) {
   )
 }
 
+async function openVersionDropdown() {
+  await waitForRole('combobox', { name: /openshift version/i })
+  await clickByRole('combobox', { name: /openshift version/i })
+}
+
+function getDropdownOptionTexts(): string[] {
+  return screen.getAllByRole('option').map((o) => o.textContent ?? '')
+}
+
 describe('NodePoolForm image filtering', () => {
   beforeEach(() => {
     getOCPVersions.mockReset()
   })
 
-  it('should select the first valid image using numeric comparison', async () => {
+  it('should exclude versions greater than the cluster version via compareVersions', async () => {
     renderNodePoolForm('4.14.5', ['4.14.5', '4.14.3', '4.15.0', '4.12.0'])
+    await openVersionDropdown()
 
-    await waitFor(() => {
-      expect(getVersionToggle().textContent).toContain('4.14.5')
-    })
+    const options = getDropdownOptionTexts()
+    expect(options).toContain('4.14.5')
+    expect(options).toContain('4.14.3')
+    expect(options).toContain('4.12.0')
+    expect(options).not.toContain('4.15.0')
   })
 
-  it('should include 4.9 images for a 4.10 cluster (numeric isWithinTwoVersions)', async () => {
-    renderNodePoolForm('4.10.0', ['4.10.0', '4.9.5', '4.9.0', '4.7.0'])
+  it('should include images within 2 minor versions via numeric isWithinTwoVersions', async () => {
+    renderNodePoolForm('4.14.0', ['4.14.0', '4.13.0', '4.12.0', '4.11.0'])
+    await openVersionDropdown()
 
-    await waitFor(() => {
-      expect(getVersionToggle().textContent).toContain('4.10.0')
-    })
+    const options = getDropdownOptionTexts()
+    expect(options).toContain('4.14.0')
+    expect(options).toContain('4.13.0')
+    expect(options).toContain('4.12.0')
+    expect(options).not.toContain('4.11.0')
   })
 
-  it('should reject images below version 4.11.0 (isValidImage major/minor check)', async () => {
+  it('should reject images below version 4.11.0 via isValidImage', async () => {
     renderNodePoolForm('4.14.0', ['4.14.0', '4.13.0', '4.10.5', '3.11.0'])
+    await openVersionDropdown()
 
-    await waitFor(() => {
-      const text = getVersionToggle().textContent
-      expect(text).toContain('4.14.0')
-    })
+    const options = getDropdownOptionTexts()
+    expect(options).toContain('4.14.0')
+    expect(options).toContain('4.13.0')
+    expect(options).not.toContain('4.10.5')
+    expect(options).not.toContain('3.11.0')
   })
 
   it('should accept 5.x images when cluster is 5.x (isValidImage for major > 4)', async () => {
     renderNodePoolForm('5.0.0', ['5.0.0', '4.17.0'])
+    await openVersionDropdown()
 
-    await waitFor(() => {
-      expect(getVersionToggle().textContent).toContain('5.0.0')
-    })
+    const options = getDropdownOptionTexts()
+    expect(options).toContain('5.0.0')
+    expect(options).not.toContain('4.17.0')
   })
 
-  it('should exclude images from different major versions (isWithinTwoVersions major != check)', async () => {
+  it('should exclude images from different major versions via isWithinTwoVersions', async () => {
     renderNodePoolForm('5.0.0', ['5.0.0', '4.17.0', '4.16.0'])
+    await openVersionDropdown()
 
-    await waitFor(() => {
-      expect(getVersionToggle().textContent).toContain('5.0.0')
-    })
+    const options = getDropdownOptionTexts()
+    expect(options).toContain('5.0.0')
+    expect(options).not.toContain('4.17.0')
+    expect(options).not.toContain('4.16.0')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.test.tsx
@@ -1,0 +1,135 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { HostedClusterK8sResource, OpenshiftVersionOptionType } from '@openshift-assisted/ui-lib/cim'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Cluster, ClusterStatus, HypershiftCloudPlatformType } from '../../../../../resources/utils'
+import { Provider } from '../../../../../ui-components'
+import { NodePoolForm } from './NodePoolForm'
+
+jest.mock('@openshift-assisted/ui-lib/cim', () => {
+  const actual = jest.requireActual('@openshift-assisted/ui-lib/cim')
+  return {
+    ...actual,
+    getOCPVersions: jest.fn(() => [] as OpenshiftVersionOptionType[]),
+  }
+})
+
+const { getOCPVersions } = jest.requireMock('@openshift-assisted/ui-lib/cim') as {
+  getOCPVersions: jest.Mock
+}
+
+function mockCluster(version: string): Cluster {
+  return {
+    name: 'test-cluster',
+    namespace: 'clusters',
+    uid: '',
+    status: ClusterStatus.ready,
+    isHive: false,
+    isManaged: true,
+    isCurator: false,
+    isHostedCluster: true,
+    isRegionalHubCluster: false,
+    hasAutomationTemplate: false,
+    hive: { isHibernatable: false },
+    provider: Provider.aws,
+    distribution: { ocp: { version } },
+    labels: {},
+    nodes: { ready: 0, unhealthy: 0, unknown: 0, nodeList: [] },
+    isManagedOpenShift: false,
+  } as unknown as Cluster
+}
+
+function mockHostedCluster(version: string): HostedClusterK8sResource {
+  return {
+    apiVersion: 'hypershift.openshift.io/v1beta1',
+    kind: 'HostedCluster',
+    metadata: { name: 'test-cluster', namespace: 'clusters' },
+    spec: {
+      release: { image: `quay.io/openshift-release-dev/ocp-release:${version}-multi` },
+      infraID: 'test-infra-id',
+      platform: { type: HypershiftCloudPlatformType.AWS },
+    },
+  } as unknown as HostedClusterK8sResource
+}
+
+function makeImageVersions(versions: string[]): OpenshiftVersionOptionType[] {
+  return versions.map((v) => ({
+    label: v,
+    value: v,
+    version: v,
+    default: false,
+    supportLevel: 'production' as const,
+  }))
+}
+
+function fakeClusterImageSets(versions: string[]) {
+  return versions.map((v) => ({
+    apiVersion: 'hive.openshift.io/v1',
+    kind: 'ClusterImageSet',
+    metadata: { name: `img${v}` },
+    spec: { releaseImage: `quay.io/openshift-release-dev/ocp-release:${v}-multi` },
+  }))
+}
+
+function getVersionToggle() {
+  return screen.getByRole('combobox', { name: /openshift version/i })
+}
+
+function renderNodePoolForm(clusterVersion: string, imageVersions: string[]) {
+  getOCPVersions.mockReturnValue(makeImageVersions(imageVersions))
+  return render(
+    <NodePoolForm
+      cluster={mockCluster(clusterVersion)}
+      hostedCluster={mockHostedCluster(clusterVersion)}
+      close={jest.fn()}
+      clusterImages={fakeClusterImageSets(imageVersions)}
+    />
+  )
+}
+
+describe('NodePoolForm image filtering', () => {
+  beforeEach(() => {
+    getOCPVersions.mockReset()
+  })
+
+  it('should select the first valid image using numeric comparison', async () => {
+    renderNodePoolForm('4.14.5', ['4.14.5', '4.14.3', '4.15.0', '4.12.0'])
+
+    await waitFor(() => {
+      expect(getVersionToggle().textContent).toContain('4.14.5')
+    })
+  })
+
+  it('should include 4.9 images for a 4.10 cluster (numeric isWithinTwoVersions)', async () => {
+    renderNodePoolForm('4.10.0', ['4.10.0', '4.9.5', '4.9.0', '4.7.0'])
+
+    await waitFor(() => {
+      expect(getVersionToggle().textContent).toContain('4.10.0')
+    })
+  })
+
+  it('should reject images below version 4.11.0 (isValidImage major/minor check)', async () => {
+    renderNodePoolForm('4.14.0', ['4.14.0', '4.13.0', '4.10.5', '3.11.0'])
+
+    await waitFor(() => {
+      const text = getVersionToggle().textContent
+      expect(text).toContain('4.14.0')
+    })
+  })
+
+  it('should accept 5.x images when cluster is 5.x (isValidImage for major > 4)', async () => {
+    renderNodePoolForm('5.0.0', ['5.0.0', '4.17.0'])
+
+    await waitFor(() => {
+      expect(getVersionToggle().textContent).toContain('5.0.0')
+    })
+  })
+
+  it('should exclude images from different major versions (isWithinTwoVersions major != check)', async () => {
+    renderNodePoolForm('5.0.0', ['5.0.0', '4.17.0', '4.16.0'])
+
+    await waitFor(() => {
+      expect(getVersionToggle().textContent).toContain('5.0.0')
+    })
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.tsx
@@ -243,13 +243,15 @@ export function NodePoolForm(props: {
     },
   }
 
-  //Checks if minor version of image is >= 11
+  // Checks if image is at least 4.11.0
   const isValidImage = (version: string | undefined) => {
     if (!version) {
       return false
     }
     const versionParts = version.split('.')
-    if (Number(versionParts[1]) < 11) {
+    const major = Number(versionParts[0])
+    const minor = Number(versionParts[1])
+    if (major < 4 || (major === 4 && minor < 11)) {
       return false
     }
     return true

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolForm.tsx
@@ -33,6 +33,7 @@ import {
   OpenshiftVersionOptionType,
 } from '@openshift-assisted/ui-lib/cim'
 import { getHostedClusterVersion, NodePool, NodePoolApiVersion, NodePoolKind } from '../../../../../resources'
+import { compareVersions } from './utils/version-utils'
 import {
   Cluster,
   createResource,
@@ -265,7 +266,9 @@ export function NodePoolForm(props: {
     const cpVersionParts = cpVersion.split('.')
     const npVersionParts = npVersion.split('.')
 
-    if (cpVersionParts[0] > npVersionParts[0] || cpVersionParts[0] < npVersionParts[0]) {
+    const cpMajor = Number(cpVersionParts[0])
+    const npMajor = Number(npVersionParts[0])
+    if (cpMajor !== npMajor) {
       return false
     }
 
@@ -283,7 +286,11 @@ export function NodePoolForm(props: {
       const availableImages = getOCPVersions(props.clusterImages)
       const filteredImages: any[] = []
       availableImages.forEach((image) => {
-        if (image.version <= ver && isWithinTwoVersions(ver, image.version) && isValidImage(image.version)) {
+        if (
+          compareVersions(image.version, ver) <= 0 &&
+          isWithinTwoVersions(ver, image.version) &&
+          isValidImage(image.version)
+        ) {
           filteredImages.push(image)
         }
       })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/utils/version-utils.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/utils/version-utils.test.ts
@@ -1,6 +1,47 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { isMinorOrMajorUpgrade } from './version-utils'
+import { compareVersions, isMinorOrMajorUpgrade } from './version-utils'
+
+describe('compareVersions', () => {
+  it('should return 0 for equal versions', () => {
+    expect(compareVersions('4.14.2', '4.14.2')).toBe(0)
+  })
+
+  it('should return negative when a < b', () => {
+    expect(compareVersions('4.13.10', '4.14.2')).toBeLessThan(0)
+  })
+
+  it('should return positive when a > b', () => {
+    expect(compareVersions('4.14.2', '4.13.10')).toBeGreaterThan(0)
+  })
+
+  it('should compare major versions numerically', () => {
+    expect(compareVersions('5.0.0', '4.99.99')).toBeGreaterThan(0)
+    expect(compareVersions('4.99.99', '5.0.0')).toBeLessThan(0)
+  })
+
+  it('should compare minor versions numerically (not lexicographically)', () => {
+    expect(compareVersions('4.9.0', '4.10.0')).toBeLessThan(0)
+    expect(compareVersions('4.10.0', '4.9.0')).toBeGreaterThan(0)
+  })
+
+  it('should handle two-part versions', () => {
+    expect(compareVersions('4.16', '4.16.3')).toBeLessThan(0)
+    expect(compareVersions('5.0', '4.99')).toBeGreaterThan(0)
+    expect(compareVersions('4.16', '4.16')).toBe(0)
+  })
+
+  it('should treat missing segments as 0', () => {
+    expect(compareVersions('5.0', '5.0.0')).toBe(0)
+  })
+
+  it('should handle undefined and empty values', () => {
+    expect(compareVersions(undefined, undefined)).toBe(0)
+    expect(compareVersions(undefined, '4.14.2')).toBeLessThan(0)
+    expect(compareVersions('4.14.2', undefined)).toBeGreaterThan(0)
+    expect(compareVersions('', '4.14.2')).toBeLessThan(0)
+  })
+})
 
 describe('isMinorOrMajorUpgrade', () => {
   describe('minor version upgrades', () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/utils/version-utils.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/utils/version-utils.test.ts
@@ -41,6 +41,32 @@ describe('compareVersions', () => {
     expect(compareVersions('4.14.2', undefined)).toBeGreaterThan(0)
     expect(compareVersions('', '4.14.2')).toBeLessThan(0)
   })
+
+  describe('regression: string comparison bugs', () => {
+    it('should order 4.9 < 4.10 (string comparison would get this wrong)', () => {
+      expect(compareVersions('4.9.0', '4.10.0')).toBeLessThan(0)
+      expect(compareVersions('4.9.5', '4.10.0')).toBeLessThan(0)
+    })
+
+    it('should not produce false positives from independent segment comparison', () => {
+      // The old isVersionGreater compared each segment independently:
+      // isVersionGreater("4.13.5", "4.14.3") returned true because 5 > 3 at patch,
+      // even though 4.14.3 > 4.13.5 overall.
+      expect(compareVersions('4.13.5', '4.14.3')).toBeLessThan(0)
+      expect(compareVersions('4.14.3', '4.13.5')).toBeGreaterThan(0)
+    })
+
+    it('should compare patch versions correctly when major.minor are equal', () => {
+      expect(compareVersions('4.14.3', '4.14.5')).toBeLessThan(0)
+      expect(compareVersions('4.14.10', '4.14.9')).toBeGreaterThan(0)
+    })
+
+    it('should handle OCP 5.0 version comparisons', () => {
+      expect(compareVersions('5.0.0', '4.17.5')).toBeGreaterThan(0)
+      expect(compareVersions('4.17.5', '5.0.0')).toBeLessThan(0)
+      expect(compareVersions('5.0.1', '5.0.0')).toBeGreaterThan(0)
+    })
+  })
 })
 
 describe('isMinorOrMajorUpgrade', () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/utils/version-utils.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/utils/version-utils.ts
@@ -1,6 +1,28 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /**
+ * Numerically compares two version strings segment by segment.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ * Handles two-part (4.16) and three-part (4.16.3) versions correctly,
+ * treating missing segments as 0 (e.g., "5.0" is equivalent to "5.0.0").
+ */
+export function compareVersions(a: string | undefined, b: string | undefined): number {
+  if (!a && !b) return 0
+  if (!a) return -1
+  if (!b) return 1
+
+  const aParts = a.split('.').map((s) => Number.parseInt(s, 10) || 0)
+  const bParts = b.split('.').map((s) => Number.parseInt(s, 10) || 0)
+  const len = Math.max(aParts.length, bParts.length)
+
+  for (let i = 0; i < len; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+/**
  * Determines if upgrading from currentVersion to targetVersion is a minor or major version upgrade.
  *
  * @param currentVersion - The current cluster version (e.g., "4.13.10")


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ACM 5.0 Version Numbering Investigation - Dev (Console)

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-29843

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version comparisons across cluster and nodepool UIs to use numeric, segment-aware ordering so update indicators, upgrade checkbox states, and image filtering are correct for multi-part versions (e.g., 4.9 vs 4.10).

* **New Features**
  * Added a reusable numeric version-comparison utility for consistent ordering across upgrade flows and filters.

* **Tests**
  * Added and expanded tests validating numeric multi-segment version ordering and related UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->