### PR TITLE
Delay coderabbitai commenting until review is complete

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,6 +46,12 @@ reviews:
   # Provides a quick at-a-glance assessment of the PR health
   review_status: true
 
+  # in_progress_fortune: Posts a "Currently processing..." comment while CodeRabbit is reviewing
+  # Default: true
+  # The pending commit status is sufficient to indicate a review is in progress;
+  # disable this to reduce noise in the PR comment thread.
+  in_progress_fortune: false
+
   # collapse_walkthrough: Collapses the detailed file-by-file walkthrough by default
   # Default: true
   # Helps keep reviews concise; users can expand sections as needed


### PR DESCRIPTION
See https://docs.coderabbit.ai/pr-reviews/walkthroughs#fortune-while-you-wait

coderabbitai comments on a PR as soon as it is opened with some placeholder information. That comment is later updated with the review results.

Changing this option should turn off that feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit review configuration to disable in-progress status messages during PR reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->