### PR TITLE
ACM-32811-ACM-32804: Update axios to 0.31.0 & 1.15.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "@stolostron/react-data-view": "^3.3.1",
         "@tanstack/react-query": "^4.42.2",
         "ajv": "8.17.1",
-        "axios": "^0.30.3",
+        "axios": "^0.31.0",
         "cidr-tools": "4.3.0",
         "debounce": "1.2.1",
         "deep-diff": "1.0.2",
@@ -7358,14 +7358,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/p-map": {
@@ -7381,10 +7381,13 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared": {
       "version": "2.0.5",
@@ -7397,21 +7400,24 @@
       }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
       "version": "4.2.5",
@@ -13148,9 +13154,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
-      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.31.0.tgz",
+      "integrity": "sha512-HGIUj/P74co3rSLBV9SHz9LMgCmrXFEtkfMcC5r6bS5j3dBHUcAje2tS4fmU6WM20kuhvUX04XE58594dpgi1g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
@@ -38308,15 +38314,6 @@
         "@openshift-console/dynamic-plugin-sdk": ">=1.0.0 || >=4.19.0-prerelease"
       }
     },
-    "packages/multicluster-sdk/node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "packages/multicluster-sdk/node_modules/@jest/transform": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
@@ -38756,16 +38753,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "packages/react-form-wizard/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "packages/react-form-wizard/node_modules/@babel/helpers": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "@stolostron/react-data-view": "^3.3.1",
     "@tanstack/react-query": "^4.42.2",
     "ajv": "8.17.1",
-    "axios": "^0.30.3",
+    "axios": "^0.31.0",
     "cidr-tools": "4.3.0",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",


### PR DESCRIPTION
Updated axios to 0.30.0 & 1.15.0 to fix [CVE-2025-62718](https://www.cve.org/CVERecord?id=CVE-2025-62718)

https://issues.redhat.com/browse/ACM-32811
https://issues.redhat.com/browse/ACM-32804