### PR TITLE
[ACM-32978 ] Fix AcmDropdown MenuItem to render href items as anchor tags

### DIFF
--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.test.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.test.tsx
@@ -25,6 +25,7 @@ describe('AcmDropdown', () => {
       { id: 'forbidden', text: 'Other config', isAriaDisabled: true, tooltip: 'Forbidden' },
       { id: 'launch-out', text: 'Launch page', icon: <ExternalLinkAltIcon /> },
       { id: 'link item', text: 'Link item', href: 'www.google.com', component: 'a' },
+      { id: 'external-link', text: 'External link', href: 'https://example.com', target: '_blank' },
       { id: 'new-feature', text: 'New feature', label: 'Technology Preview', labelColor: 'blue' },
     ]
     return (
@@ -102,6 +103,18 @@ describe('AcmDropdown', () => {
     expect(getByTestId('dropdown')).toBeInTheDocument()
     userEvent.click(getByTestId('dropdown'))
     expect(queryByTestId('install-config')).toBeNull()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+  test('renders target="_blank" items with rel="noopener noreferrer"', async () => {
+    const { getByTestId } = render(<Component />)
+    userEvent.click(getByTestId('dropdown'))
+    await waitFor(() => expect(getByTestId('external-link')).toBeInTheDocument())
+    const externalLink = getByTestId('external-link')
+    const anchor = externalLink.closest('a')
+    expect(anchor).toBeInTheDocument()
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(anchor).toHaveAttribute('target', '_blank')
     await new Promise((resolve) => setTimeout(resolve, 0))
   })
 

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.test.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.test.tsx
@@ -104,4 +104,15 @@ describe('AcmDropdown', () => {
     expect(queryByTestId('install-config')).toBeNull()
     await new Promise((resolve) => setTimeout(resolve, 0))
   })
+
+  test('renders items with href as anchor tags', async () => {
+    const { getByTestId } = render(<Component />)
+    userEvent.click(getByTestId('dropdown'))
+    await waitFor(() => expect(getByTestId('link item')).toBeInTheDocument())
+    const linkItem = getByTestId('link item')
+    const anchor = linkItem.closest('a')
+    expect(anchor).toBeInTheDocument()
+    expect(anchor).toHaveAttribute('href', 'www.google.com')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
 })

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -57,6 +57,8 @@ export type AcmDropdownItems = {
   isSelected?: boolean
   flyoutMenu?: AcmDropdownItems[]
   component?: React.ReactNode
+  target?: string
+  rel?: string
 }
 
 type MenuItemProps = {
@@ -79,6 +81,8 @@ const MenuItems = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
                 itemId={item.id}
                 isAriaDisabled={item.isDisabled || item.isAriaDisabled}
                 isSelected={item.isSelected}
+                to={item.href}
+                target={item.target}
                 flyoutMenu={
                   item.flyoutMenu?.length ? (
                     <MenuItems id={`${item.id}-submenu`} menuItems={item.flyoutMenu} onSelect={onSelect} />

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -83,6 +83,7 @@ const MenuItems = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
                 isSelected={item.isSelected}
                 to={item.href}
                 target={item.target}
+                rel={item.rel ?? (item.target === '_blank' ? 'noopener noreferrer' : undefined)}
                 flyoutMenu={
                   item.flyoutMenu?.length ? (
                     <MenuItems id={`${item.id}-submenu`} menuItems={item.flyoutMenu} onSelect={onSelect} />


### PR DESCRIPTION
When multiple ClusterManagementAddOn resources have launch-link annotations, the "Launch dashboard" dropdown items render as <button> elements instead of <a> tags, making them non-clickable.

This is a regression from the PF5 Menu migration (cf2652b6e) where the href prop on DropdownItem was not carried over to MenuItem's to prop. PatternFly 6 MenuItem uses the to prop to decide rendering as <a> vs <button>.

Pass to={item.href} and target={item.target} to MenuItem so items with href render as native links with proper navigation behavior.

# 📝 Summary

**Ticket Summary (Title):**  
AcmDropdown with multiple item fails to generate href link   

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32978 

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dropdown items now support configurable link targets and relationship attributes.

* **Tests**
  * Added test coverage for link-based dropdown items rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->