### PR TITLE
ACM-32967 Look up hub-name in RBAC-friendly manner

### DIFF
--- a/frontend/src/routes/Applications/CreateArgoApplication/CreatePullApplicationSet.test.tsx
+++ b/frontend/src/routes/Applications/CreateArgoApplication/CreatePullApplicationSet.test.tsx
@@ -318,9 +318,9 @@ const placementGit: Placement = {
           labelSelector: {
             matchExpressions: [
               {
-                key: 'name',
+                key: 'local-cluster',
                 operator: 'NotIn',
-                values: ['local-cluster'],
+                values: ['true'],
               },
             ],
           },
@@ -356,9 +356,9 @@ const placementHelm: Placement = {
           labelSelector: {
             matchExpressions: [
               {
-                key: 'name',
+                key: 'local-cluster',
                 operator: 'NotIn',
-                values: ['local-cluster'],
+                values: ['true'],
               },
             ],
           },

--- a/frontend/src/wizards/Argo/ArgoWizard.test.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.test.tsx
@@ -12,14 +12,20 @@ import {
   nockIgnoreApiPaths,
   nockIgnoreOperatorCheck,
 } from '../../lib/nock-util'
-import { createClusterVersionMock } from '../../lib/test-util'
+import {
+  createClusterVersionMock,
+  clickByRole,
+  clickByText,
+  typeByRole,
+  waitForNocks,
+  waitForText,
+} from '../../lib/test-util'
 
 const mockUseClusterVersion = createClusterVersionMock()
 jest.mock('../../hooks/use-cluster-version', () => ({
   useClusterVersion: () => mockUseClusterVersion(),
 }))
 
-import { clickByRole, clickByText, typeByRole, waitForNocks, waitForText } from '../../lib/test-util'
 import { NavigationPath } from '../../NavigationPath'
 import {
   GitOpsClusterApiVersion,
@@ -1080,9 +1086,9 @@ const submittedGitPullModel = [
             labelSelector: {
               matchExpressions: [
                 {
-                  key: 'name',
+                  key: 'local-cluster',
                   operator: 'NotIn',
-                  values: ['local-cluster'],
+                  values: ['true'],
                 },
               ],
             },

--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -357,9 +357,9 @@ export function ArgoWizard(props: ArgoWizardProps) {
                     labelSelector: {
                       matchExpressions: [
                         {
-                          key: 'name',
+                          key: 'local-cluster',
                           operator: 'NotIn',
-                          values: [hubClusterName],
+                          values: ['true'],
                         },
                       ],
                     },
@@ -607,7 +607,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
               clusterSetBindings={props.clusterSetBindings}
               createClusterSetCallback={props.createClusterSetCallback}
               isPullModel={isPullModel}
-              hubClusterName={hubClusterName}
             />
           </Step>
         )}
@@ -870,7 +869,6 @@ function ArgoWizardPlacementSection(props: {
   clusters: IResource[]
   createClusterSetCallback?: () => void
   isPullModel?: boolean
-  hubClusterName: string
 }) {
   const { t } = useTranslation()
   const resources = useItem() as IResource[]
@@ -922,9 +920,9 @@ function ArgoWizardPlacementSection(props: {
                                   labelSelector: {
                                     matchExpressions: [
                                       {
-                                        key: 'name',
+                                        key: 'local-cluster',
                                         operator: 'NotIn',
-                                        values: [props.hubClusterName],
+                                        values: ['true'],
                                       },
                                     ],
                                   },

--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -37,6 +37,7 @@ import { IResource } from '../common/resources/IResource'
 import { Placement } from '../Placement/Placement'
 import { WizardPage } from '../WizardPage'
 import { ClusterSetMonitor } from './ClusterSetMonitor'
+import { useLocalHubName } from '../../hooks/use-local-hub'
 import { CreateArgoResources } from './CreateArgoResources'
 import { MultipleSourcesSelector } from './MultipleSourcesSelector'
 import { SourceSelector } from './SourceSelector'
@@ -161,10 +162,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
   const { t } = useTranslation()
   const { validateAppSetName } = useValidation()
 
-  const hubCluster = useMemo(
-    () => props.clusters.find((cls) => cls.metadata?.labels && cls.metadata.labels['local-cluster'] === 'true'),
-    [props.clusters]
-  )
+  const hubClusterName = useLocalHubName()
   const sourceGitChannels = useMemo(
     () =>
       props.channels
@@ -361,7 +359,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
                         {
                           key: 'name',
                           operator: 'NotIn',
-                          values: [hubCluster?.metadata?.name],
+                          values: [hubClusterName],
                         },
                       ],
                     },
@@ -565,7 +563,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
         </Step>
         <Step id="repository" label={t('Template')}>
           <WizItemSelector selectKey="kind" selectValue="ApplicationSet">
-            <GitOpsPrivateRepoAlert isPullModel={isPullModel} hubClusterName={hubCluster?.metadata?.name ?? ''} />
+            <GitOpsPrivateRepoAlert isPullModel={isPullModel} hubClusterName={hubClusterName} />
             <Section label={t('Repository')} description={t('Repository of the applications to be created.')}>
               {source && !sources ? (
                 <SourceSelector
@@ -609,7 +607,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
               clusterSetBindings={props.clusterSetBindings}
               createClusterSetCallback={props.createClusterSetCallback}
               isPullModel={isPullModel}
-              hubClusterName={hubCluster?.metadata?.name ?? ''}
+              hubClusterName={hubClusterName}
             />
           </Step>
         )}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
TypeError when RBAC user with AppSet and Namespace permissions enters AppSet Wizard

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32967

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces


#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Argo Wizard now consistently derives the hub cluster and standardizes how pull-model placements exclude the local cluster, improving reliability across the wizard.
* **Tests**
  * Updated unit tests to reflect the standardized placement selector behavior and supporting test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->