### PR TITLE
[ACM-32997] Openshift Virt create cluster wizard should use common op…

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -17,14 +17,7 @@ import { createCluster } from '../../../../../lib/create-cluster'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
 import { PluginContext } from '../../../../../lib/PluginContext'
 import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
-import {
-  ClusterCurator,
-  createClusterCurator,
-  IResource,
-  ProviderConnection,
-  Secret,
-  SubscriptionOperator,
-} from '../../../../../resources'
+import { ClusterCurator, createClusterCurator, IResource, ProviderConnection, Secret } from '../../../../../resources'
 import { createResource as createResourceTool } from '../../../../../resources/utils'
 import { useCanJoinClusterSets, useMustJoinClusterSet } from '../../ClusterSets/components/useCanJoinClusterSets'
 // template/data
@@ -67,6 +60,7 @@ import { useLocalHubName } from '../../../../../hooks/use-local-hub'
 import './style.css'
 import { VALID_DNS_LABEL } from '../../../../../components/TemplateEditor/utils/validation-types'
 import { getPlatform } from './components/assisted-installer/hypershift/utils'
+import { SupportedOperator, useOperatorCheck } from '~/lib/operatorCheck'
 
 // Register the custom 'and' helper
 Handlebars.registerHelper('and', function (a, b) {
@@ -118,11 +112,11 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
     namespacesState,
     secretsState,
     settingsState,
-    subscriptionOperatorsState,
   } = useSharedAtoms()
   const {
     ansibleCredentialsValue,
     clusterCuratorSupportedCurationsValue,
+    kubevirtOperatorSubscriptionsValue,
     providerConnectionsValue,
     validClusterCuratorTemplatesValue,
   } = useSharedSelectors()
@@ -171,14 +165,9 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
   const namespaces = useRecoilValue(namespacesState)
   const validCuratorTemplates = useRecoilValue(validClusterCuratorTemplatesValue)
 
-  const subscriptionOperators = useRecoilValue(subscriptionOperatorsState)
-  const isKubevirtEnabled = useMemo(() => {
-    return (
-      subscriptionOperators.findIndex(
-        (operator: SubscriptionOperator) => operator.metadata.name === 'kubevirt-hyperconverged'
-      ) > -1
-    )
-  }, [subscriptionOperators])
+  // use common operator check to determine if Openshift Virtualization is installed
+  const kubevirtOperator = useOperatorCheck(SupportedOperator.kubevirt, kubevirtOperatorSubscriptionsValue)
+  const isKubevirtEnabled = !kubevirtOperator.pending && kubevirtOperator.installed
 
   const [selectedConnection, setSelectedConnection] = useState<ProviderConnection>()
   const onControlChange = useCallback(


### PR DESCRIPTION
…erator check

# 📝 Summary

**Ticket Summary (Title):**  
Fix bug where the Openshift Virtualization Operator alert is incorrectly displayed when the operator is installed. This bug is due to the current operator check looking for the Subscription Operator `metadata.name` rather than the `spec.name` field. The fix is to use the updated common operator check function.

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32997

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved code organization by consolidating KubeVirt operator detection to use a shared utility function, replacing custom detection logic with a standardized approach for consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->