### PR TITLE
ACM-32980 Use local-cluster label instead of basing on name for pull model placement [release-2.16]

### DIFF
--- a/frontend/src/routes/Applications/CreateArgoApplication/CreateApplicationArgoPullModel.test.tsx
+++ b/frontend/src/routes/Applications/CreateArgoApplication/CreateApplicationArgoPullModel.test.tsx
@@ -305,9 +305,9 @@ const placementGit: Placement = {
           labelSelector: {
             matchExpressions: [
               {
-                key: 'name',
+                key: 'local-cluster',
                 operator: 'NotIn',
-                values: ['local-cluster'],
+                values: ['true'],
               },
             ],
           },
@@ -343,9 +343,9 @@ const placementHelm: Placement = {
           labelSelector: {
             matchExpressions: [
               {
-                key: 'name',
+                key: 'local-cluster',
                 operator: 'NotIn',
-                values: ['local-cluster'],
+                values: ['true'],
               },
             ],
           },

--- a/frontend/src/wizards/Argo/ArgoWizard.test.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.test.tsx
@@ -1073,9 +1073,9 @@ const submittedGitPullModel = [
             labelSelector: {
               matchExpressions: [
                 {
-                  key: 'name',
+                  key: 'local-cluster',
                   operator: 'NotIn',
-                  values: ['local-cluster'],
+                  values: ['true'],
                 },
               ],
             },

--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -157,10 +157,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
 
   const { t } = useTranslation()
 
-  const hubCluster = useMemo(
-    () => props.clusters.find((cls) => cls.metadata?.labels && cls.metadata.labels['local-cluster'] === 'true'),
-    [props.clusters]
-  )
   const sourceGitChannels = useMemo(
     () =>
       props.channels
@@ -342,9 +338,9 @@ export function ArgoWizard(props: ArgoWizardProps) {
                     labelSelector: {
                       matchExpressions: [
                         {
-                          key: 'name',
+                          key: 'local-cluster',
                           operator: 'NotIn',
-                          values: [hubCluster?.metadata?.name],
+                          values: ['true'],
                         },
                       ],
                     },
@@ -584,7 +580,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
               clusterSetBindings={props.clusterSetBindings}
               createClusterSetCallback={props.createClusterSetCallback}
               isPullModel={isPullModel}
-              hubClusterName={hubCluster?.metadata?.name ?? ''}
             />
           </Step>
         )}
@@ -847,7 +842,6 @@ function ArgoWizardPlacementSection(props: {
   clusters: IResource[]
   createClusterSetCallback?: () => void
   isPullModel?: boolean
-  hubClusterName: string
 }) {
   const { t } = useTranslation()
   const resources = useItem() as IResource[]
@@ -899,9 +893,9 @@ function ArgoWizardPlacementSection(props: {
                                   labelSelector: {
                                     matchExpressions: [
                                       {
-                                        key: 'name',
+                                        key: 'local-cluster',
                                         operator: 'NotIn',
-                                        values: [props.hubClusterName],
+                                        values: ['true'],
                                       },
                                     ],
                                   },


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
TypeError when RBAC user with AppSet and Namespace permissions enters AppSet Wizard

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32980

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces


#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression