### PR TITLE
ACM-33027 Matched Clusters is always 0 in appset placement topology pod

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts
@@ -392,7 +392,7 @@ function addK8Details(
   )
 
   if (type === 'placements' || type === 'placement' || type === 'placementDecision') {
-    const specNbOfClustersTarget = node?.specs?.raw?.status?.decisions ?? []
+    const specNbOfClustersTarget = node?.specs?.raw?.status?.numberOfSelectedClusters ?? 0
 
     // placementDecision
     const clusterSets = node?.placementDecision?.spec?.clusterSets
@@ -403,7 +403,7 @@ function addK8Details(
     mainDetails.push(
       {
         labelValue: t('Matched Clusters'),
-        value: specNbOfClustersTarget.length,
+        value: specNbOfClustersTarget,
       },
       { labelValue: t('ClusterSet'), value: clusterSets ? clusterSets.join() : t('Not defined') },
       {


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Matched Clusters is always 0 in appset placement topology pod


**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33027

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the "Matched Clusters" calculation in application topology details. The metric now directly reflects the actual number of selected clusters, eliminating potential discrepancies in placement visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->