### PR TITLE
[ACM-33067] Fix incorrect search disabled warning in page header

### DIFF
--- a/frontend/src/lib/search.test.ts
+++ b/frontend/src/lib/search.test.ts
@@ -59,39 +59,13 @@ describe('useQuerySearchDisabledManagedClusters', () => {
             filters: [
               { property: 'kind', values: ['Cluster'] },
               { property: 'addon', values: ['search-collector=false'] },
-              { property: 'name', values: ['!local-cluster'] },
+              { property: 'label', values: ['!local-cluster=true'] },
             ],
           },
         ],
       },
       query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
     })
-  })
-
-  it('should use the local hub name from useLocalHubName hook', async () => {
-    mockUseLocalHubName.mockReturnValue('custom-hub')
-
-    const { result } = renderHookWithRecoil(() => useQuerySearchDisabledManagedClusters())
-
-    const queryFunction = result.current
-    await queryFunction()
-
-    expect(mockPostRequest).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        variables: {
-          input: [
-            {
-              filters: [
-                { property: 'kind', values: ['Cluster'] },
-                { property: 'addon', values: ['search-collector=false'] },
-                { property: 'name', values: ['!custom-hub'] },
-              ],
-            },
-          ],
-        },
-      })
-    )
   })
 
   it('should handle different hub names correctly', async () => {
@@ -119,7 +93,7 @@ describe('useQuerySearchDisabledManagedClusters', () => {
                 filters: [
                   { property: 'kind', values: ['Cluster'] },
                   { property: 'addon', values: ['search-collector=false'] },
-                  { property: 'name', values: [testCase.expectedName] },
+                  { property: 'label', values: ['!local-cluster=true'] },
                 ],
               },
             ],
@@ -174,21 +148,6 @@ describe('useQuerySearchDisabledManagedClusters', () => {
     expect(firstQueryFunction).toBe(secondQueryFunction)
   })
 
-  it('should create new function when localHubName changes', () => {
-    const { result, rerender } = renderHookWithRecoil(() => useQuerySearchDisabledManagedClusters())
-
-    const firstQueryFunction = result.current
-
-    // Change hub name
-    mockUseLocalHubName.mockReturnValue('different-hub')
-    rerender()
-
-    const secondQueryFunction = result.current
-
-    // The function should be different due to useCallback dependency
-    expect(firstQueryFunction).not.toBe(secondQueryFunction)
-  })
-
   it('should use the correct API endpoint', async () => {
     const { result } = renderHookWithRecoil(() => useQuerySearchDisabledManagedClusters())
 
@@ -211,7 +170,7 @@ describe('useQuerySearchDisabledManagedClusters', () => {
     expect(searchQuery.variables.input[0].filters).toEqual([
       { property: 'kind', values: ['Cluster'] },
       { property: 'addon', values: ['search-collector=false'] },
-      { property: 'name', values: ['!local-cluster'] },
+      { property: 'label', values: ['!local-cluster=true'] },
     ])
   })
 })

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -3,7 +3,6 @@
 import { useCallback, useMemo } from 'react'
 import { useLocation } from 'react-router-dom-v5-compat'
 import { getBackendUrl, IRequestResult, postRequest } from '../resources/utils'
-import { useLocalHubName } from '../hooks/use-local-hub'
 
 export const apiSearchUrl = '/proxy/search'
 const searchFilterQuery =
@@ -35,7 +34,6 @@ export type SearchQuery = {
 }
 
 export function useQuerySearchDisabledManagedClusters(): () => IRequestResult<ISearchResult> {
-  const localHubName = useLocalHubName()
   return useCallback(
     () =>
       postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
@@ -46,14 +44,14 @@ export function useQuerySearchDisabledManagedClusters(): () => IRequestResult<IS
               filters: [
                 { property: 'kind', values: ['Cluster'] },
                 { property: 'addon', values: ['search-collector=false'] },
-                { property: 'name', values: [`!${localHubName}`] },
+                { property: 'label', values: [`!local-cluster=true`] },
               ],
             },
           ],
         },
         query: searchFilterQuery,
       }),
-    [localHubName]
+    []
   )
 }
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationDetails.test.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationDetails.test.tsx
@@ -20,7 +20,7 @@ import { defaultPlugin, PluginContext } from '../../../lib/PluginContext'
 import { waitForText } from '../../../lib/test-util'
 import { ActionExtensionProps } from '../../../plugin-extensions/properties'
 import { AcmExtension } from '../../../plugin-extensions/types'
-import { GetMessagesDocument, SearchSchemaDocument } from '../../Search/search-sdk/search-sdk'
+import { SearchSchemaDocument } from '../../Search/search-sdk/search-sdk'
 import {
   mockApplication0,
   mockApplications,
@@ -334,16 +334,6 @@ describe('Applications Page', () => {
             searchSchema: {
               allProperties: ['cluster', 'kind', 'label', 'name', 'namespace'],
             },
-          },
-        },
-      },
-      {
-        request: {
-          query: GetMessagesDocument,
-        },
-        result: {
-          data: {
-            messages: [],
           },
         },
       },

--- a/frontend/src/routes/Search/SearchPage.test.tsx
+++ b/frontend/src/routes/Search/SearchPage.test.tsx
@@ -13,13 +13,12 @@ import { nockIgnoreOperatorCheck, nockRequest } from '../../lib/nock-util'
 import { wait, waitForNocks } from '../../lib/test-util'
 import { ConfigMap } from '../../resources'
 import { UserPreference } from '../../resources/userpreference'
-import {
-  GetMessagesDocument,
-  SearchCompleteDocument,
-  SearchResultItemsDocument,
-  SearchSchemaDocument,
-} from './search-sdk/search-sdk'
+import { SearchCompleteDocument, SearchResultItemsDocument, SearchSchemaDocument } from './search-sdk/search-sdk'
 import SearchPage from './SearchPage'
+
+jest.mock('../../lib/search', () => ({
+  useQuerySearchDisabledManagedClusters: jest.fn(() => jest.fn()),
+}))
 
 // Mock the KubevirtProviderAlert component
 jest.mock('../../components/KubevirtProviderAlert', () => ({
@@ -93,16 +92,6 @@ describe('SearchPage', () => {
           },
         },
       },
-      {
-        request: {
-          query: GetMessagesDocument,
-        },
-        result: {
-          data: {
-            messages: [],
-          },
-        },
-      },
     ]
     render(
       <RecoilRoot
@@ -148,16 +137,6 @@ describe('SearchPage', () => {
         },
         result: {
           errors: [new GraphQLError('Error getting search schema data')],
-        },
-      },
-      {
-        request: {
-          query: GetMessagesDocument,
-        },
-        result: {
-          data: {
-            messages: [],
-          },
         },
       },
     ]
@@ -211,16 +190,6 @@ describe('SearchPage', () => {
         },
         result: {
           errors: ['error sending federated request' as unknown as GraphQLError],
-        },
-      },
-      {
-        request: {
-          query: GetMessagesDocument,
-        },
-        result: {
-          data: {
-            messages: [],
-          },
         },
       },
     ]
@@ -292,23 +261,6 @@ describe('SearchPage', () => {
           },
         },
       },
-      {
-        request: {
-          query: GetMessagesDocument,
-        },
-        result: {
-          data: {
-            messages: [
-              {
-                id: 'S20',
-                kind: 'info',
-                description: 'Search is disabled on some of your managed clusters.',
-                __typename: 'Message',
-              },
-            ],
-          },
-        },
-      },
     ]
     render(
       <RecoilRoot
@@ -343,9 +295,6 @@ describe('SearchPage', () => {
 
     // check searchbar updated properly
     await waitFor(() => expect(screen.queryByText('kind:deployment')).toBeTruthy())
-
-    // Validate message when managed clusters are disabled. We don't have translation in this context.
-    await waitFor(() => expect(screen.queryByText('Search is disabled on some clusters.')).toBeTruthy())
   })
   it('should render SearchPage with predefined query', async () => {
     nockIgnoreOperatorCheck()
@@ -370,16 +319,6 @@ describe('SearchPage', () => {
             searchSchema: {
               allProperties: ['cluster', 'kind', 'label', 'name', 'namespace'],
             },
-          },
-        },
-      },
-      {
-        request: {
-          query: GetMessagesDocument,
-        },
-        result: {
-          data: {
-            messages: [],
           },
         },
       },
@@ -475,7 +414,6 @@ describe('SearchPage', () => {
         },
         result: { data: { searchSchema: { allProperties: ['cluster', 'kind', 'label', 'name', 'namespace'] } } },
       },
-      { request: { query: GetMessagesDocument }, result: { data: { messages: [] } } },
       {
         request: {
           query: SearchResultItemsDocument,

--- a/frontend/src/routes/Search/SearchPage.tsx
+++ b/frontend/src/routes/Search/SearchPage.tsx
@@ -32,7 +32,6 @@ import {
 import { searchClient } from './search-sdk/search-client'
 import {
   SearchResultItemsQuery,
-  useGetMessagesQuery,
   useSearchCompleteQuery,
   useSearchResultItemsQuery,
   useSearchSchemaQuery,
@@ -385,7 +384,6 @@ export default function SearchPage() {
   const configMaps = useRecoilValue(configMapsState)
   const [selectedSearch, setSelectedSearch] = useState(savedSearchesText)
   const [queryErrors, setQueryErrors] = useState(false)
-  const [queryMessages, setQueryMessages] = useState<any[]>([])
   const [isUserPreferenceLoading, setIsUserPreferenceLoading] = useState(true)
   const [userPreference, setUserPreference] = useState<UserPreference | undefined>(undefined)
 
@@ -454,14 +452,6 @@ export default function SearchPage() {
   }, [presetSearchQuery, userSavedSearches, t])
 
   const query = convertStringToQuery(presetSearchQuery, searchResultLimit)
-  const msgQuery = useGetMessagesQuery({
-    client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
-  })
-  useEffect(() => {
-    if (msgQuery.data?.messages) {
-      setQueryMessages(msgQuery.data?.messages)
-    }
-  }, [msgQuery.data])
   // Helper function to check if search query contains VirtualMachine kinds
   const hasVirtualMachineKinds = (query: string): boolean => {
     const lowerQuery = query.toLowerCase()
@@ -470,7 +460,7 @@ export default function SearchPage() {
   }
 
   return (
-    <AcmPage header={<HeaderWithNotification messages={queryMessages} />}>
+    <AcmPage header={<HeaderWithNotification />}>
       <RenderDropDownAndNewTab
         selectedSearch={selectedSearch}
         setSelectedSearch={setSelectedSearch}

--- a/frontend/src/routes/Search/components/HeaderWithNotification.test.tsx
+++ b/frontend/src/routes/Search/components/HeaderWithNotification.test.tsx
@@ -4,56 +4,158 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
+import { nockSearch } from '~/lib/nock-util'
+import { waitForNocks } from '~/lib/test-util'
 import { isGlobalHubState, Settings, settingsState } from '../../../atoms'
-import { Message } from '../search-sdk/search-sdk'
 import HeaderWithNotification from './HeaderWithNotification'
 
-// case where we have a message about disabled search (current message)
-test('renders clusters disabled message', () => {
-  const disableSearch = [
-    { id: 'S20', kind: 'info', description: 'Search is disabled on some of your managed clusters.' },
-  ]
+test('renders without search disabled message', async () => {
+  const searchIsDisabledMock = nockSearch(
+    {
+      operationName: 'searchResult',
+      variables: {
+        input: [
+          {
+            filters: [
+              {
+                property: 'kind',
+                values: ['Cluster'],
+              },
+              {
+                property: 'addon',
+                values: ['search-collector=false'],
+              },
+              {
+                property: 'label',
+                values: ['!local-cluster=true'],
+              },
+            ],
+          },
+        ],
+      },
+      query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+    },
+    {
+      data: {
+        searchResult: [{ items: [] }],
+      },
+    }
+  )
   const { baseElement } = render(
     <RecoilRoot>
       <MemoryRouter>
-        <HeaderWithNotification messages={disableSearch} />
+        <HeaderWithNotification />
       </MemoryRouter>
     </RecoilRoot>
   )
+  await waitForNocks([searchIsDisabledMock])
   expect(baseElement).toMatchSnapshot()
 })
 
-// case where we have no message
-test('renders empty message', () => {
-  const emptyMessage: Message[] = []
+test('renders with search disabled message', async () => {
+  const searchIsNotDisabledMock = nockSearch(
+    {
+      operationName: 'searchResult',
+      variables: {
+        input: [
+          {
+            filters: [
+              {
+                property: 'kind',
+                values: ['Cluster'],
+              },
+              {
+                property: 'addon',
+                values: ['search-collector=false'],
+              },
+              {
+                property: 'label',
+                values: ['!local-cluster=true'],
+              },
+            ],
+          },
+        ],
+      },
+      query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+    },
+    {
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'test-cluster',
+                kind: 'cluster',
+                name: 'test-cluster',
+                apigroup: 'internal.open-cluster-management.io',
+                label:
+                  'cloud=Amazon; cluster.open-cluster-management.io/clusterset=hub; clusterID=70ebe797-4791-4958-be17-f088411a0db5; feature.open-cluster-management.io/addon-application-manager=available; feature.open-cluster-management.io/addon-cert-policy-controller=available; feature.open-cluster-management.io/addon-config-policy-controller=available; feature.open-cluster-management.io/addon-governance-policy-framework=available; feature.open-cluster-management.io/addon-work-manager=available; installer.name=multiclusterhub; installer.namespace=open-cluster-management; name=test-cluster; openshiftVersion=4.11.0-fc.3; velero.io/exclude-from-backup=true; vendor=OpenShift',
+                ManagedClusterImportSucceeded: 'True',
+                HubAcceptedManagedCluster: 'True',
+                ManagedClusterConditionAvailable: 'True',
+                created: '2022-07-08T13:02:56Z',
+                cpu: 36,
+                kubernetesVersion: 'v1.24.0+284d62a',
+                memory: '144758296Ki',
+                ManagedClusterJoined: 'True',
+                addon:
+                  'application-manager=true; cert-policy-controller=true; policy-controller=true; search-collector=false',
+                consoleURL: 'https://console-openshift-console.apps.cs-aws-411-7cwgp.dev02.red-chesterfield.com',
+                status: 'OK',
+                ClusterCertificateRotated: 'True',
+              },
+            ],
+          },
+        ],
+      },
+    }
+  )
   const { baseElement } = render(
     <RecoilRoot>
       <MemoryRouter>
-        <HeaderWithNotification messages={emptyMessage} />
+        <HeaderWithNotification />
       </MemoryRouter>
     </RecoilRoot>
   )
+  await waitForNocks([searchIsNotDisabledMock])
   expect(baseElement).toMatchSnapshot()
 })
 
-// case where we have a different message
-test('renders unknown message', () => {
-  const newMessage = [{ id: 'S90', kind: 'warning', message: 'This is a new message' }]
-  const { baseElement } = render(
-    <RecoilRoot>
-      <MemoryRouter>
-        <HeaderWithNotification messages={newMessage} />
-      </MemoryRouter>
-    </RecoilRoot>
-  )
-  expect(baseElement).toMatchSnapshot()
-})
-
-test('renders with Global Search alert & no message', () => {
+test('renders with Global Search alert & no message', async () => {
   const mockSettings: Settings = {
     globalSearchFeatureFlag: 'enabled',
   }
-  const emptyMessage: Message[] = []
+  const searchIsNotDisabledMock = nockSearch(
+    {
+      operationName: 'searchResult',
+      variables: {
+        input: [
+          {
+            filters: [
+              {
+                property: 'kind',
+                values: ['Cluster'],
+              },
+              {
+                property: 'addon',
+                values: ['search-collector=false'],
+              },
+              {
+                property: 'label',
+                values: ['!local-cluster=true'],
+              },
+            ],
+          },
+        ],
+      },
+      query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+    },
+    {
+      data: {
+        searchResult: [{ items: [] }],
+      },
+    }
+  )
   const { baseElement } = render(
     <RecoilRoot
       initializeState={(snapshot) => {
@@ -62,9 +164,10 @@ test('renders with Global Search alert & no message', () => {
       }}
     >
       <MemoryRouter>
-        <HeaderWithNotification messages={emptyMessage} />
+        <HeaderWithNotification />
       </MemoryRouter>
     </RecoilRoot>
   )
+  await waitForNocks([searchIsNotDisabledMock])
   expect(baseElement).toMatchSnapshot()
 })

--- a/frontend/src/routes/Search/components/HeaderWithNotification.tsx
+++ b/frontend/src/routes/Search/components/HeaderWithNotification.tsx
@@ -20,7 +20,8 @@ export default function HeaderWithNotification() {
   const { data, loading, error } = useQuery(queryDisabled)
 
   useEffect(() => {
-    setIsSearchDisabled(!loading && !error && data?.[0]?.data?.searchResult?.[0]?.items.length > 0)
+    const items = data?.[0]?.data?.searchResult?.[0]?.items
+    setIsSearchDisabled(!loading && !error && Array.isArray(items) && items.length > 0)
   }, [data, loading, error])
 
   return (

--- a/frontend/src/routes/Search/components/HeaderWithNotification.tsx
+++ b/frontend/src/routes/Search/components/HeaderWithNotification.tsx
@@ -1,19 +1,27 @@
 /* Copyright Contributors to the Open Cluster Management project */
 // Copyright (c) 2021 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom-v5-compat'
+import { useQuerySearchDisabledManagedClusters } from '~/lib/search'
+import { useQuery } from '~/lib/useQuery'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
 import { useRecoilValue, useSharedAtoms } from '../../../shared-recoil'
 import { AcmInlineStatus, AcmPageHeader, StatusType } from '../../../ui-components'
-import { Message } from '../search-sdk/search-sdk'
 
-export default function HeaderWithNotification(props: { messages: Message[] }) {
+export default function HeaderWithNotification() {
   const { t } = useTranslation()
   const { isGlobalHubState, settingsState } = useSharedAtoms()
   const isGlobalHub = useRecoilValue(isGlobalHubState)
   const settings = useRecoilValue(settingsState)
-  const { messages } = props
+  const [isSearchDisabled, setIsSearchDisabled] = useState(false)
+  const queryDisabled = useQuerySearchDisabledManagedClusters()
+  const { data, loading, error } = useQuery(queryDisabled)
+
+  useEffect(() => {
+    setIsSearchDisabled(!loading && !error && data?.[0]?.data?.searchResult?.[0]?.items.length > 0)
+  }, [data, loading, error])
 
   return (
     <AcmPageHeader
@@ -23,33 +31,28 @@ export default function HeaderWithNotification(props: { messages: Message[] }) {
         settings.globalSearchFeatureFlag === 'enabled' &&
         t('Global search is enabled. Resources across all your managed hubs and clusters will be shown.')
       }
-      actions={messages.map((msg, index) => {
-        const displayShortText = t('Search is disabled on some clusters.') || msg?.description
-        const displayLongText =
-          t(
-            'Currently, search is disabled on some of your managed clusters. Some data might be missing from the console view.'
-          ) || msg?.description
-        const footerText = t('View clusters with search add-on disabled.')
-
-        return (
+      actions={
+        isSearchDisabled ? (
           <AcmInlineStatus
-            key={msg.id + index}
+            key={'search-disabled-warning'}
             type={StatusType.warning}
-            status={displayShortText}
+            status={t('Search is disabled on some clusters.')}
             popover={{
-              headerContent: displayShortText,
-              bodyContent: displayLongText,
-              footerContent: msg.id === 'S20' && (
+              headerContent: t('Search is disabled on some clusters.'),
+              bodyContent: t(
+                'Currently, search is disabled on some of your managed clusters. Some data might be missing from the console view.'
+              ),
+              footerContent: (
                 <Link
                   to={`${NavigationPath.search}?filters={"textsearch":"kind%3ACluster%20addon%3Asearch-collector%3Dfalse%20label%3A!local-cluster%3Dtrue"}`}
                 >
-                  {footerText}
+                  {t('View clusters with search add-on disabled.')}
                 </Link>
               ),
             }}
           />
-        )
-      })}
+        ) : null
+      }
     />
   )
 }

--- a/frontend/src/routes/Search/components/__snapshots__/HeaderWithNotification.test.tsx.snap
+++ b/frontend/src/routes/Search/components/__snapshots__/HeaderWithNotification.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders clusters disabled message 1`] = `
+exports[`renders with Global Search alert & no message 1`] = `
 <body>
   <div>
     <section
@@ -36,18 +36,48 @@ exports[`renders clusters disabled message 1`] = `
                       >
                         <div
                           class="pf-v6-c-content"
-                          data-ouia-component-id="OUIA-Generated-Content-1"
+                          data-ouia-component-id="OUIA-Generated-Content-3"
                           data-ouia-component-type="PF6/Content"
                           data-ouia-safe="true"
                           data-pf-content="true"
                         >
                           <h1
                             class="pf-v6-c-title pf-m-h1"
-                            data-ouia-component-id="OUIA-Generated-Title-1"
+                            data-ouia-component-id="OUIA-Generated-Title-3"
                             data-ouia-component-type="PF6/Title"
                             data-ouia-safe="true"
                           >
-                            Search
+                            Global search
+                            <div
+                              style="display: contents;"
+                            >
+                              <button
+                                class="pf-v6-c-button pf-m-plain"
+                                data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                                data-ouia-component-type="PF6/Button"
+                                data-ouia-safe="true"
+                                style="padding: 0px; margin-left: 8px; vertical-align: middle;"
+                                type="button"
+                              >
+                                <span
+                                  class="pf-v6-c-button__icon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="pf-v6-svg"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    viewBox="0 0 512 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                    />
+                                  </svg>
+                                </span>
+                              </button>
+                            </div>
                           </h1>
                         </div>
                       </div>
@@ -58,80 +88,13 @@ exports[`renders clusters disabled message 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="pf-v6-l-split__item"
-        >
-          <section
-            class="pf-v6-c-page__main-breadcrumb"
-          >
-            <div
-              class="pf-v6-l-stack pf-m-gutter"
-            >
-              <div
-                class="pf-v6-l-stack__item pf-m-fill"
-                style="display: flex; flex-direction: column; align-items: flex-end; justify-content: flex-end;"
-              >
-                <div
-                  class="css-k008qs"
-                  style="align-items: baseline;"
-                >
-                  <div
-                    class="css-19gc7lg"
-                  >
-                    <span
-                      class="pf-v6-c-icon"
-                    >
-                      <span
-                        class="pf-v6-c-icon__content pf-m-warning"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v6-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 576 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <span>
-                    <div
-                      style="display: contents;"
-                    >
-                      <button
-                        class="pf-v6-c-button pf-m-link css-1dkl6e6"
-                        data-ouia-component-id="OUIA-Generated-Button-link-1"
-                        data-ouia-component-type="PF6/Button"
-                        data-ouia-safe="true"
-                        style="padding-left: 5px;"
-                        type="button"
-                      >
-                        <span
-                          class="pf-v6-c-button__text"
-                        >
-                          Search is disabled on some clusters.
-                        </span>
-                      </button>
-                    </div>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
       </div>
     </section>
   </div>
 </body>
 `;
 
-exports[`renders empty message 1`] = `
+exports[`renders with search disabled message 1`] = `
 <body>
   <div>
     <section
@@ -189,29 +152,13 @@ exports[`renders empty message 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="pf-v6-l-split__item"
-        >
-          <section
-            class="pf-v6-c-page__main-breadcrumb"
-          >
-            <div
-              class="pf-v6-l-stack pf-m-gutter"
-            >
-              <div
-                class="pf-v6-l-stack__item pf-m-fill"
-                style="display: flex; flex-direction: column; align-items: flex-end; justify-content: flex-end;"
-              />
-            </div>
-          </section>
-        </div>
       </div>
     </section>
   </div>
 </body>
 `;
 
-exports[`renders unknown message 1`] = `
+exports[`renders without search disabled message 1`] = `
 <body>
   <div>
     <section
@@ -247,14 +194,14 @@ exports[`renders unknown message 1`] = `
                       >
                         <div
                           class="pf-v6-c-content"
-                          data-ouia-component-id="OUIA-Generated-Content-3"
+                          data-ouia-component-id="OUIA-Generated-Content-1"
                           data-ouia-component-type="PF6/Content"
                           data-ouia-safe="true"
                           data-pf-content="true"
                         >
                           <h1
                             class="pf-v6-c-title pf-m-h1"
-                            data-ouia-component-id="OUIA-Generated-Title-3"
+                            data-ouia-component-id="OUIA-Generated-Title-1"
                             data-ouia-component-type="PF6/Title"
                             data-ouia-safe="true"
                           >
@@ -268,183 +215,6 @@ exports[`renders unknown message 1`] = `
               </section>
             </div>
           </div>
-        </div>
-        <div
-          class="pf-v6-l-split__item"
-        >
-          <section
-            class="pf-v6-c-page__main-breadcrumb"
-          >
-            <div
-              class="pf-v6-l-stack pf-m-gutter"
-            >
-              <div
-                class="pf-v6-l-stack__item pf-m-fill"
-                style="display: flex; flex-direction: column; align-items: flex-end; justify-content: flex-end;"
-              >
-                <div
-                  class="css-k008qs"
-                  style="align-items: baseline;"
-                >
-                  <div
-                    class="css-19gc7lg"
-                  >
-                    <span
-                      class="pf-v6-c-icon"
-                    >
-                      <span
-                        class="pf-v6-c-icon__content pf-m-warning"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v6-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 576 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </div>
-                  <span>
-                    <div
-                      style="display: contents;"
-                    >
-                      <button
-                        class="pf-v6-c-button pf-m-link css-1dkl6e6"
-                        data-ouia-component-id="OUIA-Generated-Button-link-2"
-                        data-ouia-component-type="PF6/Button"
-                        data-ouia-safe="true"
-                        style="padding-left: 5px;"
-                        type="button"
-                      >
-                        <span
-                          class="pf-v6-c-button__text"
-                        >
-                          Search is disabled on some clusters.
-                        </span>
-                      </button>
-                    </div>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-    </section>
-  </div>
-</body>
-`;
-
-exports[`renders with Global Search alert & no message 1`] = `
-<body>
-  <div>
-    <section
-      class="pf-v6-c-page__main-section pf-m-no-padding pf-m-sticky-top"
-      id="page-header"
-    >
-      <div
-        class="pf-v6-l-split"
-      >
-        <div
-          class="pf-v6-l-split__item pf-m-fill"
-        >
-          <div
-            class="pf-v6-l-stack pf-m-gutter"
-          >
-            <div
-              class="pf-v6-l-stack__item pf-m-fill"
-            >
-              <section
-                class="pf-v6-c-page__main-section"
-              >
-                <div
-                  class="pf-v6-l-stack pf-m-gutter"
-                >
-                  <div
-                    class="pf-v6-l-stack__item pf-m-fill"
-                  >
-                    <div
-                      class="pf-v6-l-split pf-m-gutter"
-                    >
-                      <div
-                        class="pf-v6-l-split__item"
-                      >
-                        <div
-                          class="pf-v6-c-content"
-                          data-ouia-component-id="OUIA-Generated-Content-4"
-                          data-ouia-component-type="PF6/Content"
-                          data-ouia-safe="true"
-                          data-pf-content="true"
-                        >
-                          <h1
-                            class="pf-v6-c-title pf-m-h1"
-                            data-ouia-component-id="OUIA-Generated-Title-4"
-                            data-ouia-component-type="PF6/Title"
-                            data-ouia-safe="true"
-                          >
-                            Global search
-                            <div
-                              style="display: contents;"
-                            >
-                              <button
-                                class="pf-v6-c-button pf-m-plain"
-                                data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                data-ouia-component-type="PF6/Button"
-                                data-ouia-safe="true"
-                                style="padding: 0px; margin-left: 8px; vertical-align: middle;"
-                                type="button"
-                              >
-                                <span
-                                  class="pf-v6-c-button__icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="pf-v6-svg"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    viewBox="0 0 512 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                          </h1>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </section>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pf-v6-l-split__item"
-        >
-          <section
-            class="pf-v6-c-page__main-breadcrumb"
-          >
-            <div
-              class="pf-v6-l-stack pf-m-gutter"
-            >
-              <div
-                class="pf-v6-l-stack__item pf-m-fill"
-                style="display: flex; flex-direction: column; align-items: flex-end; justify-content: flex-end;"
-              />
-            </div>
-          </section>
         </div>
       </div>
     </section>


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
The search api "messages" query to find clusters with the search addon disabled still uses the hardcoded "local-cluster" name. This results in the search disabled warning always being present if the hub cluster is not named "local-cluster".

This change set uses the correct query to identify if any managed clusters have the search addon disabled.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-33067

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now excludes the local cluster via label-based filtering, improving detection of disabled clusters.

* **Refactor**
  * Warning logic for search simplified to remove reliance on local hub name, improving stability across renders.

* **UI**
  * Header notification now derives its disabled-search state from live query results and displays a single inline warning when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->