### PR TITLE
ACM-30604 Make paste buttons consistent

### DIFF
--- a/frontend/packages/react-form-wizard/src/components/PasteInputButton.tsx
+++ b/frontend/packages/react-form-wizard/src/components/PasteInputButton.tsx
@@ -12,6 +12,7 @@ export function PasteInputButton(props: {
   return (
     <Tooltip content={pasteButtonTooltip}>
       <Button
+        aria-label={pasteButtonTooltip}
         icon={<PasteIcon />}
         variant="control"
         onClick={() => {

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -56,6 +56,7 @@ import {
   Title,
   ToggleGroup,
   ToggleGroupItem,
+  Tooltip,
   Wizard,
   WizardFooterType,
   WizardFooterWrapper,
@@ -1509,17 +1510,21 @@ function SelectOptionsGallery(props: { input: InputBase<string>; options: Select
 
 function PasteInputButton(props: { setValue: (value: string) => void; setShowSecrets?: (value: boolean) => void }) {
   const { setValue, setShowSecrets } = props
+  const { t } = useTranslation()
   return (
-    <Button
-      icon={<PasteIcon />}
-      variant="control"
-      onClick={() => {
-        navigator.clipboard.readText().then((value) => {
-          setValue(value)
-          if (value && setShowSecrets) setShowSecrets(false)
-        })
-      }}
-    ></Button>
+    <Tooltip content={t('Paste')}>
+      <Button
+        icon={<PasteIcon />}
+        variant="control"
+        onClick={() => {
+          navigator.clipboard.readText().then((value) => {
+            setValue(value)
+            if (value && setShowSecrets) setShowSecrets(false)
+          })
+        }}
+        tabIndex={-1}
+      ></Button>
+    </Tooltip>
   )
 }
 

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -1514,6 +1514,7 @@ function PasteInputButton(props: { setValue: (value: string) => void; setShowSec
   return (
     <Tooltip content={t('Paste')}>
       <Button
+        aria-label={t('Paste')}
         icon={<PasteIcon />}
         variant="control"
         onClick={() => {


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Paste from clipboard button in credential form has no tooltip or indication of its function

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-30604

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized tooltip to the Paste button for clearer guidance and consistent accessible labeling.

* **Accessibility**
  * Removed the Paste button from the tab order to prevent unexpected focus.
  * Added an explicit accessible name to the Paste button so screen readers announce the tooltip text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->