### PR TITLE
ACM-33047 WizTextArea loses formatting when shown in Review step

### DIFF
--- a/frontend/packages/react-form-wizard/src/review/ReviewStep.tsx
+++ b/frontend/packages/react-form-wizard/src/review/ReviewStep.tsx
@@ -706,6 +706,20 @@ function renderReviewInputDescriptionContent(node: WizardInputDomNode): ReactNod
   return <></>
 }
 
+/** When review value is a plain string with newlines, show each segment on its own line. */
+function renderReviewValueWithNewlines(valueContent: ReactNode): ReactNode {
+  if (typeof valueContent === 'string' && valueContent.includes('\n')) {
+    const lines = valueContent.split('\n')
+    return lines.map((line, index) => (
+      <Fragment key={index}>
+        {index > 0 ? <br /> : null}
+        {line}
+      </Fragment>
+    ))
+  }
+  return valueContent
+}
+
 /** Base margin 32px; each nested ARRAY_INPUT adds 2px. */
 function reviewArrayInstanceMarginLeft(arrayInputNesting: number): number {
   return 32 + 2 * arrayInputNesting
@@ -863,13 +877,13 @@ function renderReviewInputRows(nodes: readonly WizardInputDomNode[], ctx: Review
                 onPenIconClick={() => onReviewEdit(inputNode, 'navigate')}
                 onArrowClick={yamlVisible ? () => onReviewEdit(inputNode, 'highlight') : undefined}
               >
-                {valueContent}
+                {renderReviewValueWithNewlines(valueContent)}
               </ReviewPenHoverZone>
             ) : (
               <>
                 <DescriptionListTerm>{termContent}</DescriptionListTerm>
                 <DescriptionListDescription id={inputNode.id ?? ''}>
-                  <span className="wizard-review-inline-value">{valueContent}</span>
+                  <span className="wizard-review-inline-value">{renderReviewValueWithNewlines(valueContent)}</span>
                 </DescriptionListDescription>
               </>
             )}


### PR DESCRIPTION
# 📝 Summary
<img width="1702" height="534" alt="CleanShot 2026-04-21 at 15 13 23@2x" src="https://github.com/user-attachments/assets/b4d666a3-c63d-4452-bf23-03df1443d32b" />

**Ticket Summary (Title):**  
ACM-33047 WizTextArea loses formatting when shown in Review step

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33047

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->