### PR TITLE
CCXDEV-16350 fix: use || instead of ?? for UPGRADE_RISKS_PREDICTION_URL

### DIFF
--- a/backend/src/lib/config.ts
+++ b/backend/src/lib/config.ts
@@ -45,11 +45,16 @@ export async function loadConfigSettings(): Promise<string[]> {
       } else if (key === 'globalSearchFeatureFlag') {
         // Global search tech-preview requires feature flag toggle (2.11)
         process.env[key] = settings[key]
+      } else if (key === 'UPGRADE_RISKS_PREDICTION_URL') {
+        process.env[key] = settings[key]
       }
     }
     if (process.env['globalSearchFeatureFlag'] && !settings['globalSearchFeatureFlag']) {
       // If globalSearchFeatureFlag is set but has been removed from config settings -> removing env var.
       delete process.env['globalSearchFeatureFlag']
+    }
+    if (process.env['UPGRADE_RISKS_PREDICTION_URL'] && !settings['UPGRADE_RISKS_PREDICTION_URL']) {
+      delete process.env['UPGRADE_RISKS_PREDICTION_URL']
     }
     if (settings.LOG_LEVEL) {
       logger.level = settings.LOG_LEVEL

--- a/backend/src/routes/upgrade-risks-prediction.ts
+++ b/backend/src/routes/upgrade-risks-prediction.ts
@@ -53,7 +53,7 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
         // https://github.com/RedHatInsights/insights-results-smart-proxy/blob/master/server/router_utils.go#L168
         const userAgent = 'acm-operator/v2.10.0 cluster/acm-hub'
         const insightsPath =
-          process.env.UPGRADE_RISKS_PREDICTION_URL ??
+          process.env.UPGRADE_RISKS_PREDICTION_URL ||
           'https://console.redhat.com/api/insights-results-aggregator/v2/upgrade-risks-prediction'
 
         // create array of clusterIds with length of 100


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

Fix ACM UI URP env variable

Rollup tree-shakes `process.env.X ?? 'fallback'` to `'fallback'` at build time when the env var is not set in the build environment, making the runtime env var override ineffective. Switching to `||` prevents this optimization while being functionally equivalent for env vars (which are always strings or undefined, never null).

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

[CCXDEV-16350](https://redhat.atlassian.net/browse/CCXDEV-16350)

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback handling for the upgrade risk prediction service so an empty or missing configuration now falls back to the default prediction endpoint, ensuring predictions continue to load reliably across environments.

* **Chores**
  * Config loader now recognizes and propagates the upgrade risks prediction URL from configuration into runtime environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CCXDEV-16350]: https://redhat.atlassian.net/browse/CCXDEV-16350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ