### PR TITLE
[ACM-33148] Add placement preview to standalone placement wizard

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/Placements/CreatePlacement/PlacementWizard.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/Placements/CreatePlacement/PlacementWizard.tsx
@@ -16,6 +16,7 @@ import {
   useItem,
 } from '@patternfly-labs/react-form-wizard'
 import { useValidation } from '~/hooks/useValidation'
+import { useRecoilValue, useSharedAtoms } from '~/shared-recoil'
 import { IClusterSetBinding } from '~/wizards/common/resources/IClusterSetBinding'
 import { IPlacement, PlacementKind, PlacementType } from '~/wizards/common/resources/IPlacement'
 import { NavigationPath } from '~/NavigationPath'
@@ -123,6 +124,8 @@ function PlacementStepContent(props: {
   clusters: IResource[]
 }) {
   const { t } = useTranslation()
+  const { settingsState } = useSharedAtoms()
+  const settings = useRecoilValue(settingsState)
   const placement = useItem() as IPlacement
   const namespace = placement?.metadata?.namespace
 
@@ -143,6 +146,7 @@ function PlacementStepContent(props: {
         'ClusterSets failed to load. Verify that there is at least one ClusterSet bound to your selected namespace.'
       )}
       hideName
+      showPlacementPreview={settings.enhancedPlacement === 'enabled'}
       alertContent={
         <Button variant="link" onClick={() => window.open(NavigationPath.clusterSets)} style={{ padding: '0' }}>
           {t('Add cluster set')}


### PR DESCRIPTION
## Summary
- Wires the `enhancedPlacement` feature flag and `usePlacementDebug` hook into the standalone placement wizard (`PlacementWizard.tsx`) so it shows the matched clusters preview UI
- Includes changes from both `ACM-30639-wizard-placement-enhancements-v2` (placement preview backend + UI) and `ACM-30639-general-wizard-updates` (general wizard UX improvements)
- Fixes unused `isClusterSet` variable after merge

## Context
The placement preview feature (matched cluster counts, footer link, clusters modal) was only wired up in the policy/policy-set wizards via `PlacementSection`. The standalone placement wizard at Infrastructure > Clusters > Placements rendered the `Placement` component without `useFeatureFlag` or `placementDebugState`, so the preview never appeared.

**Jira:** [ACM-33148](https://redhat.atlassian.net/browse/ACM-33148)
**Depends on:** #5995 (placement preview) and ACM-30639-general-wizard-updates

## Test plan
- [ ] Enable `enhancedPlacement` in console settings
- [ ] Navigate to Infrastructure > Clusters > Placements > Create placement
- [ ] Configure namespace, cluster sets, and/or label expressions
- [ ] Verify "Matched by Placement" count appears in the wizard step and footer
- [ ] Verify clicking the footer link opens the matched clusters modal
- [ ] Verify the policy wizard placement preview still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACM-33148]: https://redhat.atlassian.net/browse/ACM-33148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Placement preview visibility can now be controlled through global application settings, providing users with enhanced configuration options for the placement workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->