### PR TITLE
ACM-33256 App topology when first created shows error--should show pending

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.ts
@@ -329,7 +329,7 @@ export const getPulseStatusForArgoApp = (node: TopologyNodeWithStatus, isAppSet?
       },
       status: { health: { status: appStatus } },
     })
-  } else if (relatedApps.length === 0) {
+  } else if (relatedApps.length === 0 && !safeGet(node, 'specs.isCreating', false)) {
     return redPulse
   }
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -34,6 +34,9 @@ import {
 import { PlacementDecision } from '../../../../../resources/placement-decision'
 import { Placement } from '../../../../../resources/placement'
 
+/** Window after ApplicationSet creation during which `isCreating` is true on the topology node. */
+const APP_SET_CREATION_GRACE_PERIOD_MS = 5 * 60 * 1000
+
 /**
  * Generates topology data for ApplicationSet applications
  * Creates nodes and links representing the application structure including:
@@ -67,6 +70,10 @@ export async function getAppSetTopology(
   const { activeTypes, activeClusters, activeApplications } = toolbarControl
   const clusterNames = activeClusters && activeClusters.length > 0 ? activeClusters : allClusterNames
 
+  const creationTimestamp = application.app?.metadata?.creationTimestamp
+  const createdAt = creationTimestamp ? new Date(creationTimestamp).getTime() : NaN
+  const isCreating = Number.isFinite(createdAt) && Date.now() - createdAt < APP_SET_CREATION_GRACE_PERIOD_MS
+
   /////////////////////////////////////////////
   ////  APPLICATION SET NODE /////////////////
   /////////////////////////////////////////////
@@ -80,6 +87,7 @@ export async function getAppSetTopology(
     specs: {
       isDesign: true,
       raw: application.app,
+      isCreating,
       allClusters: {
         isLocal: allClusterNames.includes(hubClusterName),
         remoteCount: allClusterNames.includes(hubClusterName) ? allClusterNames.length - 1 : allClusterNames.length,

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/StyledNode.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/StyledNode.tsx
@@ -210,7 +210,7 @@ const renderCountDecorator = (element: Node, resourceCount: number): React.React
   const y = height / 2
 
   return (
-    <g className="pf-topology__node__decorator">
+    <g className="pf-topology__node__decorator" pointerEvents="none">
       <g transform={`translate(${x}, ${y})`}>
         <g transform={`translate(-16, -12)`}>
           <use href={'#nodeStatusIcon_clusterCount'} width={32} height={24} className={'resourceCountIcon'} />

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/StyledNode.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/StyledNode.tsx
@@ -210,7 +210,7 @@ const renderCountDecorator = (element: Node, resourceCount: number): React.React
   const y = height / 2
 
   return (
-    <g className="pf-topology__node__decorator" pointerEvents="none">
+    <g className="pf-topology__node__decorator" style={{ userSelect: 'none', pointerEvents: 'none' }}>
       <g transform={`translate(${x}, ${y})`}>
         <g transform={`translate(-16, -12)`}>
           <use href={'#nodeStatusIcon_clusterCount'} width={32} height={24} className={'resourceCountIcon'} />

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/TopologyToolbar.test.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/TopologyToolbar.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TopologyToolbar, { useToolbarControl, ToolbarControl } from './TopologyToolbar'
 import { TopologyProps } from '../Topology'
@@ -379,6 +379,93 @@ describe('TopologyToolbar tests', () => {
       // The toolbar renders with clearAllFilters callback which is connected to the Toolbar component
       // Verify the toolbar is rendered with the filter groups
       expect(container.querySelector('.pf-m-toggle-group-container')).toBeInTheDocument()
+    })
+
+    test('Clear all filters resets cluster, application, and type filters', async () => {
+      const setActiveClusters = jest.fn()
+      const setActiveApplications = jest.fn()
+      const setActiveTypes = jest.fn()
+      const setDrawerContent = jest.fn()
+      const props = createMockTopologyProps({
+        setDrawerContent,
+        toolbarControl: createMockToolbarControl({
+          allClusters: ['c1', 'c2'],
+          activeClusters: ['c1'],
+          setActiveClusters,
+          allApplications: ['a1'],
+          activeApplications: ['a1'],
+          setActiveApplications,
+          allTypes: ['Deployment'],
+          activeTypes: ['Deployment'],
+          setActiveTypes,
+        }),
+      })
+      render(<TopologyToolbar {...props} />)
+
+      const clearAll = screen.getByRole('button', { name: 'Clear all filters' })
+      await userEvent.click(clearAll)
+
+      expect(setActiveClusters).toHaveBeenCalledWith(undefined)
+      expect(setActiveApplications).toHaveBeenCalledWith(undefined)
+      expect(setActiveTypes).toHaveBeenCalledWith(undefined)
+      expect(setDrawerContent).toHaveBeenCalledWith('Close', false, true, true, true, undefined, true)
+    })
+  })
+
+  describe('Filter selection edge cases', () => {
+    /** MenuToggle for the cluster filter (label text "Clusters" also appears in the static "Clusters (n):" caption). */
+    function getClusterFilterToggle() {
+      const row = document.getElementById('row1')
+      expect(row).toBeTruthy()
+      const buttons = within(row as HTMLElement).getAllByRole('button')
+      const toggle = buttons.find(
+        (b) =>
+          b.getAttribute('aria-label') === 'Clusters' ||
+          b.textContent === 'Clusters' ||
+          /^Clusters\d*$/.test((b.textContent || '').replace(/\s/g, ''))
+      )
+      expect(toggle).toBeTruthy()
+      return toggle as HTMLElement
+    }
+
+    test('selecting "All clusters" clears active cluster filter', async () => {
+      const setActiveClusters = jest.fn()
+      const props = createMockTopologyProps({
+        toolbarControl: createMockToolbarControl({
+          allClusters: ['cluster1', 'cluster2'],
+          activeClusters: ['cluster1'],
+          setActiveClusters,
+        }),
+      })
+      render(<TopologyToolbar {...props} />)
+
+      await userEvent.click(getClusterFilterToggle())
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+      })
+      await userEvent.click(within(screen.getByRole('menu')).getByText('All clusters'))
+
+      expect(setActiveClusters).toHaveBeenCalledWith(undefined)
+    })
+
+    test('deselecting a cluster removes it from active filters', async () => {
+      const setActiveClusters = jest.fn()
+      const props = createMockTopologyProps({
+        toolbarControl: createMockToolbarControl({
+          allClusters: ['cluster1', 'cluster2'],
+          activeClusters: ['cluster1'],
+          setActiveClusters,
+        }),
+      })
+      render(<TopologyToolbar {...props} />)
+
+      await userEvent.click(getClusterFilterToggle())
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+      })
+      await userEvent.click(within(screen.getByRole('menu')).getByText('cluster1'))
+
+      expect(setActiveClusters).toHaveBeenCalledWith(undefined)
     })
   })
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/TopologyToolbar.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/TopologyToolbar.tsx
@@ -152,10 +152,11 @@ const TopologyToolbar: FC<TopologyProps> = (topologyProps) => {
     setDrawerContent?.('Close', false, true, true, true, undefined, true)
   }
 
-  const onDelete = (type: string, id: string) => {
+  const onDelete = (type: string, id: string | { key: string; node: unknown }) => {
+    const itemKey = typeof id === 'object' && id !== null && 'key' in id ? id.key : id
     const config = filterConfigs.find((c) => c.key === type)
     if (config) {
-      config.setActive(config.activeItems?.filter((item) => item !== id))
+      config.setActive(config.activeItems?.filter((item) => item !== itemKey))
     } else {
       filterConfigs.forEach((c) => c.setActive(undefined))
     }
@@ -188,7 +189,9 @@ const TopologyToolbar: FC<TopologyProps> = (topologyProps) => {
           <ToolbarFilter
             key={config.key}
             labels={config.activeItems?.map((item) => ({ key: item, node: item }))}
-            deleteLabel={(category, label) => onDelete(category as string, label as string)}
+            deleteLabel={(category, label) =>
+              onDelete(category as string, label as string | { key: string; node: unknown })
+            }
             deleteLabelGroup={(category) => onDeleteGroup(category as string)}
             categoryName={config.key}
           >

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/componentFactory.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/componentFactory.ts
@@ -6,12 +6,12 @@ import {
   GraphComponent,
   GraphElement,
   ComponentFactory,
-  withDragNode,
   withSelection,
   WithSelectionProps,
 } from '@patternfly/react-topology'
 
 import StyledNode from './StyledNode'
+import { withDragNodeMinDistance } from './withDragNodeMinDistance'
 import StyledEdge from './StyledEdge'
 
 const defaultComponentFactory: ComponentFactory = (
@@ -23,7 +23,7 @@ const defaultComponentFactory: ComponentFactory = (
       // @ts-ignore: Fixed in next pf topology
       return withPanZoom()(GraphComponent)
     case ModelKind.node:
-      return withDragNode()(withSelection()(StyledNode as any as ComponentType<WithSelectionProps>))
+      return withDragNodeMinDistance()(withSelection()(StyledNode as any as ComponentType<WithSelectionProps>))
     case ModelKind.edge:
       return StyledEdge as any as ComponentType<{ element: GraphElement }>
     default:

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/componentFactory.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/componentFactory.ts
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-topology'
 
 import StyledNode from './StyledNode'
-import { withDragNodeMinDistance } from './withDragNodeMinDistance'
+import { withDragNodeAfterThreshold } from '../contexts/withDragNodeAfterThreshold'
 import StyledEdge from './StyledEdge'
 
 const defaultComponentFactory: ComponentFactory = (
@@ -23,7 +23,7 @@ const defaultComponentFactory: ComponentFactory = (
       // @ts-ignore: Fixed in next pf topology
       return withPanZoom()(GraphComponent)
     case ModelKind.node:
-      return withDragNodeMinDistance()(withSelection()(StyledNode as any as ComponentType<WithSelectionProps>))
+      return withDragNodeAfterThreshold()(withSelection()(StyledNode as any as ComponentType<WithSelectionProps>))
     case ModelKind.edge:
       return StyledEdge as any as ComponentType<{ element: GraphElement }>
     default:

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/withDragNodeMinDistance.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/withDragNodeMinDistance.tsx
@@ -1,0 +1,173 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { useContext, useRef, useMemo, type ComponentType, type FunctionComponent } from 'react'
+import {
+  action,
+  observer,
+  Controller,
+  ElementContext,
+  isNode,
+  Node,
+  useDndDrag,
+  useDndManager,
+  WithDragNodeProps,
+  Modifiers,
+  DragSourceSpec,
+  DragEvent,
+  DragObjectWithType,
+  DragSpecOperationType,
+  DragOperationWithType,
+  DragSourceMonitor,
+  DRAG_NODE_EVENT,
+  DRAG_NODE_START_EVENT,
+  DRAG_NODE_END_EVENT,
+  DRAG_MOVE_OPERATION,
+  SELECTION_EVENT,
+} from '@patternfly/react-topology'
+
+const defaultOperation = {
+  [Modifiers.DEFAULT]: { type: DRAG_MOVE_OPERATION },
+}
+
+/** Ignore pointer movement until Chebyshev distance from drag start exceeds this many pixels. */
+const DEFAULT_MIN_DRAG_PX = 4
+
+export const withDragNodeMinDistance =
+  <
+    DragObject extends DragObjectWithType = DragObjectWithType,
+    DropResult = any,
+    CollectedProps extends object = object,
+    Props extends object = object,
+  >(
+    spec?: Omit<
+      DragSourceSpec<DragObject, DragSpecOperationType<DragOperationWithType>, DropResult, CollectedProps, Props>,
+      'item'
+    > & {
+      item?: DragObject
+    },
+    minDragPx: number = DEFAULT_MIN_DRAG_PX
+  ) =>
+  <P extends WithDragNodeProps & CollectedProps & Props>(WrappedComponent: ComponentType<P>) => {
+    const Component: FunctionComponent<Omit<P, keyof WithDragNodeProps>> = (props) => {
+      const element = useContext(ElementContext)
+      if (!isNode(element)) {
+        throw new Error('withDragNodeMinDistance must wrap a component used within the scope of a Node')
+      }
+      const elementRef = useRef(element)
+      elementRef.current = element
+
+      const activatedRef = useRef(false)
+      const dndManager = useDndManager()
+
+      const [dragNodeProps, dragNodeRef] = useDndDrag(
+        useMemo(() => {
+          const sourceSpec: DragSourceSpec<any, any, any, any, Props> = {
+            item: (spec && spec.item) || { type: '#useDragNode#' },
+            operation: (monitor: DragSourceMonitor, p: Props) => {
+              if (spec) {
+                const operation = typeof spec.operation === 'function' ? spec.operation(monitor, p) : spec.operation
+                if (typeof operation === 'object' && Object.keys(operation).length > 0) {
+                  return {
+                    ...defaultOperation,
+                    ...operation,
+                  }
+                }
+              }
+              return defaultOperation
+            },
+            begin: (monitor, p) => {
+              activatedRef.current = false
+              elementRef.current.raise()
+              if (elementRef.current.isGroup()) {
+                elementRef.current.getChildren().forEach((c) => {
+                  c.raise()
+                })
+              }
+
+              const result = spec && spec.begin && spec.begin(monitor, p)
+
+              elementRef.current
+                .getController()
+                .fireEvent(DRAG_NODE_START_EVENT, elementRef.current, monitor.getDragEvent(), monitor.getOperation())
+
+              return result || elementRef.current
+            },
+            drag: (event: DragEvent, monitor, p) => {
+              const { initialX, initialY, x, y, dx, dy } = event
+              if (Math.max(Math.abs(x - initialX), Math.abs(y - initialY)) <= minDragPx) {
+                return
+              }
+
+              function moveElement(e: Node, tx: number, ty: number) {
+                let moved = true
+                if (e.isGroup()) {
+                  const nodeChildren = e.getChildren().filter(isNode)
+                  if (nodeChildren.length) {
+                    moved = false
+                    nodeChildren.forEach((child) => moveElement(child, tx, ty))
+                  }
+                }
+                if (moved) {
+                  e.setPosition(e.getPosition().clone().translate(tx, ty))
+                }
+              }
+
+              if (!activatedRef.current) {
+                activatedRef.current = true
+                moveElement(elementRef.current, x - initialX, y - initialY)
+              } else {
+                moveElement(elementRef.current, dx, dy)
+              }
+
+              if (spec?.drag) {
+                spec.drag(event, monitor, p)
+              }
+
+              elementRef.current
+                .getController()
+                .fireEvent(DRAG_NODE_EVENT, elementRef.current, event, monitor.getOperation())
+            },
+            canDrag: spec ? spec.canDrag : undefined,
+            end: async (dropResult, monitor, p) => {
+              const didMovePastThreshold = activatedRef.current
+              activatedRef.current = false
+              let controller: Controller
+              try {
+                controller = elementRef.current.getController()
+              } catch {
+                return
+              }
+
+              if (spec && spec.end) {
+                try {
+                  await spec.end(dropResult, monitor, p)
+                } catch {
+                  dndManager.cancel()
+                }
+              }
+
+              action(() => {
+                controller.fireEvent(
+                  DRAG_NODE_END_EVENT,
+                  elementRef.current,
+                  monitor.getDragEvent(),
+                  monitor.getOperation()
+                )
+              })()
+
+              // d3 drag prevents the native click; treat sub-threshold gesture as a click for selection.
+              if (!didMovePastThreshold && !monitor.isCancelled()) {
+                controller.fireEvent(SELECTION_EVENT, [elementRef.current.getId()])
+              }
+            },
+            collect: spec ? spec.collect : undefined,
+            canCancel: spec ? spec.canCancel : true,
+          }
+          return sourceSpec
+        }, [dndManager]),
+        props as any
+      )
+      return <WrappedComponent {...(props as any)} dragNodeRef={dragNodeRef} {...dragNodeProps} />
+    }
+    Component.displayName = `withDragNodeMinDistance(${WrappedComponent.displayName || WrappedComponent.name})`
+    return observer(Component)
+  }

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.test.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.test.tsx
@@ -163,18 +163,10 @@ describe('withDragNodeAfterThreshold', () => {
 
     lastSpec.begin!(monitor, {})
 
-    lastSpec.drag!(
-      { initialX: 0, initialY: 0, x: 3, y: 3, dx: 3, dy: 3 } as DragEvent,
-      monitor,
-      {}
-    )
+    lastSpec.drag!({ initialX: 0, initialY: 0, x: 3, y: 3, dx: 3, dy: 3 } as DragEvent, monitor, {})
     expect(node.setPosition).not.toHaveBeenCalled()
 
-    lastSpec.drag!(
-      { initialX: 0, initialY: 0, x: 5, y: 0, dx: 5, dy: 0 } as DragEvent,
-      monitor,
-      {}
-    )
+    lastSpec.drag!({ initialX: 0, initialY: 0, x: 5, y: 0, dx: 5, dy: 0 } as DragEvent, monitor, {})
     expect(node.setPosition).toHaveBeenCalled()
   })
 
@@ -187,11 +179,7 @@ describe('withDragNodeAfterThreshold', () => {
     } as unknown as DragSourceMonitor
     lastSpec.begin!(monitor, {})
 
-    lastSpec.drag!(
-      { initialX: 0, initialY: 0, x: 10, y: 0, dx: 10, dy: 0 } as DragEvent,
-      monitor,
-      {}
-    )
+    lastSpec.drag!({ initialX: 0, initialY: 0, x: 10, y: 0, dx: 10, dy: 0 } as DragEvent, monitor, {})
 
     expect(node.getController().fireEvent).toHaveBeenCalledWith(DRAG_NODE_EVENT, node, expect.anything(), 'op')
   })
@@ -221,11 +209,7 @@ describe('withDragNodeAfterThreshold', () => {
     } as unknown as DragSourceMonitor
 
     lastSpec.begin!(monitor, {})
-    lastSpec.drag!(
-      { initialX: 0, initialY: 0, x: 5, y: 0, dx: 5, dy: 0 } as DragEvent,
-      monitor,
-      {}
-    )
+    lastSpec.drag!({ initialX: 0, initialY: 0, x: 5, y: 0, dx: 5, dy: 0 } as DragEvent, monitor, {})
     ;(node.getController().fireEvent as jest.Mock).mockClear()
 
     await lastSpec.end!(undefined, monitor, {})

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.test.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.test.tsx
@@ -1,0 +1,247 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import type { DragEvent, DragSourceMonitor } from '@patternfly/react-topology'
+import {
+  ElementContext,
+  ModelKind,
+  SELECTION_EVENT,
+  DRAG_NODE_START_EVENT,
+  DRAG_NODE_EVENT,
+  DRAG_NODE_END_EVENT,
+} from '@patternfly/react-topology'
+import type { Node } from '@patternfly/react-topology'
+import { withDragNodeAfterThreshold } from './withDragNodeAfterThreshold'
+
+const useDndDragMock = jest.fn()
+
+jest.mock('@patternfly/react-topology', () => {
+  const actual = jest.requireActual('@patternfly/react-topology')
+  return {
+    ...actual,
+    useDndDrag: (...args: unknown[]) => useDndDragMock(...args),
+    useDndManager: jest.fn(() => ({ cancel: jest.fn() })),
+    observer: (Component: React.ComponentType) => Component,
+  }
+})
+
+type DragSpec = {
+  item?: unknown
+  operation?: unknown
+  begin?: (monitor: DragSourceMonitor, p: object) => unknown
+  drag?: (event: DragEvent, monitor: DragSourceMonitor, p: object) => void
+  end?: (dropResult: unknown, monitor: DragSourceMonitor, p: object) => Promise<void> | void
+  canDrag?: unknown
+  collect?: unknown
+  canCancel?: unknown
+}
+
+function createMockNode(): Node {
+  const fireEvent = jest.fn()
+  const controller = { fireEvent }
+  const translateResult = { x: 0, y: 0 }
+  const cloneObj = {
+    translate: jest.fn((tx: number, ty: number) => {
+      translateResult.x += tx
+      translateResult.y += ty
+      return translateResult
+    }),
+  }
+  const position = {
+    clone: jest.fn(() => cloneObj),
+  }
+  return {
+    getKind: () => ModelKind.node,
+    raise: jest.fn(),
+    isGroup: jest.fn(() => false),
+    getChildren: jest.fn(() => []),
+    getController: jest.fn(() => controller),
+    getId: () => 'test-node-id',
+    getPosition: jest.fn(() => position),
+    setPosition: jest.fn(),
+  } as unknown as Node
+}
+
+/** Avoid spreading drag props onto the DOM; collected props can override JSX children. */
+const Inner: React.FC<{ dragNodeRef?: React.Ref<unknown> } & Record<string, unknown>> = () => (
+  <div id="inner-node">inner</div>
+)
+
+function renderWrapped(spec?: Parameters<typeof withDragNodeAfterThreshold>[0], thresholdPx?: number, node?: Node) {
+  const Wrapped = withDragNodeAfterThreshold(spec, thresholdPx)(Inner)
+  const element = node ?? createMockNode()
+  return {
+    ...render(
+      <ElementContext.Provider value={element}>
+        <Wrapped />
+      </ElementContext.Provider>
+    ),
+    node: element,
+  }
+}
+
+describe('withDragNodeAfterThreshold', () => {
+  let lastSpec: DragSpec
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useDndDragMock.mockImplementation((spec: DragSpec) => {
+      lastSpec = spec
+      return [{ dragging: false }, jest.fn()]
+    })
+  })
+
+  test('throws when ElementContext is not a Node', () => {
+    const Wrapped = withDragNodeAfterThreshold()(Inner)
+    const BadContext = { getKind: () => ModelKind.graph } as unknown as Node
+
+    expect(() =>
+      render(
+        <ElementContext.Provider value={BadContext}>
+          <Wrapped />
+        </ElementContext.Provider>
+      )
+    ).toThrow('withDragNodeAfterThreshold must wrap a component used within the scope of a Node')
+  })
+
+  test('renders wrapped component and wires useDndDrag', () => {
+    renderWrapped()
+    expect(screen.getByTestId('inner-node')).toBeInTheDocument()
+    expect(useDndDragMock).toHaveBeenCalled()
+    expect(lastSpec.item).toEqual({ type: '#useDragNode#' })
+  })
+
+  test('uses custom spec.item when provided', () => {
+    const customItem = { type: 'custom' }
+    renderWrapped({ item: customItem })
+    expect(lastSpec.item).toEqual(customItem)
+  })
+
+  test('begin raises node and fires DRAG_NODE_START_EVENT', () => {
+    const node = createMockNode()
+    const monitor = {
+      getDragEvent: jest.fn(),
+      getOperation: jest.fn(() => 'move'),
+    } as unknown as DragSourceMonitor
+
+    renderWrapped(undefined, undefined, node)
+    const result = lastSpec.begin!(monitor, {})
+
+    expect(node.raise).toHaveBeenCalled()
+    expect(node.getController().fireEvent).toHaveBeenCalledWith(
+      DRAG_NODE_START_EVENT,
+      node,
+      monitor.getDragEvent(),
+      monitor.getOperation()
+    )
+    expect(result).toBe(node)
+  })
+
+  test('begin invokes spec.begin when provided', () => {
+    const specBegin = jest.fn(() => 'from-spec')
+    const node = createMockNode()
+    const monitor = {
+      getDragEvent: jest.fn(),
+      getOperation: jest.fn(() => 'move'),
+    } as unknown as DragSourceMonitor
+
+    renderWrapped({ begin: specBegin }, undefined, node)
+    const result = lastSpec.begin!(monitor, {})
+
+    expect(specBegin).toHaveBeenCalledWith(monitor, {})
+    expect(result).toBe('from-spec')
+  })
+
+  test('drag does not move node until Chebyshev distance exceeds threshold', () => {
+    const node = createMockNode()
+    renderWrapped(undefined, 4, node)
+    const monitor = {
+      getDragEvent: jest.fn(),
+      getOperation: jest.fn(),
+    } as unknown as DragSourceMonitor
+
+    lastSpec.begin!(monitor, {})
+
+    lastSpec.drag!(
+      { initialX: 0, initialY: 0, x: 3, y: 3, dx: 3, dy: 3 } as DragEvent,
+      monitor,
+      {}
+    )
+    expect(node.setPosition).not.toHaveBeenCalled()
+
+    lastSpec.drag!(
+      { initialX: 0, initialY: 0, x: 5, y: 0, dx: 5, dy: 0 } as DragEvent,
+      monitor,
+      {}
+    )
+    expect(node.setPosition).toHaveBeenCalled()
+  })
+
+  test('drag fires DRAG_NODE_EVENT after threshold', () => {
+    const node = createMockNode()
+    renderWrapped(undefined, 2, node)
+    const monitor = {
+      getDragEvent: jest.fn(),
+      getOperation: jest.fn(() => 'op'),
+    } as unknown as DragSourceMonitor
+    lastSpec.begin!(monitor, {})
+
+    lastSpec.drag!(
+      { initialX: 0, initialY: 0, x: 10, y: 0, dx: 10, dy: 0 } as DragEvent,
+      monitor,
+      {}
+    )
+
+    expect(node.getController().fireEvent).toHaveBeenCalledWith(DRAG_NODE_EVENT, node, expect.anything(), 'op')
+  })
+
+  test('end fires SELECTION_EVENT when drag stayed within threshold', async () => {
+    const node = createMockNode()
+    renderWrapped(undefined, 10, node)
+    const monitor = {
+      getDragEvent: jest.fn(),
+      getOperation: jest.fn(() => 'move'),
+      isCancelled: jest.fn(() => false),
+    } as unknown as DragSourceMonitor
+
+    lastSpec.begin!(monitor, {})
+    await lastSpec.end!(undefined, monitor, {})
+
+    expect(node.getController().fireEvent).toHaveBeenCalledWith(SELECTION_EVENT, ['test-node-id'])
+  })
+
+  test('end does not fire SELECTION_EVENT when node moved past threshold', async () => {
+    const node = createMockNode()
+    renderWrapped(undefined, 2, node)
+    const monitor = {
+      getDragEvent: jest.fn(),
+      getOperation: jest.fn(() => 'move'),
+      isCancelled: jest.fn(() => false),
+    } as unknown as DragSourceMonitor
+
+    lastSpec.begin!(monitor, {})
+    lastSpec.drag!(
+      { initialX: 0, initialY: 0, x: 5, y: 0, dx: 5, dy: 0 } as DragEvent,
+      monitor,
+      {}
+    )
+    ;(node.getController().fireEvent as jest.Mock).mockClear()
+
+    await lastSpec.end!(undefined, monitor, {})
+
+    expect(node.getController().fireEvent).not.toHaveBeenCalledWith(SELECTION_EVENT, ['test-node-id'])
+    expect(node.getController().fireEvent).toHaveBeenCalledWith(
+      DRAG_NODE_END_EVENT,
+      node,
+      monitor.getDragEvent(),
+      monitor.getOperation()
+    )
+  })
+
+  test('wrapped component displayName mentions HOC', () => {
+    Inner.displayName = 'InnerDisplay'
+    const Wrapped = withDragNodeAfterThreshold()(Inner)
+    expect(Wrapped.displayName).toBe('withDragNodeAfterThreshold(InnerDisplay)')
+  })
+})

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.test.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.test.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
-import type { DragEvent, DragSourceMonitor } from '@patternfly/react-topology'
+import type { DragEvent, DragSourceMonitor, WithDragNodeProps } from '@patternfly/react-topology'
 import {
   ElementContext,
   ModelKind,
@@ -64,9 +64,7 @@ function createMockNode(): Node {
 }
 
 /** Avoid spreading drag props onto the DOM; collected props can override JSX children. */
-const Inner: React.FC<{ dragNodeRef?: React.Ref<unknown> } & Record<string, unknown>> = () => (
-  <div id="inner-node">inner</div>
-)
+const Inner: React.FC<WithDragNodeProps> = () => <div id="inner-node">inner</div>
 
 function renderWrapped(spec?: Parameters<typeof withDragNodeAfterThreshold>[0], thresholdPx?: number, node?: Node) {
   const Wrapped = withDragNodeAfterThreshold(spec, thresholdPx)(Inner)

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/contexts/withDragNodeAfterThreshold.tsx
@@ -29,9 +29,9 @@ const defaultOperation = {
 }
 
 /** Ignore pointer movement until Chebyshev distance from drag start exceeds this many pixels. */
-const DEFAULT_MIN_DRAG_PX = 4
+const DEFAULT_THRESHOLD_PX = 4
 
-export const withDragNodeMinDistance =
+export const withDragNodeAfterThreshold =
   <
     DragObject extends DragObjectWithType = DragObjectWithType,
     DropResult = any,
@@ -44,13 +44,13 @@ export const withDragNodeMinDistance =
     > & {
       item?: DragObject
     },
-    minDragPx: number = DEFAULT_MIN_DRAG_PX
+    thresholdPx: number = DEFAULT_THRESHOLD_PX
   ) =>
   <P extends WithDragNodeProps & CollectedProps & Props>(WrappedComponent: ComponentType<P>) => {
     const Component: FunctionComponent<Omit<P, keyof WithDragNodeProps>> = (props) => {
       const element = useContext(ElementContext)
       if (!isNode(element)) {
-        throw new Error('withDragNodeMinDistance must wrap a component used within the scope of a Node')
+        throw new Error('withDragNodeAfterThreshold must wrap a component used within the scope of a Node')
       }
       const elementRef = useRef(element)
       elementRef.current = element
@@ -93,7 +93,7 @@ export const withDragNodeMinDistance =
             },
             drag: (event: DragEvent, monitor, p) => {
               const { initialX, initialY, x, y, dx, dy } = event
-              if (Math.max(Math.abs(x - initialX), Math.abs(y - initialY)) <= minDragPx) {
+              if (Math.max(Math.abs(x - initialX), Math.abs(y - initialY)) <= thresholdPx) {
                 return
               }
 
@@ -168,6 +168,6 @@ export const withDragNodeMinDistance =
       )
       return <WrappedComponent {...(props as any)} dragNodeRef={dragNodeRef} {...dragNodeProps} />
     }
-    Component.displayName = `withDragNodeMinDistance(${WrappedComponent.displayName || WrappedComponent.name})`
+    Component.displayName = `withDragNodeAfterThreshold(${WrappedComponent.displayName || WrappedComponent.name})`
     return observer(Component)
   }

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/css/topology-view.css
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/css/topology-view.css
@@ -14,6 +14,10 @@
 .pf-topology-connector-arrow {
   fill: #808080;
 }
+
+.pf-topology__node__label {
+  user-select: none;
+}
 .pf-v5-c-drawer__body:last-child {
   height: 100%;
 }

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/layout/TreeLayout.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/layout/TreeLayout.test.ts
@@ -7808,6 +7808,6 @@ const calculateNodeOffsets2 = {
         dy: -270,
       },
     },
-    layout: 'ColaTreeLayout',
+    layout: 'TreeLayout',
   },
 }

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/layout/TreeLayout.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/layout/TreeLayout.ts
@@ -116,7 +116,7 @@ export function calculateNodeOffsets(elements: { nodes: any[]; links: any[] }, o
     setRowX(metrics, nodeOffsetMap, options)
     placePairedNodes(metrics, nodeOffsetMap, pairedNodes, options)
   }
-  return { nodeOffsetMap, layoutType: 'TreeLayout' }
+  return { nodeOffsetMap, layout: 'TreeLayout' }
 }
 
 function groupNodesByConnections(elements: { nodes: any[]; links: any[] }) {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/layout/TreeLayout.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/layout/TreeLayout.ts
@@ -1,15 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import {
-  ColaGroup,
-  ColaLayout,
-  ColaLink,
-  ColaNode,
-  Graph,
-  LayoutNode,
-  NodeModel,
-  ColaLayoutOptions,
-  LayoutOptions,
-} from '@patternfly/react-topology'
+import { Graph, ColaLayout, LayoutNode, NodeModel, ColaLayoutOptions, LayoutOptions } from '@patternfly/react-topology'
 import get from 'lodash/get'
 import chunk from 'lodash/chunk'
 import uniqBy from 'lodash/uniqBy'
@@ -109,29 +99,6 @@ class TreeLayout extends ColaLayout {
       super.startLayout(graph, initialRun, addingNodes)
     }
   }
-
-  protected getConstraints(nodes: ColaNode[], groups: ColaGroup[], edges: ColaLink[]): any[] {
-    const constraints = super.getConstraints(nodes, groups, edges)
-    if (!this.treeOptions.useCola) {
-      return constraints
-    }
-    edges.forEach((edge) => {
-      const target = edge.target as ColaNode
-      const source = edge.source as ColaNode
-      const specs = target.element.getData()?.specs as { isPairedInLayoutWithParent?: boolean } | undefined
-      if (specs?.isPairedInLayoutWithParent) {
-        constraints.push({
-          type: 'alignment',
-          axis: 'y',
-          offsets: [
-            { node: source.index, offset: 0 },
-            { node: target.index, offset: PAIRED_LAYOUT_DY_OFFSET_FROM_PARENT },
-          ],
-        })
-      }
-    })
-    return constraints
-  }
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -140,7 +107,6 @@ class TreeLayout extends ColaLayout {
 export function calculateNodeOffsets(elements: { nodes: any[]; links: any[] }, options: TreeLayoutOptions) {
   const nodeOffsetMap: NodeOffsetMapType = {}
   const _elements = cloneDeep(elements)
-  let layout = 'TreeLayout'
   if (_elements.nodes.length) {
     const metrics: MetricsType = groupNodesByConnections(_elements)
     addRootsLeavesToConnectedGroups(metrics)
@@ -149,11 +115,8 @@ export function calculateNodeOffsets(elements: { nodes: any[]; links: any[] }, o
     setRowY(metrics, nodeOffsetMap, options)
     setRowX(metrics, nodeOffsetMap, options)
     placePairedNodes(metrics, nodeOffsetMap, pairedNodes, options)
-    if (pairedNodes.length > 1) {
-      layout = 'ColaTreeLayout'
-    }
   }
-  return { nodeOffsetMap, layout }
+  return { nodeOffsetMap, layoutType: 'TreeLayout' }
 }
 
 function groupNodesByConnections(elements: { nodes: any[]; links: any[] }) {

--- a/frontend/src/routes/Search/Details/SnapshotsTab.test.tsx
+++ b/frontend/src/routes/Search/Details/SnapshotsTab.test.tsx
@@ -201,11 +201,11 @@ describe('SnapshotsTab', () => {
       </RecoilRoot>
     )
     // Wait for managed cluster view requests to finish
-    await waitForNocks([getCanCreateMCVNock, ...mcvNocks])
     await wait()
     // Test that the component has rendered errors correctly
     await waitFor(() => expect(screen.queryByText('An unexpected error occurred.')).toBeTruthy())
     await waitFor(() => expect(screen.queryByText('Error getting search data')).toBeTruthy())
+    await waitForNocks([getCanCreateMCVNock, ...mcvNocks])
   })
 
   it('should render tab with correct snapshot data from search', async () => {
@@ -290,11 +290,11 @@ describe('SnapshotsTab', () => {
       </RecoilRoot>
     )
     // Wait for managed cluster view requests to finish
-    await waitForNocks([getCanCreateMCVNock, ...mcvNocks])
     await wait()
     // Test that the component has rendered correctly with data
     await waitFor(() => expect(screen.queryByText('centos-stream9-snapshot-20250327135448211')).toBeTruthy())
     await waitFor(() => expect(screen.queryByText('centos-stream9-snapshot-20250325211107690')).toBeTruthy())
+    await waitForNocks([getCanCreateMCVNock, ...mcvNocks])
   })
 
   it('should render tab with correct snapshot data using fine-grained RBAC', async () => {
@@ -385,10 +385,10 @@ describe('SnapshotsTab', () => {
       </RecoilRoot>
     )
     // Wait for vm requests to finish
-    await waitForNocks([getVMNock])
     await wait()
     // Test that the component has rendered correctly with data
     await waitFor(() => expect(screen.queryByText('centos-stream9-snapshot-20250327135448211')).toBeTruthy())
     await waitFor(() => expect(screen.queryByText('centos-stream9-snapshot-20250325211107690')).toBeTruthy())
+    await waitForNocks([getVMNock])
   })
 })


### PR DESCRIPTION
# 📝 Summary
1. when appset is first created, it has no generated apps--we want to make this an error if the appset has existed awhile but not right away--so I added a timeout of 5 minutes after the appset is created to show as pending, if still not there it's an error

>   const creationTimestamp = application.app?.metadata?.creationTimestamp
>   const createdAt = creationTimestamp ? new Date(creationTimestamp).getTime() : NaN
>   const isCreating = Number.isFinite(createdAt) && Date.now() - createdAt < APP_SET_CREATION_GRACE_PERIOD_MS
> 

2. when clicking on a node in topology, if the mouse moves just a pixel before you release the mouse the click is considered a dnd and nothing happens (details view doesn't appear) ---added a new DND handler the doesn't consider a click to be a dnd unless the mouse moves 4 pixels:

see withDragNodeAfterThreshold

3. clicking this close button in apptoolbar wasn't working:
<img width="782" height="180" alt="CleanShot 2026-04-27 at 14 32 29@2x" src="https://github.com/user-attachments/assets/aab2ec5e-44d7-4c6e-8f90-9b9caa594037" />

4. appset layout was messy :)

**Ticket Summary (Title):**  
App topology when first created shows error--should show pending

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33256

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ApplicationSet nodes no longer show a false error during initial creation.
  * Cluster-count decorators no longer block mouse/touch interactions.

* **New Features**
  * Node dragging now activates only after a small deliberate movement to avoid accidental drags.

* **UI Improvements**
  * Consistent topology layout labeling and more robust toolbar filter deletion behavior.
  * Node labels made non-selectable to improve interaction.

* **Tests**
  * Added coverage for drag-threshold behavior, toolbar filters, layout labeling, and related interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->