### PR TITLE
ACM-32805 - ACM-32863: Update axios to 0.31.0 & 1.15.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "@stolostron/react-data-view": "^1.14.0",
         "@tanstack/react-query": "^4.36.1",
         "ajv": "8.11.0",
-        "axios": "^0.30.3",
+        "axios": "^0.31.1",
         "cidr-tools": "4.3.0",
         "debounce": "1.2.1",
         "deep-diff": "1.0.2",
@@ -5973,14 +5973,23 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared": {
@@ -5994,14 +6003,23 @@
       }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/javascript-clients-shared/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
@@ -6016,14 +6034,23 @@
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/rbac-client/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@redhat-cloud-services/rule-components": {
@@ -11744,9 +11771,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
-      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.31.1.tgz",
+      "integrity": "sha512-Ef8DUZSZQP6igY48mjGaoEjwhely97lserep0IFJifBH4YdKvwH5eMLniy3kig2HQoBNR8EkZpDjowxwTJcmbg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
     "@stolostron/react-data-view": "^1.14.0",
     "@tanstack/react-query": "^4.36.1",
     "ajv": "8.11.0",
-    "axios": "^0.30.3",
+    "axios": "^0.31.1",
     "cidr-tools": "4.3.0",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",


### PR DESCRIPTION
Updated axios to 0.31.0 & 1.15.0 to fix [CVE-2025-62718](https://www.cve.org/CVERecord?id=CVE-2025-62718) & [CVE-2026-40175](https://www.cve.org/CVERecord?id=CVE-2026-40175) on MCE 2.6

[ACM-32805](https://redhat.atlassian.net/browse/ACM-32805)
[ACM-32863](https://redhat.atlassian.net/browse/ACM-32863)

[ACM-32805]: https://redhat.atlassian.net/browse/ACM-32805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-32863]: https://redhat.atlassian.net/browse/ACM-32863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ