### PR TITLE
ACM-32805: Add --ignore-scripts to frontend npm ci in Konflux builds

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -9,7 +9,7 @@ COPY . .
 # Running installs concurrently fails on aarch64
 RUN npm ci --omit=optional --unsafe-perm --ignore-scripts
 RUN cd backend && npm ci --omit=optional  --unsafe-perm  --ignore-scripts
-RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm
+RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm --ignore-scripts
 RUN npm run build:backend
 RUN cd frontend && npm run build:plugin:acm
 

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -9,7 +9,7 @@ COPY . .
 # Running installs concurrently fails on aarch64
 RUN npm ci --omit=optional --unsafe-perm --ignore-scripts
 RUN cd backend && npm ci --omit=optional  --unsafe-perm --ignore-scripts
-RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm
+RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm --ignore-scripts
 RUN npm run build:backend
 RUN cd frontend && npm run build:plugin:mce
 


### PR DESCRIPTION
## Summary
- The s390x Konflux builder runs out of memory (`ENOMEM` / exit code 244) during `npm ci` for the frontend, starting with the axios update in `b5459c92f`.
- Adds `--ignore-scripts` to the frontend `npm ci` step in both `Containerfile.acm.konflux` and `Containerfile.mce.konflux`, matching the root and backend install steps which already use it.
- This aligns with the `main` branch approach which sets `NPM_CONFIG_IGNORE_SCRIPTS=true` globally.

## Root Cause (maybe?)
The axios 0.30.3 → 0.31.1 update (and transitive axios 1.13.6 → 1.15.2) added ~3 new packages which pushed the s390x builder past its memory limit. The frontend `npm ci` was the only install step not using `--ignore-scripts`, causing postinstall scripts (core-js, esbuild) to spike peak memory.

## Test plan
- [ ] Verify s390x Konflux build passes on this branch
- [ ] Verify amd64, arm64, ppc64le builds still pass
- [ ] Verify the ACM and MCE plugin builds produce working artifacts
