### PR TITLE
ACM-33393 Duplicate pods in Appset topology when selecting multiple clusters

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
@@ -223,7 +223,6 @@ export const processMultiples = (
       }
     }
   })
-  return resources
 }
 
 // Resource types that typically have pods as children

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
@@ -200,32 +200,29 @@ export const processMultiples = (
   numOfDeployedClusters: number = 0
 ): Array<Record<string, unknown>> => {
   // Need to multiply the number of success clusters
-  const rCount = numOfDeployedClusters > 0 ? resources.length * numOfDeployedClusters : resources.length
-  if (rCount > 5) {
-    const groupByKind: Record<string, Array<Record<string, unknown>>> = {}
-    resources.forEach((resource) => {
-      const kind = resource.kind as string
-      if (!groupByKind[kind]) {
-        groupByKind[kind] = []
+  const groupByKind: Record<string, Array<Record<string, unknown>>> = {}
+  resources.forEach((resource) => {
+    const kind = resource.kind as string
+    if (!groupByKind[kind]) {
+      groupByKind[kind] = []
+    }
+    groupByKind[kind].push(resource)
+  })
+  return Object.entries(groupByKind).map(([kind, resourcesGroup]) => {
+    const typedResourcesGroup = resourcesGroup as Array<Record<string, unknown>>
+    if (typedResourcesGroup.length === 1) {
+      return typedResourcesGroup[0]
+    } else {
+      return {
+        kind,
+        name: '',
+        namespace: '',
+        resources: typedResourcesGroup,
+        resourceCount:
+          numOfDeployedClusters > 0 ? typedResourcesGroup.length * numOfDeployedClusters : typedResourcesGroup.length,
       }
-      groupByKind[kind].push(resource)
-    })
-    return Object.entries(groupByKind).map(([kind, resourcesGroup]) => {
-      const typedResourcesGroup = resourcesGroup as Array<Record<string, unknown>>
-      if (typedResourcesGroup.length === 1) {
-        return typedResourcesGroup[0]
-      } else {
-        return {
-          kind,
-          name: '',
-          namespace: '',
-          resources: typedResourcesGroup,
-          resourceCount:
-            numOfDeployedClusters > 0 ? typedResourcesGroup.length * numOfDeployedClusters : typedResourcesGroup.length,
-        }
-      }
-    })
-  }
+    }
+  })
   return resources
 }
 


### PR DESCRIPTION
# 📝 Summary

turns out the problem was the appset had < 5 resources deployed which hit an old threshold for subscription
deleted threshold

**Ticket Summary (Title):**  
Duplicate pods in Appset topology when selecting multiple clusters

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33393

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced resource grouping logic in Application Topology for consistent organization of resources across deployed clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->