### PR TITLE
ACM-33392 Matched Clusters is always 0 in appset placement decision topology pod

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts
@@ -391,7 +391,7 @@ function addK8Details(
   )
 
   if (type === 'placement' || type === 'placementDecision') {
-    const specNbOfClustersTarget = node?.specs?.raw?.status?.numberOfSelectedClusters ?? 0
+    const specNbOfClustersTarget = node?.specs?.raw?.status?.decisions?.length ?? 0
 
     // placementDecision
     const clusterSets = node?.placementDecision?.spec?.clusterSets


### PR DESCRIPTION
# 📝 Summary
used to use node?.specs?.raw?.status?.numberOfSelectedClusters which seems to be depricated

**Ticket Summary (Title):**  
ACM-33392 Matched Clusters is always 0 in appset placement decision topology pod


**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33392

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->