### PR TITLE
ACM-33433 Fix clusterset edit namespace binding modal clipping dropdown

### DIFF
--- a/frontend/src/components/AcmSelectBase.tsx
+++ b/frontend/src/components/AcmSelectBase.tsx
@@ -78,7 +78,7 @@ export type AcmSelectBaseProps = Pick<
   toggleId?: string
   width?: string | number
   maxHeight?: string
-  menuAppendTo?: string
+  menuAppendTo?: string | HTMLElement | (() => HTMLElement)
   isLoading?: boolean
   footer?: React.ReactNode
   isCreatable?: boolean
@@ -717,7 +717,10 @@ export function AcmSelectBase(props: AcmSelectBaseProps) {
       onOpenChange={() => closeMenu()}
       selected={selections}
       onSelect={_onSelect}
-      popperProps={{ appendTo: 'inline' }}
+      popperProps={{
+        appendTo:
+          menuAppendTo && menuAppendTo !== 'parent' ? (menuAppendTo as HTMLElement | (() => HTMLElement)) : 'inline',
+      }}
       innerRef={menuRef as React.MutableRefObject<any>}
     >
       {renderSelectList()}

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ManagedClusterSetBindingModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ManagedClusterSetBindingModal.tsx
@@ -128,7 +128,7 @@ export function ManagedClusterSetBindingModal(props: { clusterSet?: ManagedClust
               label={t('clusterSetBinding.edit.select.label')}
               placeholder={t('clusterSetBinding.edit.select.placeholder')}
               value={selectedNamespaces}
-              menuAppendTo="parent"
+              menuAppendTo={() => document.body}
               maxHeight="18em"
               onChange={(namespaces) => setSelectedNamespaces(namespaces)}
               isLoading={!loaded}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ClusterSet page Edit namespace binding modal clipping namespace dropdown

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33433

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

Before fix:
<img width="848" height="380" alt="image" src="https://github.com/user-attachments/assets/5389eeef-c6d5-4e6d-90bd-ab6b40301737" />

After fix:
<img width="1065" height="641" alt="image" src="https://github.com/user-attachments/assets/54f07a31-38c7-4c1b-a88d-6c6f79197b00" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dropdown menu positioning and rendering throughout the application. Select menu components now support flexible attachment options, allowing better control over where menus appear in the interface. This improvement resolves positioning issues that previously occurred when dropdowns were rendered in complex layouts, ensuring menus display correctly and remain accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->