### PR TITLE
ACM-30436 Argo cluster-scoped topology status

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
@@ -67,6 +67,7 @@ describe('getAppSetResourceStatuses', () => {
             filters: [
               { property: 'kind', values: ['customresourcedefinition'] },
               { property: 'name', values: ['widgets.example.com'] },
+              { property: 'cluster', values: ['managed-1'] },
             ],
             relatedKinds: [],
           },
@@ -376,6 +377,10 @@ const mockSearchQuery: MockSearchQuery = {
             property: 'name',
             values: ['application-menu-rh-developer-blog'],
           },
+          {
+            property: 'cluster',
+            values: ['local-cluster', 'dyna1203'],
+          },
         ],
         relatedKinds: [],
       },
@@ -389,6 +394,10 @@ const mockSearchQuery: MockSearchQuery = {
           {
             property: 'name',
             values: ['ocp100'],
+          },
+          {
+            property: 'cluster',
+            values: ['local-cluster', 'dyna1203'],
           },
         ],
         relatedKinds: [],

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
@@ -4,6 +4,11 @@ import { getAppSetResourceStatuses } from './resourceStatusesAppSet'
 import { waitFor } from '@testing-library/react'
 import { nockSearch } from '../../../../../lib/nock-util'
 import { AppSetApplicationData, AppSetApplicationModel, SearchQuery } from '../types'
+import { fleetResourceRequest } from '../../../../../resources/utils/fleet-resource-request'
+
+jest.mock('../../../../../resources/utils/fleet-resource-request', () => ({
+  fleetResourceRequest: jest.fn(() => Promise.resolve({ errorMessage: 'not available' })),
+}))
 
 describe('getAppSetResourceStatuses', () => {
   it('getAppSetResourceStatuses returns resourceStatuses', async () => {
@@ -11,6 +16,80 @@ describe('getAppSetResourceStatuses', () => {
     await waitFor(() => expect(search.isDone()).toBeTruthy())
     const result = await getAppSetResourceStatuses(application, appData)
     expect(result).toStrictEqual({ resourceStatuses: mockSearchResponse })
+  })
+
+  it('fetches remote Application CRs for pull-model apps without status.resources', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockResolvedValueOnce({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: { name: 'pull-app-managed-1', namespace: 'openshift-gitops' },
+      status: {
+        resources: [
+          { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io' },
+          { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps' },
+        ],
+      },
+    } as any)
+
+    const pullModelApp: AppSetApplicationModel = {
+      name: 'pull-app',
+      namespace: 'openshift-gitops',
+      appSetApps: [
+        {
+          metadata: { name: 'pull-app-managed-1', namespace: 'openshift-gitops' },
+          spec: { destination: { namespace: 'default', server: 'https://managed-1.example.com' } },
+        },
+      ],
+      appSetClusters: [{ name: 'managed-1', namespace: 'managed-1', status: 'ok', created: '2024-01-01' }],
+    }
+
+    const pullAppData: AppSetApplicationData = {
+      relatedKinds: ['deployment', 'customresourcedefinition'],
+      targetNamespaces: [],
+    }
+
+    const pullSearchQuery = {
+      operationName: 'searchResultItemsAndRelatedItems',
+      variables: {
+        input: [
+          {
+            keywords: [],
+            filters: [
+              { property: 'kind', values: ['deployment'] },
+              { property: 'namespace', values: ['default'] },
+              { property: 'cluster', values: ['managed-1'] },
+            ],
+            relatedKinds: ['cluster', 'pod', 'replicaset', 'replicationcontroller'],
+          },
+          {
+            keywords: [],
+            filters: [
+              { property: 'kind', values: ['customresourcedefinition'] },
+              { property: 'name', values: ['widgets.example.com'] },
+            ],
+            relatedKinds: [],
+          },
+        ],
+      },
+      query:
+        'query searchResultItemsAndRelatedItems($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n    related {\n      kind\n      items\n      __typename\n    }\n    __typename\n  }\n}',
+    }
+
+    const pullSearchResponse = {
+      data: { searchResult: [{ __typename: 'SearchResult', items: [], related: null }] },
+    }
+
+    const search = nockSearch(pullSearchQuery, pullSearchResponse)
+    await waitFor(() => expect(search.isDone()).toBeTruthy())
+    const result = await getAppSetResourceStatuses(pullModelApp, pullAppData)
+    expect(result.resourceStatuses).toBeDefined()
+    expect(mockFleetResourceRequest).toHaveBeenCalledWith('GET', 'managed-1', {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      name: 'pull-app-managed-1',
+      namespace: 'openshift-gitops',
+    })
   })
 })
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
@@ -26,7 +26,12 @@ describe('getAppSetResourceStatuses', () => {
       metadata: { name: 'pull-app-managed-1', namespace: 'openshift-gitops' },
       status: {
         resources: [
-          { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io' },
+          {
+            kind: 'CustomResourceDefinition',
+            name: 'widgets.example.com',
+            version: 'v1',
+            group: 'apiextensions.k8s.io',
+          },
           { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps' },
         ],
       },

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
@@ -87,8 +87,8 @@ describe('getAppSetResourceStatuses', () => {
     }
 
     const search = nockSearch(pullSearchQuery, pullSearchResponse)
-    await waitFor(() => expect(search.isDone()).toBeTruthy())
     const result = await getAppSetResourceStatuses(pullModelApp, pullAppData)
+    await waitFor(() => expect(search.isDone()).toBeTruthy())
     expect(result.resourceStatuses).toBeDefined()
     expect(mockFleetResourceRequest).toHaveBeenCalledWith('GET', 'managed-1', {
       apiVersion: 'argoproj.io/v1alpha1',

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
@@ -97,6 +97,229 @@ describe('getAppSetResourceStatuses', () => {
       namespace: 'openshift-gitops',
     })
   })
+
+  it('fetches each app individually when sources differ (non-uniform/matrix)', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest
+      .mockResolvedValueOnce({
+        status: {
+          resources: [{ kind: 'Deployment', name: 'deploy-a', namespace: 'ns-a', version: 'v1', group: 'apps' }],
+        },
+      } as any)
+      .mockResolvedValueOnce({
+        status: {
+          resources: [{ kind: 'Deployment', name: 'deploy-b', namespace: 'ns-b', version: 'v1', group: 'apps' }],
+        },
+      } as any)
+
+    const matrixApp: AppSetApplicationModel = {
+      name: 'matrix-app',
+      namespace: 'openshift-gitops',
+      appSetApps: [
+        {
+          metadata: { name: 'matrix-app-cluster-1', namespace: 'openshift-gitops' },
+          spec: {
+            destination: { namespace: 'ns-a' },
+            source: { repoURL: 'https://git.io/repo', path: 'path-a', targetRevision: 'main' },
+          },
+        },
+        {
+          metadata: { name: 'matrix-app-cluster-2', namespace: 'openshift-gitops' },
+          spec: {
+            destination: { namespace: 'ns-b' },
+            source: { repoURL: 'https://git.io/repo', path: 'path-b', targetRevision: 'main' },
+          },
+        },
+      ],
+      appSetClusters: [
+        { name: 'cluster-1', namespace: 'cluster-1', status: 'ok', created: '2024-01-01' },
+        { name: 'cluster-2', namespace: 'cluster-2', status: 'ok', created: '2024-01-01' },
+      ],
+    }
+
+    const matrixAppData: AppSetApplicationData = {
+      relatedKinds: ['deployment'],
+      targetNamespaces: [],
+    }
+
+    const matrixSearchQuery = {
+      operationName: 'searchResultItemsAndRelatedItems',
+      variables: {
+        input: [
+          {
+            keywords: [],
+            filters: [
+              { property: 'kind', values: ['deployment'] },
+              { property: 'namespace', values: ['ns-a', 'ns-b'] },
+              { property: 'cluster', values: ['cluster-1', 'cluster-2'] },
+            ],
+            relatedKinds: ['cluster', 'pod', 'replicaset', 'replicationcontroller'],
+          },
+        ],
+      },
+      query:
+        'query searchResultItemsAndRelatedItems($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n    related {\n      kind\n      items\n      __typename\n    }\n    __typename\n  }\n}',
+    }
+
+    const matrixSearchResponse = {
+      data: { searchResult: [{ __typename: 'SearchResult', items: [], related: null }] },
+    }
+
+    const search = nockSearch(matrixSearchQuery, matrixSearchResponse)
+    await waitFor(() => expect(search.isDone()).toBeTruthy())
+    const result = await getAppSetResourceStatuses(matrixApp, matrixAppData)
+    expect(result.resourceStatuses).toBeDefined()
+    // Both apps should have been fetched individually
+    expect(mockFleetResourceRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns early when all apps already have resources populated (non-uniform)', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockClear()
+
+    const prePopulatedApp: AppSetApplicationModel = {
+      name: 'prepop-app',
+      namespace: 'openshift-gitops',
+      appSetApps: [
+        {
+          metadata: { name: 'prepop-app-cluster-1', namespace: 'openshift-gitops' },
+          spec: {
+            destination: { namespace: 'default' },
+            source: { repoURL: 'https://git.io/repo', path: 'path-a', targetRevision: 'main' },
+          },
+          status: {
+            resources: [{ kind: 'Deployment', name: 'deploy-a', namespace: 'default', version: 'v1', group: 'apps' }],
+          },
+        },
+        {
+          metadata: { name: 'prepop-app-cluster-2', namespace: 'openshift-gitops' },
+          spec: {
+            destination: { namespace: 'other' },
+            source: { repoURL: 'https://git.io/repo', path: 'path-b', targetRevision: 'main' },
+          },
+          status: {
+            resources: [{ kind: 'Deployment', name: 'deploy-b', namespace: 'other', version: 'v1', group: 'apps' }],
+          },
+        },
+      ],
+      appSetClusters: [
+        { name: 'cluster-1', namespace: 'cluster-1', status: 'ok', created: '2024-01-01' },
+        { name: 'cluster-2', namespace: 'cluster-2', status: 'ok', created: '2024-01-01' },
+      ],
+    }
+
+    const prePopAppData: AppSetApplicationData = {
+      relatedKinds: ['deployment'],
+      targetNamespaces: [],
+    }
+
+    const prePopSearchQuery = {
+      operationName: 'searchResultItemsAndRelatedItems',
+      variables: {
+        input: [
+          {
+            keywords: [],
+            filters: [
+              { property: 'kind', values: ['deployment'] },
+              { property: 'namespace', values: ['default', 'other'] },
+              { property: 'cluster', values: ['cluster-1', 'cluster-2'] },
+            ],
+            relatedKinds: ['cluster', 'pod', 'replicaset', 'replicationcontroller'],
+          },
+        ],
+      },
+      query:
+        'query searchResultItemsAndRelatedItems($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n    related {\n      kind\n      items\n      __typename\n    }\n    __typename\n  }\n}',
+    }
+
+    const prePopSearchResponse = {
+      data: { searchResult: [{ __typename: 'SearchResult', items: [], related: null }] },
+    }
+
+    const search = nockSearch(prePopSearchQuery, prePopSearchResponse)
+    await waitFor(() => expect(search.isDone()).toBeTruthy())
+    const result = await getAppSetResourceStatuses(prePopulatedApp, prePopAppData)
+    expect(result.resourceStatuses).toBeDefined()
+    // No fleet requests since all apps already have resources
+    expect(mockFleetResourceRequest).not.toHaveBeenCalled()
+  })
+
+  it('handles sources array in spec for uniformity check', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockResolvedValueOnce({
+      status: {
+        resources: [
+          { kind: 'Deployment', name: 'multi-src-deploy', namespace: 'default', version: 'v1', group: 'apps' },
+        ],
+      },
+    } as any)
+
+    const multiSourceApp: AppSetApplicationModel = {
+      name: 'multi-src',
+      namespace: 'openshift-gitops',
+      appSetApps: [
+        {
+          metadata: { name: 'multi-src-managed-1', namespace: 'openshift-gitops' },
+          spec: {
+            destination: { namespace: 'default', server: 'https://managed-1.example.com' },
+            sources: [
+              { repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' },
+              { repoURL: 'https://git.io/charts', chart: 'my-chart', targetRevision: '1.0.0' },
+            ],
+          } as any,
+        },
+        {
+          metadata: { name: 'multi-src-managed-2', namespace: 'openshift-gitops' },
+          spec: {
+            destination: { namespace: 'default', server: 'https://managed-2.example.com' },
+            sources: [
+              { repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' },
+              { repoURL: 'https://git.io/charts', chart: 'my-chart', targetRevision: '1.0.0' },
+            ],
+          } as any,
+        },
+      ],
+      appSetClusters: [
+        { name: 'managed-1', namespace: 'managed-1', status: 'ok', created: '2024-01-01' },
+        { name: 'managed-2', namespace: 'managed-2', status: 'ok', created: '2024-01-01' },
+      ],
+    }
+
+    const multiSrcAppData: AppSetApplicationData = {
+      relatedKinds: ['deployment'],
+      targetNamespaces: [],
+    }
+
+    const multiSrcSearchQuery = {
+      operationName: 'searchResultItemsAndRelatedItems',
+      variables: {
+        input: [
+          {
+            keywords: [],
+            filters: [
+              { property: 'kind', values: ['deployment'] },
+              { property: 'namespace', values: ['default'] },
+              { property: 'cluster', values: ['managed-1', 'managed-2'] },
+            ],
+            relatedKinds: ['cluster', 'pod', 'replicaset', 'replicationcontroller'],
+          },
+        ],
+      },
+      query:
+        'query searchResultItemsAndRelatedItems($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n    related {\n      kind\n      items\n      __typename\n    }\n    __typename\n  }\n}',
+    }
+
+    const multiSrcSearchResponse = {
+      data: { searchResult: [{ __typename: 'SearchResult', items: [], related: null }] },
+    }
+
+    const search = nockSearch(multiSrcSearchQuery, multiSrcSearchResponse)
+    await waitFor(() => expect(search.isDone()).toBeTruthy())
+    const result = await getAppSetResourceStatuses(multiSourceApp, multiSrcAppData)
+    expect(result.resourceStatuses).toBeDefined()
+    // Uniform sources array — only one fleet request
+    expect(mockFleetResourceRequest).toHaveBeenCalledTimes(1)
+  })
 })
 
 interface TestAppSetApplicationData extends AppSetApplicationData {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.test.ts
@@ -43,7 +43,7 @@ describe('getAppSetResourceStatuses', () => {
       appSetApps: [
         {
           metadata: { name: 'pull-app-managed-1', namespace: 'openshift-gitops' },
-          spec: { destination: { namespace: 'default', server: 'https://managed-1.example.com' } },
+          spec: { destination: { namespace: 'default', name: 'managed-1' } },
         },
       ],
       appSetClusters: [{ name: 'managed-1', namespace: 'managed-1', status: 'ok', created: '2024-01-01' }],
@@ -119,14 +119,14 @@ describe('getAppSetResourceStatuses', () => {
         {
           metadata: { name: 'matrix-app-cluster-1', namespace: 'openshift-gitops' },
           spec: {
-            destination: { namespace: 'ns-a' },
+            destination: { namespace: 'ns-a', name: 'cluster-1' },
             source: { repoURL: 'https://git.io/repo', path: 'path-a', targetRevision: 'main' },
           },
         },
         {
           metadata: { name: 'matrix-app-cluster-2', namespace: 'openshift-gitops' },
           spec: {
-            destination: { namespace: 'ns-b' },
+            destination: { namespace: 'ns-b', name: 'cluster-2' },
             source: { repoURL: 'https://git.io/repo', path: 'path-b', targetRevision: 'main' },
           },
         },
@@ -261,7 +261,7 @@ describe('getAppSetResourceStatuses', () => {
         {
           metadata: { name: 'multi-src-managed-1', namespace: 'openshift-gitops' },
           spec: {
-            destination: { namespace: 'default', server: 'https://managed-1.example.com' },
+            destination: { namespace: 'default', name: 'managed-1' },
             sources: [
               { repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' },
               { repoURL: 'https://git.io/charts', chart: 'my-chart', targetRevision: '1.0.0' },
@@ -271,7 +271,7 @@ describe('getAppSetResourceStatuses', () => {
         {
           metadata: { name: 'multi-src-managed-2', namespace: 'openshift-gitops' },
           spec: {
-            destination: { namespace: 'default', server: 'https://managed-2.example.com' },
+            destination: { namespace: 'default', name: 'managed-2' },
             sources: [
               { repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' },
               { repoURL: 'https://git.io/charts', chart: 'my-chart', targetRevision: '1.0.0' },

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
@@ -4,6 +4,7 @@ import { searchClient } from '../../../../Search/search-sdk/search-client'
 import { SearchResultItemsAndRelatedItemsDocument } from '../../../../Search/search-sdk/search-sdk'
 import { getQueryStringForResource } from '../model/topologyUtils'
 import { getArgoSecret } from './resourceStatusesArgo'
+import { fleetResourceRequest } from '../../../../../resources/utils/fleet-resource-request'
 import {
   AppSetApplicationModel,
   AppSetApplicationData,
@@ -22,6 +23,9 @@ import {
  * It handles both namespaced and cluster-scoped resources, and retrieves Argo secrets
  * for authentication purposes.
  *
+ * For pull-model ApplicationSets, hub Application CRs may not have status.resources populated.
+ * In that case, this function fetches the remote Application CRs to get the expected resource list.
+ *
  * @param application - The ApplicationSet application model containing metadata and app/cluster lists
  * @param appData - Application data structure that will be populated with search results and target namespaces
  * @returns Promise resolving to an object containing the resource statuses from the search query
@@ -38,8 +42,11 @@ export async function getAppSetResourceStatuses(
     appSetClustersList.push(cls.name)
   })
 
+  // For pull-model, hub apps may lack status.resources; fetch from remote clusters if needed
+  const appsWithResources = await ensureAppResources(appSetApps, namespace, appSetClustersList)
+
   // Get resource statuses by querying the search API
-  const resourceStatuses = await getResourceStatuses(name, namespace, appSetApps, appData, appSetClustersList)
+  const resourceStatuses = await getResourceStatuses(name, namespace, appsWithResources, appData, appSetClustersList)
 
   // Retrieve Argo secrets for authentication, if available
   const secret = await getArgoSecret(appData, resourceStatuses as Record<string, unknown>)
@@ -49,6 +56,61 @@ export async function getAppSetResourceStatuses(
   }
 
   return { resourceStatuses }
+}
+
+/**
+ * Ensures that the Application list has status.resources populated.
+ * For pull-model, the hub Application CRs often lack status.resources because ArgoCD
+ * runs on the managed cluster. This function fetches the remote Application CRs to get
+ * the expected resource list for cluster-scoped resources (CRDs, StorageClasses, etc.).
+ */
+async function ensureAppResources(
+  appSetApps: AppSetApplication[],
+  namespace: string,
+  clusterNames: string[]
+): Promise<AppSetApplication[]> {
+  const hasResources = appSetApps.some((app: any) => app?.status?.resources?.length > 0)
+  if (hasResources || appSetApps.length === 0 || clusterNames.length === 0) {
+    return appSetApps
+  }
+
+  // Hub apps lack status.resources — fetch from remote clusters
+  const enrichedApps: AppSetApplication[] = [...appSetApps]
+
+  const fetchPromises = appSetApps.map(async (app: AppSetApplication, index: number) => {
+    const appName = app.metadata?.name
+    if (!appName) return
+
+    for (const clusterName of clusterNames) {
+      try {
+        const result = await fleetResourceRequest('GET', clusterName, {
+          apiVersion: 'argoproj.io/v1alpha1',
+          kind: 'Application',
+          name: appName,
+          namespace,
+        })
+
+        if ('errorMessage' in result) continue
+
+        const resources = (result as any)?.status?.resources
+        if (Array.isArray(resources) && resources.length > 0) {
+          enrichedApps[index] = {
+            ...app,
+            status: {
+              ...app.status,
+              resources,
+            },
+          } as AppSetApplication
+          return
+        }
+      } catch {
+        // Continue to next cluster on failure
+      }
+    }
+  })
+
+  await Promise.allSettled(fetchPromises)
+  return enrichedApps
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
@@ -213,10 +213,12 @@ async function getResourceStatuses(
     appSetClusters.toString()
   )
 
-  // Build separate queries for each cluster-scoped resource
+  // Build separate queries for each cluster-scoped resource, scoped to the target clusters
   if (kindsNotNamespaceScoped.length > 0) {
     kindsNotNamespaceScoped.forEach((item: string, i: number) => {
-      queryNotNamespaceScoped.push(getQueryStringForResource([item], kindsNotNamespaceScopedNames[i], '', ''))
+      queryNotNamespaceScoped.push(
+        getQueryStringForResource([item], kindsNotNamespaceScopedNames[i], '', appSetClusters.toString())
+      )
     })
   }
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
@@ -63,20 +63,43 @@ export async function getAppSetResourceStatuses(
  * For pull-model, the hub Application CRs often lack status.resources because ArgoCD
  * runs on the managed cluster. This function fetches the remote Application CRs to get
  * the expected resource list for cluster-scoped resources (CRDs, StorageClasses, etc.).
+ *
+ * Optimization: Checks whether all apps share the same source spec (repoURL + path +
+ * targetRevision). If uniform, one fetch suffices for all apps. If sources differ
+ * (matrix/merge generator), each app is fetched individually.
  */
 async function ensureAppResources(
   appSetApps: AppSetApplication[],
   namespace: string,
   clusterNames: string[]
 ): Promise<AppSetApplication[]> {
-  const hasResources = appSetApps.some((app: any) => app?.status?.resources?.length > 0)
-  if (hasResources || appSetApps.length === 0 || clusterNames.length === 0) {
+  if (appSetApps.length === 0 || clusterNames.length === 0) {
     return appSetApps
   }
 
-  // Hub apps lack status.resources — fetch from remote clusters
-  const enrichedApps: AppSetApplication[] = [...appSetApps]
+  // Check if any hub app already has status.resources (e.g. hub is also a target cluster)
+  const localResources = appSetApps.find((app) => (app.status?.resources?.length ?? 0) > 0)?.status?.resources
 
+  const uniform = areAppSetSourcesUniform(appSetApps)
+
+  if (uniform) {
+    // All apps deploy the same manifests — use local data if available, otherwise one fleet request
+    const sampleResources = localResources ?? (await fetchFirstAvailableResources(appSetApps, namespace, clusterNames))
+    if (!sampleResources) return appSetApps
+
+    return appSetApps.map((app: AppSetApplication) => {
+      if (app.status?.resources?.length) return app
+      return { ...app, status: { ...app.status, resources: sampleResources } } as AppSetApplication
+    })
+  }
+
+  // If we already have all resources populated, no need to fetch
+  if (localResources && appSetApps.every((app) => (app.status?.resources?.length ?? 0) > 0)) {
+    return appSetApps
+  }
+
+  // Sources differ — fetch each app individually
+  const enrichedApps: AppSetApplication[] = [...appSetApps]
   const fetchPromises = appSetApps.map(async (app: AppSetApplication, index: number) => {
     const appName = app.metadata?.name
     if (!appName) return
@@ -89,28 +112,67 @@ async function ensureAppResources(
           name: appName,
           namespace,
         })
-
         if ('errorMessage' in result) continue
 
         const resources = (result as any)?.status?.resources
         if (Array.isArray(resources) && resources.length > 0) {
-          enrichedApps[index] = {
-            ...app,
-            status: {
-              ...app.status,
-              resources,
-            },
-          } as AppSetApplication
+          enrichedApps[index] = { ...app, status: { ...app.status, resources } } as AppSetApplication
           return
         }
       } catch {
-        // Continue to next cluster on failure
+        // Continue to next cluster
       }
     }
   })
-
   await Promise.allSettled(fetchPromises)
   return enrichedApps
+}
+
+/** Determines if all apps share the same source configuration. */
+function areAppSetSourcesUniform(appSetApps: AppSetApplication[]): boolean {
+  if (appSetApps.length <= 1) return true
+
+  const getSourceKey = (app: AppSetApplication): string => {
+    const source = app.spec?.source
+    const sources = (app.spec as any)?.sources
+    if (Array.isArray(sources)) {
+      return JSON.stringify(sources.map((s: any) => ({ r: s.repoURL, p: s.path, t: s.targetRevision, c: s.chart })))
+    }
+    return `${source?.repoURL || ''}|${source?.path || ''}|${source?.targetRevision || ''}|${source?.chart || ''}`
+  }
+
+  const firstKey = getSourceKey(appSetApps[0])
+  return appSetApps.every((app) => getSourceKey(app) === firstKey)
+}
+
+/** Fetches status.resources from the first reachable remote Application CR. */
+async function fetchFirstAvailableResources(
+  appSetApps: AppSetApplication[],
+  namespace: string,
+  clusterNames: string[]
+): Promise<any[] | null> {
+  for (const app of appSetApps) {
+    const appName = app.metadata?.name
+    if (!appName) continue
+
+    for (const clusterName of clusterNames) {
+      try {
+        const result = await fleetResourceRequest('GET', clusterName, {
+          apiVersion: 'argoproj.io/v1alpha1',
+          kind: 'Application',
+          name: appName,
+          namespace,
+        })
+        if ('errorMessage' in result) continue
+
+        const resources = (result as any)?.status?.resources
+        if (Array.isArray(resources) && resources.length > 0) return resources
+      } catch {
+        // Continue to next cluster
+      }
+    }
+  }
+  return null
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/resourceStatusesAppSet.ts
@@ -2,9 +2,13 @@
 
 import { searchClient } from '../../../../Search/search-sdk/search-client'
 import { SearchResultItemsAndRelatedItemsDocument } from '../../../../Search/search-sdk/search-sdk'
-import { getQueryStringForResource } from '../model/topologyUtils'
+import {
+  areSourcesUniform,
+  fetchArgoAppStatusResources,
+  getAppTargetCluster,
+  getQueryStringForResource,
+} from '../model/topologyUtils'
 import { getArgoSecret } from './resourceStatusesArgo'
-import { fleetResourceRequest } from '../../../../../resources/utils/fleet-resource-request'
 import {
   AppSetApplicationModel,
   AppSetApplicationData,
@@ -23,7 +27,7 @@ import {
  * It handles both namespaced and cluster-scoped resources, and retrieves Argo secrets
  * for authentication purposes.
  *
- * For pull-model ApplicationSets, hub Application CRs may not have status.resources populated.
+ * For pull-model ApplicationSets, hub Application CRs will not have status.resources populated.
  * In that case, this function fetches the remote Application CRs to get the expected resource list.
  *
  * @param application - The ApplicationSet application model containing metadata and app/cluster lists
@@ -42,8 +46,8 @@ export async function getAppSetResourceStatuses(
     appSetClustersList.push(cls.name)
   })
 
-  // For pull-model, hub apps may lack status.resources; fetch from remote clusters if needed
-  const appsWithResources = await ensureAppResources(appSetApps, namespace, appSetClustersList)
+  // For pull-model, hub apps lack status.resources; fetch from remote clusters
+  const appsWithResources = await ensureAppResources(appSetApps, namespace, appSetClusters)
 
   // Get resource statuses by querying the search API
   const resourceStatuses = await getResourceStatuses(name, namespace, appsWithResources, appData, appSetClustersList)
@@ -60,7 +64,7 @@ export async function getAppSetResourceStatuses(
 
 /**
  * Ensures that the Application list has status.resources populated.
- * For pull-model, the hub Application CRs often lack status.resources because ArgoCD
+ * For pull-model, the hub Application CRs lack status.resources because ArgoCD
  * runs on the managed cluster. This function fetches the remote Application CRs to get
  * the expected resource list for cluster-scoped resources (CRDs, StorageClasses, etc.).
  *
@@ -71,108 +75,60 @@ export async function getAppSetResourceStatuses(
 async function ensureAppResources(
   appSetApps: AppSetApplication[],
   namespace: string,
-  clusterNames: string[]
+  clusters: AppSetClusterInfo[]
 ): Promise<AppSetApplication[]> {
-  if (appSetApps.length === 0 || clusterNames.length === 0) {
+  if (
+    appSetApps.length === 0 ||
+    clusters.length === 0 ||
+    appSetApps.every((app) => (app.status?.resources?.length ?? 0) > 0)
+  ) {
+    // if there are no appSets/clusters or we already have all resources populated, no need to fetch
     return appSetApps
   }
 
-  // Check if any hub app already has status.resources (e.g. hub is also a target cluster)
-  const localResources = appSetApps.find((app) => (app.status?.resources?.length ?? 0) > 0)?.status?.resources
+  const sharedResources = areSourcesUniform(appSetApps, (app: AppSetApplication) => ({
+    source: app.spec?.source,
+    sources: (app.spec as any)?.sources,
+  }))
+    ? fetchFirstAvailableResources(appSetApps, namespace, clusters)
+    : undefined
 
-  const uniform = areAppSetSourcesUniform(appSetApps)
-
-  if (uniform) {
-    // All apps deploy the same manifests — use local data if available, otherwise one fleet request
-    const sampleResources = localResources ?? (await fetchFirstAvailableResources(appSetApps, namespace, clusterNames))
-    if (!sampleResources) return appSetApps
-
-    return appSetApps.map((app: AppSetApplication) => {
+  return Promise.all(
+    appSetApps.map(async (app: AppSetApplication) => {
       if (app.status?.resources?.length) return app
-      return { ...app, status: { ...app.status, resources: sampleResources } } as AppSetApplication
+      const resources = await (sharedResources ?? fetchSingleAppResources(app, namespace, clusters))
+      if (!resources) return app
+      return { ...app, status: { ...app.status, resources } } as AppSetApplication
     })
-  }
-
-  // If we already have all resources populated, no need to fetch
-  if (localResources && appSetApps.every((app) => (app.status?.resources?.length ?? 0) > 0)) {
-    return appSetApps
-  }
-
-  // Sources differ — fetch each app individually
-  const enrichedApps: AppSetApplication[] = [...appSetApps]
-  const fetchPromises = appSetApps.map(async (app: AppSetApplication, index: number) => {
-    const appName = app.metadata?.name
-    if (!appName) return
-
-    for (const clusterName of clusterNames) {
-      try {
-        const result = await fleetResourceRequest('GET', clusterName, {
-          apiVersion: 'argoproj.io/v1alpha1',
-          kind: 'Application',
-          name: appName,
-          namespace,
-        })
-        if ('errorMessage' in result) continue
-
-        const resources = (result as any)?.status?.resources
-        if (Array.isArray(resources) && resources.length > 0) {
-          enrichedApps[index] = { ...app, status: { ...app.status, resources } } as AppSetApplication
-          return
-        }
-      } catch {
-        // Continue to next cluster
-      }
-    }
-  })
-  await Promise.allSettled(fetchPromises)
-  return enrichedApps
+  )
 }
 
-/** Determines if all apps share the same source configuration. */
-function areAppSetSourcesUniform(appSetApps: AppSetApplication[]): boolean {
-  if (appSetApps.length <= 1) return true
-
-  const getSourceKey = (app: AppSetApplication): string => {
-    const source = app.spec?.source
-    const sources = (app.spec as any)?.sources
-    if (Array.isArray(sources)) {
-      return JSON.stringify(sources.map((s: any) => ({ r: s.repoURL, p: s.path, t: s.targetRevision, c: s.chart })))
-    }
-    return `${source?.repoURL || ''}|${source?.path || ''}|${source?.targetRevision || ''}|${source?.chart || ''}`
-  }
-
-  const firstKey = getSourceKey(appSetApps[0])
-  return appSetApps.every((app) => getSourceKey(app) === firstKey)
-}
-
-/** Fetches status.resources from the first reachable remote Application CR. */
+/** Tries each app in order, returning resources from the first reachable one. */
 async function fetchFirstAvailableResources(
   appSetApps: AppSetApplication[],
   namespace: string,
-  clusterNames: string[]
+  clusters: AppSetClusterInfo[]
 ): Promise<any[] | null> {
   for (const app of appSetApps) {
-    const appName = app.metadata?.name
-    if (!appName) continue
-
-    for (const clusterName of clusterNames) {
-      try {
-        const result = await fleetResourceRequest('GET', clusterName, {
-          apiVersion: 'argoproj.io/v1alpha1',
-          kind: 'Application',
-          name: appName,
-          namespace,
-        })
-        if ('errorMessage' in result) continue
-
-        const resources = (result as any)?.status?.resources
-        if (Array.isArray(resources) && resources.length > 0) return resources
-      } catch {
-        // Continue to next cluster
-      }
-    }
+    const resources = await fetchSingleAppResources(app, namespace, clusters)
+    if (resources) return resources
   }
   return null
+}
+
+/** Resolves the app's target cluster from its destination and fetches status.resources. */
+async function fetchSingleAppResources(
+  app: AppSetApplication,
+  namespace: string,
+  clusters: AppSetClusterInfo[]
+): Promise<any[] | null> {
+  const appName = app.metadata?.name
+  if (!appName) return null
+
+  const clusterName = getAppTargetCluster(app.spec.destination, clusters)
+  if (!clusterName) return null
+
+  return fetchArgoAppStatusResources(clusterName, appName, namespace)
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -6,6 +6,7 @@ import i18next, { TFunction } from 'i18next'
 import type { ApplicationModel, ExtendedTopology } from '../types'
 import type { ToolbarControl } from '../topology/components/TopologyToolbar'
 import { searchClient } from '../../../../Search/search-sdk/search-client'
+import { fleetResourceRequest } from '../../../../../resources/utils/fleet-resource-request'
 
 const t: TFunction = i18next.t.bind(i18next)
 
@@ -44,6 +45,11 @@ jest.mock('../../../../../resources/utils', () => ({
       },
     ]),
   })),
+}))
+
+// Mock fleet-resource-request
+jest.mock('../../../../../resources/utils/fleet-resource-request', () => ({
+  fleetResourceRequest: jest.fn(() => Promise.resolve({ errorMessage: 'not available' })),
 }))
 
 // Mock window.open
@@ -641,6 +647,154 @@ describe('getAppSetTopology', () => {
     const appSetNode = result.nodes.find((n) => n.type === 'applicationset') as any
     expect(appSetNode).toBeDefined()
     expect(appSetNode.isArgoCDPullModelTargetLocalCluster).toBe(true)
+  })
+
+  it('should include cluster-scoped resources from remote Application status.resources for pull model', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockResolvedValueOnce({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: { name: 'test-pullmodel-crd-managed-cluster-1', namespace: 'openshift-gitops' },
+      status: {
+        resources: [
+          { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps', health: { status: 'Healthy' } },
+          { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io', health: { status: 'Healthy' } },
+          { kind: 'StorageClass', name: 'fast-storage', version: 'v1', group: 'storage.k8s.io', health: { status: 'Healthy' } },
+        ],
+      },
+    } as any)
+
+    // Search returns only the Deployment as a related resource (CRD and StorageClass don't exist yet)
+    mockSearchClient.query.mockResolvedValueOnce({
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'app-uid-1',
+                name: 'test-pullmodel-crd-managed-cluster-1',
+                namespace: 'openshift-gitops',
+                cluster: 'managed-cluster-1',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+            ],
+            related: [
+              {
+                kind: 'Deployment',
+                items: [
+                  {
+                    _uid: 'deploy-uid-1',
+                    _relatedUids: ['app-uid-1'],
+                    name: 'my-app',
+                    namespace: 'default',
+                    kind: 'Deployment',
+                    cluster: 'managed-cluster-1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'test-pullmodel-crd',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'test-pullmodel-crd', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'managed-cluster-1' }],
+      appSetApps: [{ metadata: { name: 'test-pullmodel-crd-managed-cluster-1' }, spec: {} }] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // The Deployment found via search should be in topology
+    const deployNode = result.nodes.find((n) => n.type === 'deployment' && n.name === 'my-app')
+    expect(deployNode).toBeDefined()
+
+    // The CRD from status.resources should also be in topology even though not found in search
+    const crdNode = result.nodes.find((n) => n.type === 'customresourcedefinition' && n.name === 'widgets.example.com')
+    expect(crdNode).toBeDefined()
+
+    // The StorageClass from status.resources should also be in topology
+    const scNode = result.nodes.find((n) => n.type === 'storageclass' && n.name === 'fast-storage')
+    expect(scNode).toBeDefined()
+  })
+
+  it('should show resources with healthy status as running for pull model', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockResolvedValueOnce({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: { name: 'test-pullmodel-status-managed-cluster-1', namespace: 'openshift-gitops' },
+      status: {
+        resources: [
+          { kind: 'StorageClass', name: 'fast-storage', version: 'v1', group: 'storage.k8s.io', health: { status: 'Healthy' } },
+          { kind: 'CustomResourceDefinition', name: 'missing.example.com', version: 'v1', group: 'apiextensions.k8s.io', health: { status: 'Missing' } },
+        ],
+      },
+    } as any)
+
+    // Search returns no related resources (nothing exists yet)
+    mockSearchClient.query.mockResolvedValueOnce({
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'app-uid-2',
+                name: 'test-pullmodel-status-managed-cluster-1',
+                namespace: 'openshift-gitops',
+                cluster: 'managed-cluster-1',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+            ],
+            related: [],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'test-pullmodel-status',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'test-pullmodel-status', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'managed-cluster-1' }],
+      appSetApps: [{ metadata: { name: 'test-pullmodel-status-managed-cluster-1' }, spec: {} }] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // Healthy StorageClass should appear with 'running' status mapped from health.status
+    const scNode = result.nodes.find((n) => n.type === 'storageclass' && n.name === 'fast-storage')
+    expect(scNode).toBeDefined()
+    expect((scNode as any)?.specs?.raw?.status).toBe('running')
+
+    // Missing CRD should appear in topology (will be shown as pending)
+    const crdNode = result.nodes.find((n) => n.type === 'customresourcedefinition' && n.name === 'missing.example.com')
+    expect(crdNode).toBeDefined()
   })
 
   it('should filter by active clusters when provided', async () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -456,6 +456,69 @@ describe('getAppSetTopology', () => {
     expect(mockToolbarControl.setAllClusters).toHaveBeenCalledWith(['local-cluster', 'managed-cluster-1'])
   })
 
+  it('should not duplicate cluster-scoped resources when deployed to multiple clusters', async () => {
+    // Push model with cluster-scoped resources (CRDs) deployed to two clusters
+    mockSearchClient.query.mockResolvedValue({
+      loading: false,
+      networkStatus: 7,
+      data: { searchResult: [] },
+    })
+
+    const application: ApplicationModel = {
+      name: 'test-appset-crd-dedup',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'test-appset-crd-dedup', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: false,
+      appSetClusters: [{ name: 'local-cluster' }, { name: 'managed-cluster-1' }],
+      appSetApps: [
+        {
+          metadata: { name: 'test-appset-crd-dedup-local-cluster' },
+          spec: {},
+          status: {
+            resources: [
+              { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io' },
+              { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps' },
+            ],
+          },
+        },
+        {
+          metadata: { name: 'test-appset-crd-dedup-managed-cluster-1' },
+          spec: {},
+          status: {
+            resources: [
+              { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io' },
+              { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps' },
+            ],
+          },
+        },
+      ] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // CRD should appear exactly once (deduplicated across clusters)
+    const crdNodes = result.nodes.filter((n) => n.type === 'customresourcedefinition' && n.name === 'widgets.example.com')
+    expect(crdNodes).toHaveLength(1)
+
+    // The single CRD node should have both clusters in clustersNames
+    const crdNode = crdNodes[0]
+    expect((crdNode as any).specs.clustersNames).toContain('local-cluster')
+    expect((crdNode as any).specs.clustersNames).toContain('managed-cluster-1')
+
+    // Namespaced Deployment should still have separate entries per cluster (concatenated into allResources)
+    const deployNodes = result.nodes.filter((n) => n.type === 'deployment' && n.name === 'my-app')
+    expect(deployNodes.length).toBeGreaterThanOrEqual(1)
+  })
+
   it('should handle ApplicationSet with app status information', async () => {
     const application: ApplicationModel = {
       name: 'test-appset-status',

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -485,7 +485,12 @@ describe('getAppSetTopology', () => {
           spec: {},
           status: {
             resources: [
-              { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io' },
+              {
+                kind: 'CustomResourceDefinition',
+                name: 'widgets.example.com',
+                version: 'v1',
+                group: 'apiextensions.k8s.io',
+              },
               { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps' },
             ],
           },
@@ -495,7 +500,12 @@ describe('getAppSetTopology', () => {
           spec: {},
           status: {
             resources: [
-              { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io' },
+              {
+                kind: 'CustomResourceDefinition',
+                name: 'widgets.example.com',
+                version: 'v1',
+                group: 'apiextensions.k8s.io',
+              },
               { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps' },
             ],
           },
@@ -506,7 +516,9 @@ describe('getAppSetTopology', () => {
     const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
 
     // CRD should appear exactly once (deduplicated across clusters)
-    const crdNodes = result.nodes.filter((n) => n.type === 'customresourcedefinition' && n.name === 'widgets.example.com')
+    const crdNodes = result.nodes.filter(
+      (n) => n.type === 'customresourcedefinition' && n.name === 'widgets.example.com'
+    )
     expect(crdNodes).toHaveLength(1)
 
     // The single CRD node should have both clusters in clustersNames
@@ -720,9 +732,28 @@ describe('getAppSetTopology', () => {
       metadata: { name: 'test-pullmodel-crd-managed-cluster-1', namespace: 'openshift-gitops' },
       status: {
         resources: [
-          { kind: 'Deployment', name: 'my-app', namespace: 'default', version: 'v1', group: 'apps', health: { status: 'Healthy' } },
-          { kind: 'CustomResourceDefinition', name: 'widgets.example.com', version: 'v1', group: 'apiextensions.k8s.io', health: { status: 'Healthy' } },
-          { kind: 'StorageClass', name: 'fast-storage', version: 'v1', group: 'storage.k8s.io', health: { status: 'Healthy' } },
+          {
+            kind: 'Deployment',
+            name: 'my-app',
+            namespace: 'default',
+            version: 'v1',
+            group: 'apps',
+            health: { status: 'Healthy' },
+          },
+          {
+            kind: 'CustomResourceDefinition',
+            name: 'widgets.example.com',
+            version: 'v1',
+            group: 'apiextensions.k8s.io',
+            health: { status: 'Healthy' },
+          },
+          {
+            kind: 'StorageClass',
+            name: 'fast-storage',
+            version: 'v1',
+            group: 'storage.k8s.io',
+            health: { status: 'Healthy' },
+          },
         ],
       },
     } as any)
@@ -803,8 +834,20 @@ describe('getAppSetTopology', () => {
       metadata: { name: 'test-pullmodel-status-managed-cluster-1', namespace: 'openshift-gitops' },
       status: {
         resources: [
-          { kind: 'StorageClass', name: 'fast-storage', version: 'v1', group: 'storage.k8s.io', health: { status: 'Healthy' } },
-          { kind: 'CustomResourceDefinition', name: 'missing.example.com', version: 'v1', group: 'apiextensions.k8s.io', health: { status: 'Missing' } },
+          {
+            kind: 'StorageClass',
+            name: 'fast-storage',
+            version: 'v1',
+            group: 'storage.k8s.io',
+            health: { status: 'Healthy' },
+          },
+          {
+            kind: 'CustomResourceDefinition',
+            name: 'missing.example.com',
+            version: 'v1',
+            group: 'apiextensions.k8s.io',
+            health: { status: 'Missing' },
+          },
         ],
       },
     } as any)

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -988,6 +988,337 @@ describe('getAppSetTopology', () => {
     expect(toolbarWithActiveTypes.setAllTypes).toHaveBeenCalled()
   })
 
+  it('should fetch resources individually for pull model with non-uniform sources (matrix generator)', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    // Two different apps fetched individually due to non-uniform sources
+    mockFleetResourceRequest
+      .mockResolvedValueOnce({
+        status: {
+          resources: [
+            { kind: 'Deployment', name: 'app-a', namespace: 'default', version: 'v1', group: 'apps' },
+            {
+              kind: 'CustomResourceDefinition',
+              name: 'crds-a.example.com',
+              version: 'v1',
+              group: 'apiextensions.k8s.io',
+              health: { status: 'Healthy' },
+            },
+          ],
+        },
+      } as any)
+      .mockResolvedValueOnce({
+        status: {
+          resources: [
+            { kind: 'Deployment', name: 'app-b', namespace: 'other', version: 'v1', group: 'apps' },
+            {
+              kind: 'StorageClass',
+              name: 'sc-b',
+              version: 'v1',
+              group: 'storage.k8s.io',
+              health: { status: 'Healthy' },
+            },
+          ],
+        },
+      } as any)
+
+    mockSearchClient.query.mockResolvedValueOnce({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'uid-1',
+                name: 'matrix-app-cluster-1',
+                namespace: 'openshift-gitops',
+                cluster: 'cluster-1',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+              {
+                _uid: 'uid-2',
+                name: 'matrix-app-cluster-2',
+                namespace: 'openshift-gitops',
+                cluster: 'cluster-2',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+            ],
+            related: [],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'matrix-app',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'matrix-app', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'cluster-1' }, { name: 'cluster-2' }],
+      appSetApps: [
+        {
+          metadata: { name: 'matrix-app-cluster-1' },
+          spec: { source: { repoURL: 'https://git.io/repo', path: 'path-a', targetRevision: 'main' } },
+        },
+        {
+          metadata: { name: 'matrix-app-cluster-2' },
+          spec: { source: { repoURL: 'https://git.io/repo', path: 'path-b', targetRevision: 'main' } },
+        },
+      ] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // Both apps should have been fetched individually since sources differ
+    expect(mockFleetResourceRequest).toHaveBeenCalledTimes(2)
+    // Resources from both apps should appear in topology
+    const crdNode = result.nodes.find((n) => n.type === 'customresourcedefinition' && n.name === 'crds-a.example.com')
+    expect(crdNode).toBeDefined()
+    const scNode = result.nodes.find((n) => n.type === 'storageclass' && n.name === 'sc-b')
+    expect(scNode).toBeDefined()
+  })
+
+  it('should handle pull model when fleet request fails and no local resources available', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockResolvedValueOnce({ errorMessage: 'cluster unavailable' } as any)
+
+    mockSearchClient.query.mockResolvedValueOnce({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'uid-fail',
+                name: 'fail-app-cluster-1',
+                namespace: 'openshift-gitops',
+                cluster: 'cluster-1',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+            ],
+            related: [],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'fail-app',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'fail-app', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'cluster-1' }],
+      appSetApps: [
+        {
+          metadata: { name: 'fail-app-cluster-1' },
+          spec: { source: { repoURL: 'https://git.io/r', path: 'p', targetRevision: 'main' } },
+        },
+      ] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // Should still produce a valid topology (just without the expected resources from fleet)
+    expect(result.nodes).toBeDefined()
+    expect(result.links).toBeDefined()
+  })
+
+  it('should handle pull model with no appSetApps gracefully', async () => {
+    const application: ApplicationModel = {
+      name: 'empty-app',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'empty-app', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'cluster-1' }],
+      appSetApps: [] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    expect(result.nodes).toBeDefined()
+    expect(result.links).toBeDefined()
+  })
+
+  it('should use local hub app resources without fleet request when hub has status.resources', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockClear()
+
+    mockSearchClient.query.mockResolvedValueOnce({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'uid-hub',
+                name: 'hub-app-managed-1',
+                namespace: 'openshift-gitops',
+                cluster: 'managed-1',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+            ],
+            related: [],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'hub-app',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'hub-app', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'managed-1' }],
+      appSetApps: [
+        {
+          metadata: { name: 'hub-app-managed-1' },
+          spec: { source: { repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' } },
+          status: {
+            resources: [
+              {
+                kind: 'StorageClass',
+                name: 'local-sc',
+                version: 'v1',
+                group: 'storage.k8s.io',
+                health: { status: 'Healthy' },
+              },
+            ],
+          },
+        },
+      ] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // No fleet request needed — local hub data was used
+    expect(mockFleetResourceRequest).not.toHaveBeenCalled()
+    const scNode = result.nodes.find((n) => n.type === 'storageclass' && n.name === 'local-sc')
+    expect(scNode).toBeDefined()
+  })
+
+  it('should handle pull model with sources array in spec for uniformity check', async () => {
+    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+    mockFleetResourceRequest.mockResolvedValueOnce({
+      status: {
+        resources: [
+          {
+            kind: 'Deployment',
+            name: 'multi-src-deploy',
+            namespace: 'default',
+            version: 'v1',
+            group: 'apps',
+            health: { status: 'Healthy' },
+          },
+        ],
+      },
+    } as any)
+
+    mockSearchClient.query.mockResolvedValueOnce({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'uid-ms1',
+                name: 'multi-src-cluster-1',
+                namespace: 'openshift-gitops',
+                cluster: 'cluster-1',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+              {
+                _uid: 'uid-ms2',
+                name: 'multi-src-cluster-2',
+                namespace: 'openshift-gitops',
+                cluster: 'cluster-2',
+                kind: 'Application',
+                apigroup: 'argoproj.io',
+              },
+            ],
+            related: [],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'multi-src',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'multi-src', namespace: 'openshift-gitops' },
+        spec: { generators: [{}] },
+      },
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'cluster-1' }, { name: 'cluster-2' }],
+      appSetApps: [
+        {
+          metadata: { name: 'multi-src-cluster-1' },
+          spec: { sources: [{ repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' }] },
+        },
+        {
+          metadata: { name: 'multi-src-cluster-2' },
+          spec: { sources: [{ repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' }] },
+        },
+      ] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // Uniform sources array — only one fleet request needed
+    expect(mockFleetResourceRequest).toHaveBeenCalledTimes(1)
+    expect(result.nodes.find((n) => n.type === 'deployment' && n.name === 'multi-src-deploy')).toBeDefined()
+  })
+
   it('should filter by active applications when provided', async () => {
     mockSearchClient.query.mockResolvedValue({
       loading: false,

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -144,8 +144,12 @@ describe('openRouteURL', () => {
 })
 
 describe('getAppSetTopology', () => {
+  const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
+
   beforeEach(() => {
-    jest.clearAllMocks()
+    mockFleetResourceRequest.mockReset()
+    mockSearchClient.query.mockReset()
+    mockFleetResourceRequest.mockResolvedValue({ errorMessage: 'not available' } as any)
     mockSearchClient.query.mockResolvedValue({
       loading: false,
       networkStatus: 7,
@@ -727,7 +731,6 @@ describe('getAppSetTopology', () => {
   })
 
   it('should include cluster-scoped resources from remote Application status.resources for pull model', async () => {
-    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
     mockFleetResourceRequest.mockResolvedValueOnce({
       apiVersion: 'argoproj.io/v1alpha1',
       kind: 'Application',
@@ -831,7 +834,6 @@ describe('getAppSetTopology', () => {
   })
 
   it('should show resources with healthy status as running for pull model', async () => {
-    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
     mockFleetResourceRequest.mockResolvedValueOnce({
       apiVersion: 'argoproj.io/v1alpha1',
       kind: 'Application',
@@ -992,7 +994,6 @@ describe('getAppSetTopology', () => {
   })
 
   it('should fetch resources individually for pull model with non-uniform sources (matrix generator)', async () => {
-    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
     // Two different apps fetched individually due to non-uniform sources
     mockFleetResourceRequest
       .mockResolvedValueOnce({
@@ -1093,7 +1094,6 @@ describe('getAppSetTopology', () => {
   })
 
   it('should handle pull model when fleet request fails and no local resources available', async () => {
-    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
     mockFleetResourceRequest.mockResolvedValueOnce({ errorMessage: 'cluster unavailable' } as any)
 
     mockSearchClient.query.mockResolvedValueOnce({
@@ -1174,8 +1174,6 @@ describe('getAppSetTopology', () => {
   })
 
   it('should fetch resources via fleet request for uniform pull-model apps', async () => {
-    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
-    mockFleetResourceRequest.mockClear()
     mockFleetResourceRequest.mockResolvedValueOnce({
       apiVersion: 'argoproj.io/v1alpha1',
       kind: 'Application',
@@ -1246,7 +1244,6 @@ describe('getAppSetTopology', () => {
   })
 
   it('should handle pull model with sources array in spec for uniformity check', async () => {
-    const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
     mockFleetResourceRequest.mockResolvedValueOnce({
       status: {
         resources: [

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -526,9 +526,11 @@ describe('getAppSetTopology', () => {
     expect((crdNode as any).specs.clustersNames).toContain('local-cluster')
     expect((crdNode as any).specs.clustersNames).toContain('managed-cluster-1')
 
-    // Namespaced Deployment should still have separate entries per cluster (concatenated into allResources)
+    // Namespaced Deployment should still have separate entries per cluster
     const deployNodes = result.nodes.filter((n) => n.type === 'deployment' && n.name === 'my-app')
-    expect(deployNodes.length).toBeGreaterThanOrEqual(1)
+    expect(deployNodes).toHaveLength(2)
+    const deployIds = deployNodes.map((n) => n.id)
+    expect(deployIds[0]).not.toEqual(deployIds[1])
   })
 
   it('should handle ApplicationSet with app status information', async () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -902,9 +902,10 @@ describe('getAppSetTopology', () => {
     expect(scNode).toBeDefined()
     expect((scNode as any)?.specs?.raw?.status).toBe('running')
 
-    // Missing CRD should appear in topology (will be shown as pending)
+    // Missing CRD should appear in topology with pending status
     const crdNode = result.nodes.find((n) => n.type === 'customresourcedefinition' && n.name === 'missing.example.com')
     expect(crdNode).toBeDefined()
+    expect((crdNode as any)?.specs?.raw?.status).toBe('pending')
   })
 
   it('should filter by active clusters when provided', async () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -1173,9 +1173,25 @@ describe('getAppSetTopology', () => {
     expect(result.links).toBeDefined()
   })
 
-  it('should use local hub app resources without fleet request when hub has status.resources', async () => {
+  it('should fetch resources via fleet request for uniform pull-model apps', async () => {
     const mockFleetResourceRequest = fleetResourceRequest as jest.MockedFunction<typeof fleetResourceRequest>
     mockFleetResourceRequest.mockClear()
+    mockFleetResourceRequest.mockResolvedValueOnce({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: { name: 'hub-app-managed-1', namespace: 'openshift-gitops' },
+      status: {
+        resources: [
+          {
+            kind: 'StorageClass',
+            name: 'local-sc',
+            version: 'v1',
+            group: 'storage.k8s.io',
+            health: { status: 'Healthy' },
+          },
+        ],
+      },
+    } as any)
 
     mockSearchClient.query.mockResolvedValueOnce({
       loading: false,
@@ -1218,25 +1234,13 @@ describe('getAppSetTopology', () => {
         {
           metadata: { name: 'hub-app-managed-1' },
           spec: { source: { repoURL: 'https://git.io/repo', path: 'deploy', targetRevision: 'main' } },
-          status: {
-            resources: [
-              {
-                kind: 'StorageClass',
-                name: 'local-sc',
-                version: 'v1',
-                group: 'storage.k8s.io',
-                health: { status: 'Healthy' },
-              },
-            ],
-          },
         },
       ] as any,
     }
 
     const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
 
-    // No fleet request needed — local hub data was used
-    expect(mockFleetResourceRequest).not.toHaveBeenCalled()
+    expect(mockFleetResourceRequest).toHaveBeenCalledTimes(1)
     const scNode = result.nodes.find((n) => n.type === 'storageclass' && n.name === 'local-sc')
     expect(scNode).toBeDefined()
   })

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -760,6 +760,8 @@ describe('getAppSetTopology', () => {
 
     // Search returns only the Deployment as a related resource (CRD and StorageClass don't exist yet)
     mockSearchClient.query.mockResolvedValueOnce({
+      loading: false,
+      networkStatus: 7,
       data: {
         searchResult: [
           {
@@ -854,6 +856,8 @@ describe('getAppSetTopology', () => {
 
     // Search returns no related resources (nothing exists yet)
     mockSearchClient.query.mockResolvedValueOnce({
+      loading: false,
+      networkStatus: 7,
       data: {
         searchResult: [
           {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -612,7 +612,7 @@ function mergeExpectedWithSearchResults(
         mappedStatus = 'running'
       } else if (healthStatus === 'degraded') {
         mappedStatus = 'err'
-      } else if (healthStatus === 'progressing' || healthStatus === 'suspended') {
+      } else if (healthStatus === 'missing' || healthStatus === 'progressing' || healthStatus === 'suspended') {
         mappedStatus = 'pending'
       }
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -410,15 +410,28 @@ async function getAppSetResources(application: ApplicationModel) {
         relatedResult && !excludedKinds.has(relatedResult.kind.toLowerCase())
     )
 
+    // Fetch remote Application CRs to get status.resources for cluster-scoped resources
+    // that may not appear in search "related" results when they don't exist yet
+    const remoteAppResources = await fetchPullModelAppResources(applications, namespace, allClusterNames)
+
     applications?.forEach((application: ResourceItem) => {
       const applicationUid = application._uid as string
+      const applicationCluster = application.cluster as string
 
-      // Find related resources for this application on this cluster
-      const resourceList =
+      // Find related resources for this application on this cluster (resources that exist)
+      const searchRelatedList =
         relatedResults?.flatMap(
           (relatedResult: SearchRelatedResult | null) =>
             relatedResult?.items?.filter((item: ResourceItem) => item._relatedUids?.includes(applicationUid)) ?? []
         ) ?? []
+
+      // Get status.resources from the remote Application CR (the expected resources)
+      const appKey = `${application.name}/${applicationCluster}`
+      const expectedResources = remoteAppResources.get(appKey)
+
+      // Merge: use expected resources as the base, enriching with search data when available
+      const resourceList = mergeExpectedWithSearchResults(expectedResources, searchRelatedList, applicationCluster)
+
       mapRelatedResources(application.name, resourceList)
     })
   } else {
@@ -434,6 +447,111 @@ async function getAppSetResources(application: ApplicationModel) {
     applicationResourceMap,
     applicationNames: [...applicationNameSet] as string[],
   }
+}
+
+/**
+ * Fetches remote Application CRs for pull-model ApplicationSets to get their status.resources.
+ * This provides the list of expected resources regardless of whether they currently exist on the cluster.
+ *
+ * @returns Map keyed by "appName/clusterName" → array of resources from status.resources
+ */
+async function fetchPullModelAppResources(
+  applications: ResourceItem[] | undefined,
+  namespace: string,
+  allClusterNames: string[]
+): Promise<Map<string, ResourceItem[]>> {
+  const resourceMap = new Map<string, ResourceItem[]>()
+  if (!applications || applications.length === 0) {
+    return resourceMap
+  }
+
+  const fetchPromises = applications.map(async (application: ResourceItem) => {
+    const clusterName = application.cluster as string
+    if (!clusterName || !allClusterNames.includes(clusterName)) return
+
+    try {
+      const result = await fleetResourceRequest('GET', clusterName, {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'Application',
+        name: application.name as string,
+        namespace: namespace,
+      })
+
+      if ('errorMessage' in result) return
+
+      const resources = (result as any)?.status?.resources
+      if (Array.isArray(resources)) {
+        resourceMap.set(`${application.name}/${clusterName}`, resources)
+      }
+    } catch {
+      // If fleet request fails, fall back to search-only results
+    }
+  })
+
+  await Promise.allSettled(fetchPromises)
+  return resourceMap
+}
+
+/**
+ * Merges expected resources from the Application's status.resources with resources
+ * found via search. Resources in status.resources that aren't in search results
+ * are included as "expected" entries so they appear in topology regardless of
+ * their current existence on the cluster.
+ *
+ * Resources found in search are enriched with actual cluster data.
+ * Resources only in status.resources are synthesized with the target cluster,
+ * using health.status from the Application CR to determine deployed state.
+ */
+function mergeExpectedWithSearchResults(
+  expectedResources: ResourceItem[] | undefined,
+  searchRelatedList: ResourceItem[],
+  clusterName: string
+): ResourceItem[] {
+  if (!expectedResources || expectedResources.length === 0) {
+    return searchRelatedList
+  }
+
+  // Build a lookup of resources found by search (keyed by kind/name/namespace)
+  const searchResourceKeys = new Set<string>()
+  searchRelatedList.forEach((item: ResourceItem) => {
+    const key = `${(item.kind || '').toLowerCase()}/${item.name || ''}/${item.namespace || ''}`
+    searchResourceKeys.add(key)
+  })
+
+  // Start with all search-found resources (these are confirmed to exist)
+  const merged: ResourceItem[] = [...searchRelatedList]
+
+  // Add expected resources that don't exist in search results
+  expectedResources.forEach((resource: ResourceItem) => {
+    const kind = (resource.kind || '').toLowerCase()
+    const key = `${kind}/${resource.name || ''}/${resource.namespace || ''}`
+    if (!searchResourceKeys.has(key)) {
+      const healthStatus = resource.health?.status?.toLowerCase() || ''
+      // Map ArgoCD health status to search-compatible status for topology display:
+      // Healthy → running (green), Missing → not deployed (pending), Degraded → err (red)
+      let mappedStatus = ''
+      if (healthStatus === 'healthy') {
+        mappedStatus = 'running'
+      } else if (healthStatus === 'degraded') {
+        mappedStatus = 'err'
+      } else if (healthStatus === 'progressing' || healthStatus === 'suspended') {
+        mappedStatus = 'pending'
+      }
+
+      merged.push({
+        name: resource.name,
+        namespace: resource.namespace,
+        kind: resource.kind,
+        version: resource.version,
+        group: resource.group,
+        cluster: clusterName,
+        status: mappedStatus,
+        _hubCell: '',
+      })
+    }
+  })
+
+  return merged
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -588,8 +588,12 @@ function processResources(
     })
   }
 
+  // Deduplicate cluster-scoped resources (no namespace) that appear on multiple clusters.
+  // They should become a single node with all target clusters in clustersNames.
+  const deduplicatedResources = deduplicateClusterScopedResources(allResources)
+
   // create nodes for each resource
-  processMultiples(allResources).forEach((deployable: Record<string, unknown>) => {
+  processMultiples(deduplicatedResources).forEach((deployable: Record<string, unknown>) => {
     const typedDeployable = deployable as unknown as ProcessedDeployableResource
     const {
       name: deployableName,
@@ -607,8 +611,9 @@ function processResources(
       (deployableResources as any)?.[0]?.cluster ??
       getClusterName(parentId, hubClusterName)
 
-    // Generate unique member ID for the deployable resource
-    const memberId = `member--member--deployable--member--clusters--${deployableCluster}--${type}--${deployableNamespace}--${deployableName}`
+    // For cluster-scoped resources, use a stable ID without cluster to prevent duplicates
+    const clusterInId = deployableNamespace ? deployableCluster : parentClusterNames[0] || deployableCluster
+    const memberId = `member--member--deployable--member--clusters--${clusterInId}--${type}--${deployableNamespace}--${deployableName}`
 
     // Create raw resource object with metadata
     const raw: any = {
@@ -628,6 +633,11 @@ function processResources(
       raw.apiVersion = apiVersion
     }
 
+    // For cluster-scoped resources, use all target clusters; for namespaced, use parent clusters
+    const nodeClusters = deployableNamespace
+      ? parentClusterNames
+      : (typedDeployable as any)._targetClusters || parentClusterNames
+
     // Create deployable resource node
     let deployableObj: TopologyNode = {
       name: deployableName,
@@ -638,12 +648,12 @@ function processResources(
       specs: {
         isDesign: false,
         raw,
-        clustersNames: parentClusterNames,
+        clustersNames: nodeClusters,
         parent: {
           clusterId: parentId,
         },
         resources: deployableResources,
-        resourceCount: resourceCount || parentClusterNames.length,
+        resourceCount: resourceCount || nodeClusters.length,
       },
     }
 
@@ -663,6 +673,38 @@ function processResources(
     // Create virtual machine instance child nodes (for KubeVirt)
     createVirtualMachineInstance(deployableObj, parentClusterNames || [], activeTypes, links, nodes)
   })
+}
+
+/**
+ * Deduplicates cluster-scoped resources (those without a namespace) that appear
+ * multiple times for different clusters. Combines them into a single entry with
+ * _targetClusters containing all clusters where the resource should be deployed.
+ * Namespaced resources are returned unchanged.
+ */
+function deduplicateClusterScopedResources(resources: ResourceItem[]): ResourceItem[] {
+  const clusterScoped: Map<string, ResourceItem> = new Map()
+  const namespaced: ResourceItem[] = []
+
+  resources.forEach((resource: ResourceItem) => {
+    if (resource.namespace) {
+      namespaced.push(resource)
+    } else {
+      const key = `${(resource.kind || '').toLowerCase()}/${resource.name || ''}`
+      const existing = clusterScoped.get(key)
+      if (existing) {
+        const clusters = (existing as any)._targetClusters || [existing.cluster]
+        if (resource.cluster && !clusters.includes(resource.cluster)) {
+          clusters.push(resource.cluster)
+        }
+        ;(existing as any)._targetClusters = clusters
+      } else {
+        const entry = { ...resource, _targetClusters: resource.cluster ? [resource.cluster] : [] }
+        clusterScoped.set(key, entry)
+      }
+    }
+  })
+
+  return [...namespaced, ...Array.from(clusterScoped.values())]
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -412,7 +412,12 @@ async function getAppSetResources(application: ApplicationModel) {
 
     // Fetch remote Application CRs to get status.resources for cluster-scoped resources
     // that may not appear in search "related" results when they don't exist yet
-    const remoteAppResources = await fetchPullModelAppResources(applications, namespace, allClusterNames)
+    const remoteAppResources = await fetchPullModelAppResources(
+      applications,
+      namespace,
+      allClusterNames,
+      appSetApps as ResourceItem[]
+    )
 
     applications?.forEach((application: ResourceItem) => {
       const applicationUid = application._uid as string
@@ -453,43 +458,116 @@ async function getAppSetResources(application: ApplicationModel) {
  * Fetches remote Application CRs for pull-model ApplicationSets to get their status.resources.
  * This provides the list of expected resources regardless of whether they currently exist on the cluster.
  *
+ * Optimization: Determines whether all apps deploy the same manifests by comparing the
+ * source specs of the hub Application CRs (appSetApps). If all sources are identical,
+ * only one fleet request is made and the result is reused for all apps. If sources differ
+ * (matrix/merge generator varying paths), each app is fetched individually.
+ *
  * @returns Map keyed by "appName/clusterName" → array of resources from status.resources
  */
 async function fetchPullModelAppResources(
   applications: ResourceItem[] | undefined,
   namespace: string,
-  allClusterNames: string[]
+  allClusterNames: string[],
+  appSetApps: ResourceItem[] = []
 ): Promise<Map<string, ResourceItem[]>> {
   const resourceMap = new Map<string, ResourceItem[]>()
   if (!applications || applications.length === 0) {
     return resourceMap
   }
 
-  const fetchPromises = applications.map(async (application: ResourceItem) => {
-    const clusterName = application.cluster as string
-    if (!clusterName || !allClusterNames.includes(clusterName)) return
+  // Only fetch from clusters where search found an Application
+  const validApps = applications.filter(
+    (app: ResourceItem) => app.cluster && allClusterNames.includes(app.cluster as string)
+  )
+  if (validApps.length === 0) return resourceMap
 
-    try {
-      const result = await fleetResourceRequest('GET', clusterName, {
-        apiVersion: 'argoproj.io/v1alpha1',
-        kind: 'Application',
-        name: application.name as string,
-        namespace: namespace,
-      })
+  const uniform = areAppSourcesUniform(appSetApps)
 
-      if ('errorMessage' in result) return
-
-      const resources = (result as any)?.status?.resources
-      if (Array.isArray(resources)) {
-        resourceMap.set(`${application.name}/${clusterName}`, resources)
+  if (uniform) {
+    // All apps deploy the same manifests — try hub data first, then one fleet request
+    const resources = getLocalAppResources(appSetApps) ?? (await fetchFirstAvailableAppResources(validApps, namespace))
+    if (resources) {
+      for (const app of validApps) {
+        resourceMap.set(`${app.name}/${app.cluster}`, resources)
       }
-    } catch {
-      // If fleet request fails, fall back to search-only results
     }
-  })
+  } else {
+    // Sources differ across apps — must fetch each individually
+    const fetchPromises = validApps.map(async (application: ResourceItem) => {
+      const resources = await fetchSingleAppResources(application, namespace)
+      if (resources) {
+        resourceMap.set(`${application.name}/${application.cluster}`, resources)
+      }
+    })
+    await Promise.allSettled(fetchPromises)
+  }
 
-  await Promise.allSettled(fetchPromises)
   return resourceMap
+}
+
+/**
+ * Determines whether all Application CRs in the ApplicationSet deploy the same manifests
+ * by comparing their source specifications. If all apps have identical source (repoURL + path +
+ * targetRevision + chart), they will produce the same resources regardless of which cluster
+ * they target.
+ */
+function areAppSourcesUniform(appSetApps: ResourceItem[]): boolean {
+  if (appSetApps.length <= 1) return true
+
+  const getSourceKey = (app: ResourceItem): string => {
+    const spec = (app as any).spec || (app as any).metadata?.spec || {}
+    const source = spec.source || {}
+    const sources = spec.sources
+    if (Array.isArray(sources)) {
+      return JSON.stringify(sources.map((s: any) => ({ r: s.repoURL, p: s.path, t: s.targetRevision, c: s.chart })))
+    }
+    return `${source.repoURL || ''}|${source.path || ''}|${source.targetRevision || ''}|${source.chart || ''}`
+  }
+
+  const firstKey = getSourceKey(appSetApps[0])
+  return appSetApps.every((app) => getSourceKey(app) === firstKey)
+}
+
+/**
+ * Returns status.resources from a local hub Application CR if available.
+ * When the hub is also a target cluster, the local ArgoCD populates status.resources
+ * directly on the hub app — no fleet request needed.
+ */
+function getLocalAppResources(appSetApps: ResourceItem[]): ResourceItem[] | null {
+  for (const app of appSetApps) {
+    const resources = (app as any).status?.resources
+    if (Array.isArray(resources) && resources.length > 0) return resources
+  }
+  return null
+}
+
+/** Attempts to fetch status.resources from the first reachable Application. */
+async function fetchFirstAvailableAppResources(
+  validApps: ResourceItem[],
+  namespace: string
+): Promise<ResourceItem[] | null> {
+  for (const app of validApps) {
+    const resources = await fetchSingleAppResources(app, namespace)
+    if (resources) return resources
+  }
+  return null
+}
+
+async function fetchSingleAppResources(application: ResourceItem, namespace: string): Promise<ResourceItem[] | null> {
+  try {
+    const result = await fleetResourceRequest('GET', application.cluster as string, {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      name: application.name as string,
+      namespace,
+    })
+    if ('errorMessage' in result) return null
+    const resources = (result as any)?.status?.resources
+    return Array.isArray(resources) ? resources : null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -23,13 +23,14 @@ import {
 import {
   addClusters,
   addTopologyNode,
+  areSourcesUniform,
   createControllerRevisionChild,
   createDataVolumeChild,
   createReplicaChild,
   createVirtualMachineInstance,
+  fetchArgoAppStatusResources,
   getClusterName,
   getResourceTypes,
-  processMultiples,
 } from './topologyUtils'
 import { PlacementDecision } from '../../../../../resources/placement-decision'
 import { Placement } from '../../../../../resources/placement'
@@ -482,92 +483,56 @@ async function fetchPullModelAppResources(
   )
   if (validApps.length === 0) return resourceMap
 
-  const uniform = areAppSourcesUniform(appSetApps)
+  const uniform = areSourcesUniform(appSetApps, (app: ResourceItem) => {
+    const spec = (app as any).spec || (app as any).metadata?.spec || {}
+    return { source: spec.source, sources: spec.sources }
+  })
+  const appResources = await fetchAppResources(validApps, namespace, uniform)
 
-  if (uniform) {
-    // All apps deploy the same manifests — try hub data first, then one fleet request
-    const resources = getLocalAppResources(appSetApps) ?? (await fetchFirstAvailableAppResources(validApps, namespace))
+  for (const app of validApps) {
+    const resources = appResources.get(`${app.name}/${app.cluster}`)
     if (resources) {
-      for (const app of validApps) {
-        resourceMap.set(`${app.name}/${app.cluster}`, resources)
-      }
+      resourceMap.set(`${app.name}/${app.cluster}`, resources)
     }
-  } else {
-    // Sources differ across apps — must fetch each individually
-    const fetchPromises = validApps.map(async (application: ResourceItem) => {
-      const resources = await fetchSingleAppResources(application, namespace)
-      if (resources) {
-        resourceMap.set(`${application.name}/${application.cluster}`, resources)
-      }
-    })
-    await Promise.allSettled(fetchPromises)
   }
 
   return resourceMap
 }
 
 /**
- * Determines whether all Application CRs in the ApplicationSet deploy the same manifests
- * by comparing their source specifications. If all apps have identical source (repoURL + path +
- * targetRevision + chart), they will produce the same resources regardless of which cluster
- * they target.
+ * Fetches status.resources from remote Application CRs.
+ * When uniform is true, fetches once and reuses the result for all apps.
+ * When uniform is false, fetches each app individually in parallel.
  */
-function areAppSourcesUniform(appSetApps: ResourceItem[]): boolean {
-  if (appSetApps.length <= 1) return true
+async function fetchAppResources(
+  apps: ResourceItem[],
+  namespace: string,
+  uniform: boolean
+): Promise<Map<string, ResourceItem[]>> {
+  const resourceMap = new Map<string, ResourceItem[]>()
 
-  const getSourceKey = (app: ResourceItem): string => {
-    const spec = (app as any).spec || (app as any).metadata?.spec || {}
-    const source = spec.source || {}
-    const sources = spec.sources
-    if (Array.isArray(sources)) {
-      return JSON.stringify(sources.map((s: any) => ({ r: s.repoURL, p: s.path, t: s.targetRevision, c: s.chart })))
+  if (uniform) {
+    let sharedResources: ResourceItem[] | null = null
+    for (const app of apps) {
+      sharedResources = await fetchArgoAppStatusResources(app.cluster as string, app.name as string, namespace)
+      if (sharedResources) break
     }
-    return `${source.repoURL || ''}|${source.path || ''}|${source.targetRevision || ''}|${source.chart || ''}`
-  }
-
-  const firstKey = getSourceKey(appSetApps[0])
-  return appSetApps.every((app) => getSourceKey(app) === firstKey)
-}
-
-/**
- * Returns status.resources from a local hub Application CR if available.
- * When the hub is also a target cluster, the local ArgoCD populates status.resources
- * directly on the hub app — no fleet request needed.
- */
-function getLocalAppResources(appSetApps: ResourceItem[]): ResourceItem[] | null {
-  for (const app of appSetApps) {
-    const resources = (app as any).status?.resources
-    if (Array.isArray(resources) && resources.length > 0) return resources
-  }
-  return null
-}
-
-/** Attempts to fetch status.resources from the first reachable Application. */
-async function fetchFirstAvailableAppResources(
-  validApps: ResourceItem[],
-  namespace: string
-): Promise<ResourceItem[] | null> {
-  for (const app of validApps) {
-    const resources = await fetchSingleAppResources(app, namespace)
-    if (resources) return resources
-  }
-  return null
-}
-
-async function fetchSingleAppResources(application: ResourceItem, namespace: string): Promise<ResourceItem[] | null> {
-  try {
-    const result = await fleetResourceRequest('GET', application.cluster as string, {
-      apiVersion: 'argoproj.io/v1alpha1',
-      kind: 'Application',
-      name: application.name as string,
-      namespace,
+    if (sharedResources) {
+      for (const app of apps) {
+        resourceMap.set(`${app.name}/${app.cluster}`, sharedResources)
+      }
+    }
+  } else {
+    const fetchPromises = apps.map(async (app: ResourceItem) => {
+      const resources = await fetchArgoAppStatusResources(app.cluster as string, app.name as string, namespace)
+      if (resources) {
+        resourceMap.set(`${app.name}/${app.cluster}`, resources)
+      }
     })
-    if ('errorMessage' in result) return null
-    const resources = (result as any)?.status?.resources
-    return Array.isArray(resources) ? resources : null
-  } catch {
-    return null
+    await Promise.allSettled(fetchPromises)
   }
+
+  return resourceMap
 }
 
 /**
@@ -671,7 +636,7 @@ function processResources(
   const deduplicatedResources = deduplicateClusterScopedResources(allResources)
 
   // create nodes for each resource
-  processMultiples(deduplicatedResources).forEach((deployable: Record<string, unknown>) => {
+  deduplicatedResources.forEach((deployable: Record<string, unknown>) => {
     const typedDeployable = deployable as unknown as ProcessedDeployableResource
     const {
       name: deployableName,

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
@@ -3,7 +3,16 @@
 
 import { nodeMustHavePods } from '../helpers/diagram-helpers-utils'
 import { convertStringToQuery } from '../helpers/search-helper'
-import type { ApplicationData, ManagedCluster, SearchQuery, Topology, TopologyLink, TopologyNode } from '../types'
+import { fleetResourceRequest } from '../../../../../resources/utils/fleet-resource-request'
+import type {
+  AppSetClusterInfo,
+  ApplicationData,
+  ManagedCluster,
+  SearchQuery,
+  Topology,
+  TopologyLink,
+  TopologyNode,
+} from '../types'
 import { deepClone } from '../utils'
 
 /**
@@ -476,4 +485,102 @@ export const addTopologyNode = (
     return node
   }
   return { ...node, id: parentId }
+}
+
+/**
+ * Fetches status.resources from a remote ArgoCD Application CR via fleet request.
+ * Used by both topology and resource-status code paths to retrieve the expected
+ * resource list from a managed cluster's ArgoCD instance.
+ */
+export async function fetchArgoAppStatusResources(
+  clusterName: string,
+  appName: string,
+  namespace: string
+): Promise<any[] | null> {
+  try {
+    const result = await fleetResourceRequest('GET', clusterName, {
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      name: appName,
+      namespace,
+    })
+    if ('errorMessage' in result) return null
+    const resources = (result as any)?.status?.resources
+    return Array.isArray(resources) && resources.length > 0 ? resources : null
+  } catch {
+    return null
+  }
+}
+
+interface SourceSpec {
+  repoURL?: string
+  path?: string
+  targetRevision?: string
+  chart?: string
+}
+
+/**
+ * Determines whether all items share the same ArgoCD source specification.
+ * When sources are uniform, a single fleet request can supply the resource list
+ * for every item. The caller provides getSourceSpec to extract the source/sources
+ * from its own item type.
+ */
+export function areSourcesUniform<T>(
+  items: T[],
+  getSourceSpec: (item: T) => { source?: SourceSpec; sources?: SourceSpec[] }
+): boolean {
+  if (items.length <= 1) return true
+
+  const getKey = (item: T): string => {
+    const { source, sources } = getSourceSpec(item)
+    if (Array.isArray(sources)) {
+      return JSON.stringify(sources.map((s) => ({ r: s.repoURL, p: s.path, t: s.targetRevision, c: s.chart })))
+    }
+    return `${source?.repoURL || ''}|${source?.path || ''}|${source?.targetRevision || ''}|${source?.chart || ''}`
+  }
+
+  const firstKey = getKey(items[0])
+  return items.every((item) => getKey(item) === firstKey)
+}
+
+/**
+ * Resolves the target cluster name for an ArgoCD Application from its destination spec.
+ *
+ * Mirrors the logic in getArgoDestinationCluster (topologyArgo.ts / backend utils.ts):
+ *  - destination.name → direct match against cluster names (handles "in-cluster" → hub)
+ *  - destination.server → resolves via kubernetes.default.svc, cluster-proxy URL, or raw kube API URL
+ */
+export function getAppTargetCluster(
+  destination: { name?: string; server?: string },
+  clusters: AppSetClusterInfo[]
+): string | null {
+  if (destination.name) {
+    const name = destination.name === 'in-cluster' ? 'local-cluster' : destination.name
+    return findClusterByName(clusters, name)
+  }
+  if (destination.server) {
+    return resolveClusterFromServer(destination.server, clusters)
+  }
+  return null
+}
+
+function findClusterByName(clusters: AppSetClusterInfo[], name: string): string | null {
+  const match = clusters.find((c) => c.name === name)
+  return match ? match.name : null
+}
+
+const PROXY_URL_PATTERN = /\.svc\.cluster\.local:\d+\/(.+)$/
+
+function resolveClusterFromServer(server: string, clusters: AppSetClusterInfo[]): string | null {
+  if (server === 'https://kubernetes.default.svc') {
+    return findClusterByName(clusters, 'local-cluster')
+  }
+  // Cluster proxy URL: https://cluster-proxy-addon-user.multicluster-engine.svc.cluster.local:<port>/<cluster>
+  const proxyMatch = PROXY_URL_PATTERN.exec(server)
+  if (proxyMatch) {
+    return findClusterByName(clusters, proxyMatch[1])
+  }
+  // Raw kube API server URL — match against server or url fields
+  const match = clusters.find((c) => c.server === server || (c as any).url === server)
+  return match ? match.name : null
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
AppSet cluster scoped node status incorrect in the topology node details panel

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-30436

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

## Before

https://github.com/user-attachments/assets/3bac1d54-8ec1-4c13-bd84-28ddb0c39beb


## After

https://github.com/user-attachments/assets/626ce5a1-9b1e-40f1-b4b5-18a5541d071a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource display for pull-model ApplicationSets when remote status data is missing and avoided unnecessary remote fetches when status is already present.
  * Prevented duplication of cluster-scoped resources across clusters.

* **Improvements**
  * Topology now enriches and merges remote application resource lists from managed clusters, maps remote health into topology statuses, and aggregates cluster info for cluster-scoped nodes.
  * Search queries for non-namespace-scoped resources are explicitly scoped to target clusters.

* **Tests**
  * Added tests for pull-model fetch/merge flows, uniform vs non-uniform sources, deduplication, and error/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->