### PR TITLE
ACM-32500 Preserve newlines in CSV export to match console rendering

### DIFF
--- a/frontend/src/resources/utils/utils.ts
+++ b/frontend/src/resources/utils/utils.ts
@@ -52,8 +52,7 @@ export function exportObjectString(object: Record<string, string>) {
 }
 
 export function returnCSVSafeString(exportValue: string | ReactNode) {
-  // extract newlines
-  return `"${typeof exportValue === 'string' ? exportValue.split('\n').join(' ').replaceAll('"', '""') : exportValue}"`
+  return `"${typeof exportValue === 'string' ? exportValue.replaceAll('"', '""') : exportValue}"`
 }
 
 export const getISOStringTimestamp = (timestamp: string) => {

--- a/frontend/src/resources/utils/utils.ts
+++ b/frontend/src/resources/utils/utils.ts
@@ -52,7 +52,10 @@ export function exportObjectString(object: Record<string, string>) {
 }
 
 export function returnCSVSafeString(exportValue: string | ReactNode) {
-  return `"${typeof exportValue === 'string' ? exportValue.replaceAll('"', '""') : exportValue}"`
+  if (typeof exportValue !== 'string') {
+    return '"-"'
+  }
+  return `"${exportValue.replaceAll('"', '""')}"`
 }
 
 export const getISOStringTimestamp = (timestamp: string) => {

--- a/frontend/src/resources/utils/utils.ts
+++ b/frontend/src/resources/utils/utils.ts
@@ -51,7 +51,10 @@ export function exportObjectString(object: Record<string, string>) {
   return keyValueMap.toString()
 }
 
-export function returnCSVSafeString(exportValue: string | ReactNode) {
+export function returnCSVSafeString(exportValue: string | number | ReactNode) {
+  if (typeof exportValue === 'number') {
+    return `"${exportValue}"`
+  }
   if (typeof exportValue !== 'string') {
     return '"-"'
   }

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1039,7 +1039,7 @@ describe('ACM-32500: UI description text should match CSV export for multiline d
   test('preserveWhitespace textContent should match CSV export content', () => {
     const formatted = preserveWhitespace(descriptionFromApi)
     const { container } = render(<>{formatted}</>)
-    const uiText = (container.textContent ?? '').replace(/\n/g, ' ')
+    const uiText = container.textContent
 
     const csvRaw = returnCSVSafeString(descriptionFromApi)
     const csvText = csvRaw.slice(1, -1)

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1036,18 +1036,15 @@ describe('ACM-32500: UI description text should match CSV export for multiline d
   const descriptionFromApi =
     'Policy is placed on hub or managed clusters with label acm-virt-config=acm-dr-virt-config-file-name.\nCreates a velero Schedule for all virtualmachines.kubevirt.io resources with a cluster.open-cluster-management.io/backup-vm label.'
 
-  test('DOM textContent should include CSV export value (mirrors Cypress include.text assertion)', () => {
-    // Simulate UI: render description with preserveWhitespace, extract textContent
+  test('preserveWhitespace textContent should equal CSV export value', () => {
     const formatted = preserveWhitespace(descriptionFromApi)
     const { container } = render(<>{formatted}</>)
     const uiText = container.textContent
 
-    // Simulate CSV: returnCSVSafeString wraps in quotes, strip them to get the raw CSV cell value
     const csvRaw = returnCSVSafeString(descriptionFromApi)
     const csvText = csvRaw.slice(1, -1)
 
-    // Cypress uses: .should('include.text', value) — a substring match via jQuery .text()
-    expect(uiText).toContain(csvText)
+    expect(uiText).toEqual(csvText)
   })
 
   test('preserveWhitespace returns undefined for empty input', () => {

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1,13 +1,16 @@
 /* Copyright Contributors to the Open Cluster Management project */
 'use strict'
 
+import { render } from '@testing-library/react'
 import {
   hasInformOnlyPolicies,
   getPolicyRemediation,
   resolveExternalStatus,
   parseStringMap,
   policyHasDeletePruneBehavior,
+  preserveWhitespace,
 } from './util'
+import { returnCSVSafeString } from '../../../resources/utils/utils'
 import { PolicyTableItem } from '../policies/Policies'
 import { Policy, PolicyTemplate, REMEDIATION_ACTION } from '../../../resources'
 import { cloneDeep } from 'lodash'
@@ -1026,5 +1029,26 @@ describe('Test policyHasDeletePruneBehavior', () => {
     const policy = cloneDeep(basePolicy)
     delete policy.spec['policy-templates']
     expect(policyHasDeletePruneBehavior(policy)).toBe(false)
+  })
+})
+
+describe('ACM-32500: UI description text should match CSV export for multiline descriptions', () => {
+  const descriptionFromApi =
+    'Policy is placed on hub or managed clusters with label acm-virt-config=acm-dr-virt-config-file-name.\nCreates a velero Schedule for all virtualmachines.kubevirt.io resources with a cluster.open-cluster-management.io/backup-vm label.'
+
+  test('preserveWhitespace textContent should preserve whitespace between lines', () => {
+    const formatted = preserveWhitespace(descriptionFromApi)
+    const { container } = render(<>{formatted}</>)
+    const uiText = container.textContent
+
+    const csvRaw = returnCSVSafeString(descriptionFromApi)
+    const csvText = csvRaw.slice(1, -1)
+
+    expect(uiText).toEqual(csvText)
+  })
+
+  test('preserveWhitespace returns undefined for empty input', () => {
+    expect(preserveWhitespace(undefined)).toBeUndefined()
+    expect(preserveWhitespace('')).toBeUndefined()
   })
 })

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1036,10 +1036,10 @@ describe('ACM-32500: UI description text should match CSV export for multiline d
   const descriptionFromApi =
     'Policy is placed on hub or managed clusters with label acm-virt-config=acm-dr-virt-config-file-name.\nCreates a velero Schedule for all virtualmachines.kubevirt.io resources with a cluster.open-cluster-management.io/backup-vm label.'
 
-  test('preserveWhitespace textContent should preserve whitespace between lines', () => {
+  test('preserveWhitespace textContent should match CSV export content', () => {
     const formatted = preserveWhitespace(descriptionFromApi)
     const { container } = render(<>{formatted}</>)
-    const uiText = container.textContent
+    const uiText = (container.textContent ?? '').replace(/\n/g, ' ')
 
     const csvRaw = returnCSVSafeString(descriptionFromApi)
     const csvText = csvRaw.slice(1, -1)

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1036,15 +1036,18 @@ describe('ACM-32500: UI description text should match CSV export for multiline d
   const descriptionFromApi =
     'Policy is placed on hub or managed clusters with label acm-virt-config=acm-dr-virt-config-file-name.\nCreates a velero Schedule for all virtualmachines.kubevirt.io resources with a cluster.open-cluster-management.io/backup-vm label.'
 
-  test('preserveWhitespace textContent should match CSV export content', () => {
+  test('DOM textContent should include CSV export value (mirrors Cypress include.text assertion)', () => {
+    // Simulate UI: render description with preserveWhitespace, extract textContent
     const formatted = preserveWhitespace(descriptionFromApi)
     const { container } = render(<>{formatted}</>)
     const uiText = container.textContent
 
+    // Simulate CSV: returnCSVSafeString wraps in quotes, strip them to get the raw CSV cell value
     const csvRaw = returnCSVSafeString(descriptionFromApi)
     const csvText = csvRaw.slice(1, -1)
 
-    expect(uiText).toEqual(csvText)
+    // Cypress uses: .should('include.text', value) — a substring match via jQuery .text()
+    expect(uiText).toContain(csvText)
   })
 
   test('preserveWhitespace returns undefined for empty input', () => {

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1042,7 +1042,7 @@ describe('ACM-32500: UI description text should match CSV export for multiline d
     const uiText = container.textContent
 
     const csvRaw = returnCSVSafeString(descriptionFromApi)
-    const csvText = csvRaw.slice(1, -1)
+    const csvText = csvRaw.slice(1, -1).replace(/""/g, '"')
 
     expect(uiText).toEqual(csvText)
   })

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -1258,10 +1258,10 @@ describe('AcmTable', () => {
 })
 
 describe('returnCSVSafeString', () => {
-  test('returns a csv safe string replacing new line with space', () => {
+  test('returns a csv safe string preserving newlines', () => {
     const content = 'testing for multiline\ndescription'
     const exportContent = returnCSVSafeString(content)
-    expect(exportContent).toEqual('"testing for multiline description"')
+    expect(exportContent).toEqual('"testing for multiline\ndescription"')
   })
 
   test('returns a csv safe string escaping double quotes', () => {


### PR DESCRIPTION
## Summary
- PR #6063 (ACM-33260) introduced `preserveWhitespace` which renders `\n` as visual line breaks via `white-space: pre-wrap`, replacing the old `formatDescriptionForDropdown` function
- Because the console now preserves newlines in rendered descriptions, the CSV export should preserve them too — `returnCSVSafeString` no longer strips `\n` from exported values
- Newlines inside double-quoted CSV fields are valid per RFC 4180
- Adds a regression test verifying strict equality between DOM `textContent` and CSV export output for multiline policy descriptions

## Test plan
- [x] `util.test.tsx` — 54/54 pass (including ACM-32500 regression test with strict equality)
- [x] `AcmTable.test.tsx` — 50/50 pass (including updated `returnCSVSafeString` tests)
- [x] Lint and prettier clean
- [ ] Verify RHACM4K-52041 Cypress suite passes against this build

**Ticket:** https://redhat.atlassian.net/browse/ACM-32500

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


_____

See samples export screenshot:
<img width="1515" height="238" alt="Screenshot 2026-05-01 at 8 42 06 PM" src="https://github.com/user-attachments/assets/4bf33619-2f37-4075-abdf-a8a6d2d31467" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV export now correctly preserves line breaks and whitespace in description fields instead of replacing them with spaces.
  * Non-string values in CSV exports are consistently displayed as "-".

* **Tests**
  * Updated test coverage to verify whitespace preservation in CSV export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->