### PR TITLE
ACM-33632 Remove references to old PF5 CSS vars

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/style.css
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/style.css
@@ -44,10 +44,10 @@
 .temptifly-controls-labels-container,
 .creation-view-controls-labels-container {
   border-style: solid;
-  border-width: var(--pf-v5-global--BorderWidth--sm);
-  border-top-color: var(--pf-v5-global--BorderColor--300);
-  border-right-color: var(--pf-v5-global--BorderColor--300);
-  border-bottom-color: var(--pf-v5-global--BorderColor--200);
-  border-left-color: var(--pf-v5-global--BorderColor--300);
+  border-width: var(--pf-t--global--border--width--regular);
+  border-top-color: var(--pf-t--global--border--color--default);
+  border-right-color: var(--pf-t--global--border--color--default);
+  border-bottom-color: var(--pf-t--global--border--color--default);
+  border-left-color: var(--pf-t--global--border--color--default);
   box-shadow: unset !important;
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Additional labels field has bold outline on OCP 4.22

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33632

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

## After Fix
<img width="1259" height="1264" alt="image" src="https://github.com/user-attachments/assets/6e2e22af-a6d7-4d23-bf04-82ef891d3281" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for cluster creation form labels to ensure consistency with the latest design system standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->