### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,39 @@
+FROM registry-proxy.engineering.redhat.com/ubi9/nodejs-20-minimal@sha256:74487cbe6bbc7ca514b877b00670360e71ab52f9c60625b9127bacb5cfaafe74 AS builder
+
+USER root
+ENV NPM_CONFIG_NODEDIR=/usr
+
+WORKDIR /app
+COPY . .
+
+# Running installs concurrently fails on aarch64
+RUN npm ci --omit=optional --unsafe-perm --ignore-scripts && npm cache clean --force 
+RUN cd backend && npm ci --omit=optional  --unsafe-perm --ignore-scripts && npm cache clean --force
+RUN cd frontend && npm ci --legacy-peer-deps --unsafe-perm --ignore-scripts && npm cache clean --force
+RUN npm run build:backend
+RUN cd frontend && npm run build:plugin:acm && npm cache clean --force
+
+# Remove build-time dependencies before packaging
+RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
+
+FROM registry-proxy.engineering.redhat.com/ubi9/nodejs-20-minimal@sha256:74487cbe6bbc7ca514b877b00670360e71ab52f9c60625b9127bacb5cfaafe74
+
+WORKDIR /app
+ENV NODE_ENV production
+COPY --from=builder /app/backend/node_modules ./node_modules
+COPY --from=builder /app/backend/backend.mjs ./
+COPY --from=builder /app/frontend/plugins/acm/dist ./public/plugin
+USER 1001
+CMD ["node", "backend.mjs"]
+
+LABEL com.redhat.component="console-container" \
+      url="https://github.com/stolostron/console" \
+      name="rhacm2/console-rhel9" \
+      summary="console" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="data,images" \
+      io.k8s.display-name="console" \
+      maintainer="['acm-component-maintainers@redhat.com']" \
+      description="console" \
+      io.k8s.description="console" \
+      cpe="cpe:/a:redhat:acm:2.16::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)