### PR TITLE
ACM-30601 Fix helper text spacing

### DIFF
--- a/frontend/src/components/TemplateEditor/controls/ControlPanelCheckbox.js
+++ b/frontend/src/components/TemplateEditor/controls/ControlPanelCheckbox.js
@@ -5,6 +5,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Checkbox, Radio } from '@patternfly/react-core'
 import ControlPanelFormGroup from './ControlPanelFormGroup'
+import { ControlPanelHelperText } from './ControlPanelHelperText'
 
 class ControlPanelCheckbox extends React.Component {
   static propTypes = {
@@ -25,7 +26,7 @@ class ControlPanelCheckbox extends React.Component {
 
   render() {
     const { controlId, control, controlData, handleChange, i18n } = this.props
-    const { name, active, type, tip, disabled = false } = control
+    const { name, active, type, disabled = false } = control
 
     const onChange = () => {
       control.active = !active
@@ -54,10 +55,10 @@ class ControlPanelCheckbox extends React.Component {
               controlId={controlId}
               control={control}
               controlData={controlData}
-              showTip={false}
+              disableHelperText={true}
             />
           </div>
-          <div style={{ fontSize: '14px', fontWeight: 'normal' }}>{tip}</div>
+          <ControlPanelHelperText control={control} controlData={controlData} controlId={controlId} i18n={i18n} />
         </div>
       </React.Fragment>
     )

--- a/frontend/src/components/TemplateEditor/controls/ControlPanelCheckbox.js
+++ b/frontend/src/components/TemplateEditor/controls/ControlPanelCheckbox.js
@@ -55,7 +55,7 @@ class ControlPanelCheckbox extends React.Component {
               controlId={controlId}
               control={control}
               controlData={controlData}
-              disableHelperText={true}
+              omitHelperText={true}
             />
           </div>
           <ControlPanelHelperText control={control} controlData={controlData} controlId={controlId} i18n={i18n} />

--- a/frontend/src/components/TemplateEditor/controls/ControlPanelFormGroup.tsx
+++ b/frontend/src/components/TemplateEditor/controls/ControlPanelFormGroup.tsx
@@ -12,11 +12,11 @@ const ControlPanelFormGroup = (props: {
   control: any
   controlData: any
   controlId: string
-  disableHelperText?: boolean
+  omitHelperText?: boolean
   i18n: TFunction
   hideLabel?: boolean
 }) => {
-  const { controlId, control, controlData, disableHelperText = false, children, i18n, hideLabel } = props
+  const { controlId, control, controlData, omitHelperText = false, children, i18n, hideLabel } = props
   const { name, opaque, tooltip, validation = {}, icon } = control
   return (
     <React.Fragment>
@@ -48,7 +48,7 @@ const ControlPanelFormGroup = (props: {
           }
         >
           {children}
-          {!disableHelperText && (
+          {!omitHelperText && (
             <ControlPanelHelperText control={control} controlData={controlData} controlId={controlId} i18n={i18n} />
           )}
         </FormGroup>

--- a/frontend/src/components/TemplateEditor/controls/ControlPanelFormGroup.tsx
+++ b/frontend/src/components/TemplateEditor/controls/ControlPanelFormGroup.tsx
@@ -4,22 +4,20 @@
 import React, { ReactNode } from 'react'
 import { Button, FormGroup, Popover } from '@patternfly/react-core'
 import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon'
-import { useDynamicPropertyValues } from '../helpers/dynamicProperties'
 import { TFunction } from 'react-i18next'
-import { AcmHelperText } from '../../../ui-components/AcmHelperText/AcmHelperText'
+import { ControlPanelHelperText } from './ControlPanelHelperText'
 
 const ControlPanelFormGroup = (props: {
   children: ReactNode
   control: any
   controlData: any
   controlId: string
-  showTip?: boolean
+  disableHelperText?: boolean
   i18n: TFunction
   hideLabel?: boolean
 }) => {
-  const { controlId, control, controlData, showTip, children, i18n, hideLabel } = props
-  const { name, exception, opaque, tooltip, tip, validation = {}, icon } = control
-  const { info } = useDynamicPropertyValues(control, controlData, i18n, ['info'])
+  const { controlId, control, controlData, disableHelperText = false, children, i18n, hideLabel } = props
+  const { name, opaque, tooltip, validation = {}, icon } = control
   return (
     <React.Fragment>
       <div style={opaque ? { pointerEvents: 'none', opacity: 0.7 } : {}}>
@@ -50,13 +48,9 @@ const ControlPanelFormGroup = (props: {
           }
         >
           {children}
-          {(showTip === undefined || showTip === true) && tip && <div style={{ fontSize: '14px' }}>{tip}</div>}
-          <AcmHelperText
-            controlId={controlId}
-            helperText={info}
-            validated={exception ? 'error' : info ? 'default' : undefined}
-            error={exception}
-          />
+          {!disableHelperText && (
+            <ControlPanelHelperText control={control} controlData={controlData} controlId={controlId} i18n={i18n} />
+          )}
         </FormGroup>
       </div>
     </React.Fragment>

--- a/frontend/src/components/TemplateEditor/controls/ControlPanelHelperText.tsx
+++ b/frontend/src/components/TemplateEditor/controls/ControlPanelHelperText.tsx
@@ -1,0 +1,24 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { AcmHelperText } from '~/ui-components/AcmHelperText/AcmHelperText'
+import { useDynamicPropertyValues } from '../helpers/dynamicProperties'
+import { TFunction } from 'react-i18next'
+
+export const ControlPanelHelperText = (props: {
+  control: any
+  controlData: any
+  controlId: string
+  i18n: TFunction
+}) => {
+  const { controlId, control, controlData, i18n } = props
+  const { exception, tip } = control
+  const { info } = useDynamicPropertyValues(control, controlData, i18n, ['info'])
+  return (
+    <AcmHelperText
+      controlId={controlId}
+      helperText={info ?? tip}
+      validated={exception ? 'error' : info ? 'default' : undefined}
+      error={exception}
+    />
+  )
+}

--- a/frontend/src/components/TemplateEditor/controls/__snapshots__/ControlPanelCheckbox.test.js.snap
+++ b/frontend/src/components/TemplateEditor/controls/__snapshots__/ControlPanelCheckbox.test.js.snap
@@ -85,9 +85,6 @@ exports[`ControlPanelCheckbox component renders as expected 1`] = `
         </div>
       </div>
     </div>
-    <div
-      style="font-size: 14px; font-weight: normal;"
-    />
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Insufficient spacing between Additional labels input and help text

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-30601

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified helper-text component for template editor controls to standardize info, tips, and validation messaging.

* **Refactor**
  * Controls (including checkbox) now use the new helper-text component and updated control-group behavior to allow omitting helper text, improving consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->