### PR TITLE
ACM-31343 fix clusterclaim button

### DIFF
--- a/frontend/src/components/Rbac.tsx
+++ b/frontend/src/components/Rbac.tsx
@@ -165,22 +165,23 @@ type RbacButtonProps = Parameters<typeof AcmButton>[0] & {
 export function RbacButton(props: RbacButtonProps) {
   const { t } = useTranslation()
   const [isDisabled, setIsDisabled] = useState<boolean>(true)
-  const [rbac] = useState<ResourceAttributes[] | Promise<ResourceAttributes>[]>(props.rbac)
+  const { rbac, ...otherProps } = props
+  const [initialRbac] = useState<ResourceAttributes[] | Promise<ResourceAttributes>[]>(rbac)
 
   useEffect(() => {
     Promise.all(
-      rbac.map(async (rbac) => {
+      initialRbac.map(async (rbac) => {
         return await createSubjectAccessReview(rbac).promise
       })
     ).then((results) => {
       const isDisabled = !results.every((result) => result?.status?.allowed)
       setIsDisabled(isDisabled)
     })
-  }, [rbac])
+  }, [initialRbac])
 
   return (
     <AcmButton
-      {...props}
+      {...otherProps}
       isDisabled={isDisabled}
       tooltip={isDisabled ? t('rbac.unauthorized') : ''}
       className={css({

--- a/frontend/src/components/Rbac.tsx
+++ b/frontend/src/components/Rbac.tsx
@@ -173,10 +173,16 @@ export function RbacButton(props: RbacButtonProps) {
       initialRbac.map(async (rbac) => {
         return await createSubjectAccessReview(rbac).promise
       })
-    ).then((results) => {
-      const isDisabled = !results.every((result) => result?.status?.allowed)
-      setIsDisabled(isDisabled)
-    })
+    )
+      .then((results) => {
+        const isDisabled = !results.every((result) => result?.status?.allowed)
+        setIsDisabled(isDisabled)
+      })
+      .catch(() => {
+        // On error, enable the button so that a problem with permission checking does not block functionality
+        // Backend action will still fail if the user does not have permission
+        setIsDisabled(false)
+      })
   }, [initialRbac])
 
   return (

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -424,7 +424,6 @@ export function ClusterPoolsTable(props: {
           {
             header: '',
             cellTransforms: [fitContent],
-            isActionCol: true,
             cell: (clusterPool: ClusterPool) => {
               if (!isClusterPoolDeleting(clusterPool)) {
                 return (
@@ -735,7 +734,6 @@ export function ClusterPoolClaimsTable(props: { claims: ClusterClaim[] }) {
           {
             header: '',
             cellTransforms: [fitContent],
-            isActionCol: true,
             cell: (claim: ClusterClaim) => {
               return (
                 <AcmButton


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
[UI] Cluster pool - cluster claim button not re-positioned properly when zooming in/out on the cluster pool page

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-31343

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

## Before
<img width="1006" height="1123" alt="image" src="https://github.com/user-attachments/assets/85ffd950-da16-42bc-a4cf-78ef5ecf83b7" />


## After
<img width="1007" height="1136" alt="image" src="https://github.com/user-attachments/assets/6053de33-c1ee-4709-8ce3-865f9125939c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved role-based access control handling so permission checks and button enablement are more consistent and resilient, reducing the chance of blocking actions on error.
  * Reorganized action column definitions in cluster pool and cluster pool claims tables for clearer structure and maintainability without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->