### PR TITLE
[release-2.12] ACM-33236 : upgrade follow-redirects to 1.16.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17350,9 +17350,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
Axios using patched follow-redirects@1.16.0 by now fixing [CVE-2026-40895](https://www.cve.org/CVERecord?id=CVE-2026-40895) on MCE-2.7

[ACM-33236](https://redhat.atlassian.net/browse/ACM-33236)


[ACM-33236]: https://redhat.atlassian.net/browse/ACM-33236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ