### PR TITLE
Uncheck placement cluster limit by default

### DIFF
--- a/frontend/src/routes/Applications/CreateArgoApplication/CreatePullApplicationSet.test.tsx
+++ b/frontend/src/routes/Applications/CreateArgoApplication/CreatePullApplicationSet.test.tsx
@@ -301,7 +301,6 @@ const placementGit: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',
@@ -339,7 +338,6 @@ const placementHelm: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',

--- a/frontend/src/routes/Applications/CreateArgoApplication/CreatePushApplicationSet.test.tsx
+++ b/frontend/src/routes/Applications/CreateArgoApplication/CreatePushApplicationSet.test.tsx
@@ -276,7 +276,6 @@ const placementGit: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',
@@ -298,7 +297,6 @@ const placementHelm: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',

--- a/frontend/src/wizards/Argo/ArgoWizard.test.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.test.tsx
@@ -1089,7 +1089,6 @@ const submittedGitPullModel = [
           operator: 'Exists',
         },
       ],
-      numberOfClusters: 1,
       predicates: [
         {
           requiredClusterSelector: {

--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -349,7 +349,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
                   operator: 'Exists',
                 },
               ],
-              numberOfClusters: 1,
               predicates: [
                 {
                   // ArgoCD pull model doesn't support the hub cluster
@@ -425,7 +424,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
                   operator: 'Exists',
                 },
               ],
-              numberOfClusters: 1,
             },
           },
         ]


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Placement cluster limit should not be checked by default when creating ApplicationSet

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33683

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Argo Wizard placement behavior adjusted for pull-model applications: cluster selection now properly excludes the local cluster so deployments target intended remote clusters.
* **Tests**
  * Updated test fixtures to align with the revised pull-model placement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->