### PR TITLE
[AI test don't merge] fix(placement): uncheck cluster limit by default

### DIFF
--- a/frontend/src/routes/Applications/CreateArgoApplication/CreatePullApplicationSet.test.tsx
+++ b/frontend/src/routes/Applications/CreateArgoApplication/CreatePullApplicationSet.test.tsx
@@ -301,7 +301,6 @@ const placementGit: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',
@@ -339,7 +338,6 @@ const placementHelm: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',

--- a/frontend/src/routes/Applications/CreateArgoApplication/CreatePushApplicationSet.test.tsx
+++ b/frontend/src/routes/Applications/CreateArgoApplication/CreatePushApplicationSet.test.tsx
@@ -276,7 +276,6 @@ const placementGit: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',
@@ -298,7 +297,6 @@ const placementHelm: Placement = {
     namespace: gitOpsCluster.metadata.namespace,
   },
   spec: {
-    numberOfClusters: 1,
     tolerations: [
       {
         key: 'cluster.open-cluster-management.io/unreachable',

--- a/frontend/src/routes/Infrastructure/Clusters/Placements/CreatePlacement/PlacementWizard.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/Placements/CreatePlacement/PlacementWizard.tsx
@@ -60,7 +60,6 @@ export function PlacementWizard(props: PlacementWizardProps) {
               operator: 'Exists',
             },
           ],
-          numberOfClusters: 1,
         },
       },
     ]

--- a/frontend/src/wizards/Argo/ArgoWizard.test.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.test.tsx
@@ -832,7 +832,6 @@ const submittedGit = [
           operator: 'Exists',
         },
       ],
-      numberOfClusters: 1,
       predicates: [
         {
           requiredClusterSelector: {
@@ -1089,7 +1088,6 @@ const submittedGitPullModel = [
           operator: 'Exists',
         },
       ],
-      numberOfClusters: 1,
       predicates: [
         {
           requiredClusterSelector: {

--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -349,7 +349,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
                   operator: 'Exists',
                 },
               ],
-              numberOfClusters: 1,
               predicates: [
                 {
                   // ArgoCD pull model doesn't support the hub cluster
@@ -425,7 +424,6 @@ export function ArgoWizard(props: ArgoWizardProps) {
                   operator: 'Exists',
                 },
               ],
-              numberOfClusters: 1,
             },
           },
         ]
@@ -952,7 +950,6 @@ function ArgoWizardPlacementSection(props: {
                                 operator: 'Exists',
                               },
                             ],
-                            numberOfClusters: 1,
                             predicates: [
                               {
                                 // ArgoCD pull model doesn't support the hub cluster
@@ -986,7 +983,6 @@ function ArgoWizardPlacementSection(props: {
                                 operator: 'Exists',
                               },
                             ],
-                            numberOfClusters: 1,
                           },
                         } as IResource)
                   )


### PR DESCRIPTION
## Summary

- Remove `numberOfClusters: 1` from default placement specs in ArgoWizard (4 locations) and PlacementWizard (1 location)
- The "Set a limit on the number of clusters selected" checkbox is now unchecked by default, consistent with the Policies wizard

## Root Cause Analysis

The default placement spec in `ArgoWizard.tsx` and `PlacementWizard.tsx` included `numberOfClusters: 1`. The `WizCheckbox` in `Placement.tsx` evaluates `!!value || value === 0` — since `numberOfClusters` was `1` (truthy), the checkbox rendered as checked by default.

**Affected locations:**
- `frontend/src/wizards/Argo/ArgoWizard.tsx` — 4 occurrences (pull model default, push model default, inline pull/push model toggle)
- `frontend/src/routes/Infrastructure/Clusters/Placements/CreatePlacement/PlacementWizard.tsx` — 1 occurrence

The Governance/Policy wizard does NOT set `numberOfClusters` in its default placement, which is the correct behavior.

## Test plan

- [x] Unit tests updated and passing (ArgoWizard, CreatePushApplicationSet, CreatePullApplicationSet)
- [x] TypeScript type check passes
- [x] Playwright E2E test verified checkbox is unchecked in plugin mode (`localhost:9000`)
- [ ] Verify in standalone mode: Applications > Create application > ApplicationSet (push or pull) > Placement step — checkbox should be unchecked
- [ ] Verify existing placements with `numberOfClusters` set are not affected when editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated placement configuration structure to streamline cluster management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->