### PR TITLE
ACM-33072 Fix label negation filter on Discovered Policies Clusters tab

### DIFF
--- a/frontend/src/routes/Governance/discovered/details/DiscoveredByCluster.test.tsx
+++ b/frontend/src/routes/Governance/discovered/details/DiscoveredByCluster.test.tsx
@@ -1101,17 +1101,17 @@ describe('DiscoveredByCluster', () => {
     // Test the filter logic programmatically using the shared predicate
     const policies = context.policyItems![0].policies
 
-    // Scenario 1: Filter with env=prod AND !team=backend
+    // Scenario 1: Filter with env=prod AND team!=backend
     // Should show cluster-prod-frontend only (has env=prod but NOT team=backend)
-    const filter1 = ['env=prod', '!team=backend']
+    const filter1 = ['env=prod', 'team!=backend']
     const result1 = policies.filter((policy) => matchesSelectedLabels(filter1, policy))
 
     expect(result1.length).toBe(1)
     expect(result1[0].cluster).toBe('cluster-prod-frontend')
 
-    // Scenario 2: Filter with only !team=backend
+    // Scenario 2: Filter with only team!=backend
     // Should show cluster-prod-frontend (not cluster-prod-backend or cluster-dev-backend)
-    const filter2 = ['!team=backend']
+    const filter2 = ['team!=backend']
     const result2 = policies.filter((policy) => matchesSelectedLabels(filter2, policy))
 
     expect(result2.length).toBe(1)

--- a/frontend/src/routes/Governance/utils/label-utils.test.ts
+++ b/frontend/src/routes/Governance/utils/label-utils.test.ts
@@ -152,14 +152,14 @@ describe('label-utils', () => {
       const item = createMockItem('env=prod; team=backend')
 
       // Has team=backend, so exclude
-      expect(matchesSelectedLabels(['!team=backend'], item)).toBe(false)
+      expect(matchesSelectedLabels(['team!=backend'], item)).toBe(false)
 
       // Does not have team=frontend, so include
-      expect(matchesSelectedLabels(['!team=frontend'], item)).toBe(true)
+      expect(matchesSelectedLabels(['team!=frontend'], item)).toBe(true)
 
       // Multiple inequality - all must pass
-      expect(matchesSelectedLabels(['!team=frontend', '!env=staging'], item)).toBe(true)
-      expect(matchesSelectedLabels(['!team=backend', '!env=staging'], item)).toBe(false)
+      expect(matchesSelectedLabels(['team!=frontend', 'env!=staging'], item)).toBe(true)
+      expect(matchesSelectedLabels(['team!=backend', 'env!=staging'], item)).toBe(false)
     })
 
     test('should handle combined equality and inequality filters', () => {
@@ -167,8 +167,8 @@ describe('label-utils', () => {
       const item2 = createMockItem('env=prod; team=frontend')
       const item3 = createMockItem('env=dev; team=backend')
 
-      // env=prod AND !team=backend
-      const filters = ['env=prod', '!team=backend']
+      // env=prod AND team!=backend
+      const filters = ['env=prod', 'team!=backend']
       expect(matchesSelectedLabels(filters, item1)).toBe(false) // has env=prod but also has team=backend
       expect(matchesSelectedLabels(filters, item2)).toBe(true) // has env=prod, not team=backend
       expect(matchesSelectedLabels(filters, item3)).toBe(false) // doesn't have env=prod
@@ -181,7 +181,7 @@ describe('label-utils', () => {
       // No labels on item
       const noLabelsItem = createMockItem('')
       expect(matchesSelectedLabels(['env=prod'], noLabelsItem)).toBe(false)
-      expect(matchesSelectedLabels(['!env=prod'], noLabelsItem)).toBe(true)
+      expect(matchesSelectedLabels(['env!=prod'], noLabelsItem)).toBe(true)
 
       // System labels are filtered before matching
       const itemWithSystemLabels = createMockItem('env=prod; cluster-name=local-cluster')

--- a/frontend/src/routes/Governance/utils/label-utils.ts
+++ b/frontend/src/routes/Governance/utils/label-utils.ts
@@ -64,23 +64,25 @@ export const matchesSelectedLabels = (selectedValues: string[], item: Discovered
   let hasEqualityFilter = false
 
   for (const selectedValue of selectedValues) {
-    const isInequality = selectedValue.startsWith('!')
-    const value = isInequality ? selectedValue.substring(1) : selectedValue
+    const inequalityIndex = selectedValue.indexOf('!=')
+    const isInequality = inequalityIndex !== -1
 
-    // Split only on first '=' to preserve values containing '='
-    const firstEquals = value.indexOf('=')
-    if (firstEquals === -1) continue // No '=' found, skip this filter
-
-    const key = value.slice(0, firstEquals).trim()
-    const val = value.slice(firstEquals + 1).trim()
+    let key: string, val: string
+    if (isInequality) {
+      key = selectedValue.slice(0, inequalityIndex).trim()
+      val = selectedValue.slice(inequalityIndex + 2).trim()
+    } else {
+      const firstEquals = selectedValue.indexOf('=')
+      if (firstEquals === -1) continue
+      key = selectedValue.slice(0, firstEquals).trim()
+      val = selectedValue.slice(firstEquals + 1).trim()
+    }
 
     if (isInequality) {
-      // Inequality: label should NOT match - reject immediately if it does
       if (itemLabels[key] === val) {
         return false
       }
     } else {
-      // Equality: track that we have equality filters and if any matched
       hasEqualityFilter = true
       if (itemLabels[key] === val) {
         equalityMatched = true
@@ -88,7 +90,5 @@ export const matchesSelectedLabels = (selectedValues: string[], item: Discovered
     }
   }
 
-  // If there are equality filters, at least one must have matched
-  // If there are only inequality filters, all must have passed (which they did if we got here)
   return hasEqualityFilter ? equalityMatched : true
 }


### PR DESCRIPTION
## Summary

Regarding: https://redhat.atlassian.net/browse/ACM-33072
- Fixes the inequality (`!=`) label filter on the Discovered Policies **Clusters tab**, which returned "No results found" instead of matching clusters
- Root cause: `matchesSelectedLabels` expected a `!key=value` format while the AcmTable toolbar sends `key!=value` — the parser now aligns with the toolbar format
- Updates unit tests to use the correct `key!=value` format matching the AcmTable contract

## Test plan
- [x] Unit tests updated and passing (182 tests across 11 affected suites)
- [x] CodeRabbit review — 1 info-level finding (not actionable, values are generated not user-typed)
- [x] Linter (`npm run check`) passes clean
- [x] **Manually verified on cluster: created ConfigurationPolicy `acm-33072-ns-check` on `weekly`** (`environment=production`) and `weekly-managed` (`environment=staging`), confirmed the `!=` filter now returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated label filter syntax from `!key=value` to `key!=value` format for specifying inequality filters in governance features.

* **Tests**
  * Updated test cases to validate the new label filter syntax across various filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->