### PR TITLE
ACM-33678 Freeze placement cluster count while entries are incomplete

### DIFF
--- a/frontend/src/wizards/Placement/usePlacementDebug.test.ts
+++ b/frontend/src/wizards/Placement/usePlacementDebug.test.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { renderHook, act } from '@testing-library/react-hooks'
-import { usePlacementDebug, clearPlacementDebugCache } from './usePlacementDebug'
+import { usePlacementDebug, clearPlacementDebugCache, placementHasIncompleteEntries } from './usePlacementDebug'
 import { IPlacement } from '../common/resources/IPlacement'
 import { postPlacementDebug } from '../../resources/placement-debug'
 import { ResourceError, ResourceErrorCode } from '../../resources/utils/resource-request'
@@ -301,5 +301,626 @@ describe('usePlacementDebug', () => {
 
     expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
     expect(result.current.loading).toBe(false)
+  })
+
+  describe('gating on incomplete entries', () => {
+    it('freezes state when an empty label expression is added', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: mockPlacement },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      expect(result.current.matchedCount).toBe(2)
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withEmptyExpr: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: '', operator: 'In', values: [] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      rerender({ placement: withEmptyExpr })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      expect(result.current.matchedCount).toBe(2)
+      expect(result.current.loading).toBe(false)
+    })
+
+    it('freezes state when a complete expression has its values removed', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const withExpr: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env', operator: 'In', values: ['prod'] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: withExpr },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withClearedValues: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env', operator: 'In', values: [] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      rerender({ placement: withClearedValues })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      expect(result.current.matchedCount).toBe(2)
+    })
+
+    it('freezes state when a complete expression has its key removed', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const withExpr: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env', operator: 'In', values: ['prod'] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: withExpr },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withClearedKey: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: '', operator: 'In', values: ['prod'] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      rerender({ placement: withClearedKey })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+
+    it('freezes state when an empty toleration is added', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: mockPlacement },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withEmptyToleration: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          tolerations: [{ key: '', operator: 'Exists' }],
+        },
+      }
+
+      rerender({ placement: withEmptyToleration })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      expect(result.current.matchedCount).toBe(2)
+    })
+
+    it('resumes fetching when expression becomes complete', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: mockPlacement },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      // Add incomplete expression — should freeze
+      const incomplete: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env', operator: 'In', values: [] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+      rerender({ placement: incomplete })
+
+      // Complete the expression — should resume and fetch
+      const complete: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env', operator: 'In', values: ['prod'] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+      rerender({ placement: complete })
+
+      expect(result.current.loading).toBe(true)
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+
+    it('treats Exists expression with key as complete', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const withExistsExpr: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'gpu', operator: 'Exists' }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      const { result } = renderHook(() => usePlacementDebug(withExistsExpr))
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalled()
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+
+    it('freezes state for expression with only empty-string values', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: mockPlacement },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withGhostValues: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env', operator: 'In', values: [''] }],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      rerender({ placement: withGhostValues })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+
+    it('freezes state for expression with key but no operator', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: mockPlacement },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withKeyOnly: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          predicates: [
+            {
+              requiredClusterSelector: {
+                labelSelector: {
+                  matchExpressions: [{ key: 'env' } as any],
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      rerender({ placement: withKeyOnly })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+
+    it('freezes state when a toleration has its operator removed', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const withToleration: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          tolerations: [{ key: 'gpu', operator: 'Exists' }],
+        },
+      }
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: withToleration },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withClearedOperator: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          tolerations: [{ key: 'gpu' } as any],
+        },
+      }
+
+      rerender({ placement: withClearedOperator })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+
+    it('freezes state for Equal toleration with key but no value', async () => {
+      mockPostPlacementDebug.mockReturnValue({
+        promise: Promise.resolve(mockResult),
+        abort: jest.fn(),
+      })
+
+      const { result, rerender } = renderHook(({ placement }) => usePlacementDebug(placement), {
+        initialProps: { placement: mockPlacement },
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      const callCount = mockPostPlacementDebug.mock.calls.length
+
+      const withIncompleteToleration: IPlacement = {
+        ...mockPlacement,
+        spec: {
+          tolerations: [{ key: 'gpu', operator: 'Equal' }],
+        },
+      }
+
+      rerender({ placement: withIncompleteToleration })
+
+      act(() => {
+        jest.advanceTimersByTime(500)
+      })
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(mockPostPlacementDebug).toHaveBeenCalledTimes(callCount)
+      expect(result.current.matched).toEqual(['cluster1', 'cluster2'])
+    })
+  })
+})
+
+describe('placementHasIncompleteEntries', () => {
+  it('returns false for placement with no predicates or tolerations', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {},
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(false)
+  })
+
+  it('returns true when any label expression is incomplete', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {
+        predicates: [
+          {
+            requiredClusterSelector: {
+              labelSelector: {
+                matchExpressions: [
+                  { key: 'env', operator: 'In', values: ['prod'] },
+                  { key: '', operator: 'In', values: [] },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(true)
+  })
+
+  it('returns true when any toleration is incomplete', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {
+        tolerations: [{ key: '', operator: 'Exists' }],
+      },
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(true)
+  })
+
+  it('returns false when all entries are complete', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {
+        predicates: [
+          {
+            requiredClusterSelector: {
+              labelSelector: {
+                matchExpressions: [
+                  { key: 'env', operator: 'In', values: ['prod'] },
+                  { key: 'region', operator: 'Exists' },
+                ],
+              },
+            },
+          },
+        ],
+        tolerations: [{ key: 'gpu', operator: 'Equal', value: 'nvidia' }],
+      },
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(false)
+  })
+
+  it('detects In expression with key but empty values', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {
+        predicates: [
+          {
+            requiredClusterSelector: {
+              labelSelector: {
+                matchExpressions: [{ key: 'env', operator: 'In', values: [] }],
+              },
+            },
+          },
+        ],
+      },
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(true)
+  })
+
+  it('detects toleration with missing operator', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {
+        tolerations: [{ key: 'gpu' } as any],
+      },
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(true)
+  })
+
+  it('detects claim expression incompleteness', () => {
+    const placement: IPlacement = {
+      apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+      kind: 'Placement',
+      metadata: { name: 'test', namespace: 'default' },
+      spec: {
+        predicates: [
+          {
+            requiredClusterSelector: {
+              claimSelector: {
+                matchExpressions: [{ key: '', operator: 'In', values: [] }],
+              },
+            },
+          },
+        ],
+      },
+    }
+    expect(placementHasIncompleteEntries(placement)).toBe(true)
   })
 })

--- a/frontend/src/wizards/Placement/usePlacementDebug.ts
+++ b/frontend/src/wizards/Placement/usePlacementDebug.ts
@@ -1,7 +1,8 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { useEffect, useRef, useState } from 'react'
 import debounce from 'debounce'
-import { IPlacement } from '../common/resources/IPlacement'
+import { IPlacement, Toleration } from '../common/resources/IPlacement'
+import { IExpression } from '../common/resources/IMatchExpression'
 import { postPlacementDebug, PlacementDebugResult } from '../../resources/placement-debug'
 import { isRequestAbortedError, ResourceError } from '../../resources/utils/resource-request'
 
@@ -12,6 +13,37 @@ export interface PlacementDebugState {
   matchedCount: number | undefined
   loading: boolean
   error: Error | undefined
+}
+
+function isCompleteExpression(expr: IExpression): boolean {
+  if (!expr.key) return false
+  if (!expr.operator) return false
+  if (expr.operator === 'In' || expr.operator === 'NotIn') {
+    return Array.isArray(expr.values) && expr.values.some((v) => v !== undefined && v !== null && v !== '')
+  }
+  return true
+}
+
+function isCompleteToleration(tol: Toleration): boolean {
+  if (!tol.key) return false
+  if (!tol.operator) return false
+  if (tol.operator === 'Equal' && !tol.value) return false
+  return true
+}
+
+export function placementHasIncompleteEntries(placement: IPlacement): boolean {
+  for (const predicate of placement.spec?.predicates ?? []) {
+    for (const expr of predicate.requiredClusterSelector?.labelSelector?.matchExpressions ?? []) {
+      if (!isCompleteExpression(expr)) return true
+    }
+    for (const expr of predicate.requiredClusterSelector?.claimSelector?.matchExpressions ?? []) {
+      if (!isCompleteExpression(expr)) return true
+    }
+  }
+  for (const tol of placement.spec?.tolerations ?? []) {
+    if (!isCompleteToleration(tol)) return true
+  }
+  return false
 }
 
 const EMPTY_STATE: PlacementDebugState = {
@@ -66,7 +98,9 @@ function mapDebugResult(result: PlacementDebugResult): PlacementDebugState {
 }
 
 export function usePlacementDebug(placement: IPlacement | undefined): PlacementDebugState {
-  const specKey = placement ? JSON.stringify({ metadata: placement.metadata, spec: placement.spec }) : undefined
+  const isReady = placement ? !placementHasIncompleteEntries(placement) : false
+  const specKey =
+    isReady && placement ? JSON.stringify({ metadata: placement.metadata, spec: placement.spec }) : undefined
 
   const [state, setState] = useState<PlacementDebugState>(() => {
     if (specKey && specKey === cachedSpecKey && cachedState) {
@@ -111,9 +145,16 @@ export function usePlacementDebug(placement: IPlacement | undefined): PlacementD
 
   useEffect(() => {
     const debouncedFetch = debouncedFetchRef.current
-    if (!specKey || !placement) {
-      setState(EMPTY_STATE)
-      return
+
+    if (!specKey) {
+      if (!placement) {
+        setState(EMPTY_STATE)
+      }
+      // Placement exists but has incomplete entries — freeze current state
+      return () => {
+        debouncedFetch.clear()
+        abortRef.current?.()
+      }
     }
 
     if (specKey === cachedSpecKey && cachedState) {
@@ -122,7 +163,7 @@ export function usePlacementDebug(placement: IPlacement | undefined): PlacementD
     }
 
     setState({ ...EMPTY_STATE, loading: true })
-    debouncedFetch(placement, specKey)
+    debouncedFetch(placement!, specKey)
 
     return () => {
       debouncedFetch.clear()


### PR DESCRIPTION
## Summary
Regarding: https://redhat.atlassian.net/browse/ACM-33678

- Fixes premature cluster match count reset ("0 of 0 clusters") when adding or partially editing label expressions or tolerations in the Placement wizard
- The `usePlacementDebug` hook now gates on entry completeness — if any expression or toleration has missing required fields, the previous matched-cluster state is frozen until all entries are fully defined
- Applies to label expressions (key, operator, values for In/NotIn), claim expressions, and tolerations (key, operator, value for Equal)

## Test plan
- [ ] Add an empty label expression in the Placement wizard — cluster count should not change
- [ ] Add a label key without selecting an operator or values — count stays frozen
- [ ] Fill in all fields of the expression — count updates with new matches
- [ ] Remove a value from a previously valid expression — count freezes at previous result
- [ ] Add an empty toleration — cluster count should not change
- [ ] Clear the operator from a valid toleration — count freezes
- [ ] Verify existing complete expressions still trigger debug server calls normally
- [ ] `npx jest --testPathPattern='usePlacementDebug' --no-coverage` — 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent unnecessary API calls when placement predicates or tolerations are incomplete
  * System now automatically detects incomplete configurations and resumes processing once all required fields are completed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->