### PR TITLE
ACM-33997 Avoid re-checking RBAC on every render [release-2.13]

### DIFF
--- a/frontend/src/lib/rbac-util.test.ts
+++ b/frontend/src/lib/rbac-util.test.ts
@@ -1,9 +1,34 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { Namespace, NamespaceDefinition } from '../resources'
+import { renderHook } from '@testing-library/react-hooks'
+import { Namespace, NamespaceDefinition, ResourceAttributes } from '../resources'
 import { nockIgnoreApiPaths, nockRBAC } from './nock-util'
-import { areAllNamespacesUnauthorized, getAuthorizedNamespaces, isAnyNamespaceAuthorized } from './rbac-util'
+import {
+  areAllNamespacesUnauthorized,
+  getAuthorizedNamespaces,
+  isAnyNamespaceAuthorized,
+  useIsAnyNamespaceAuthorized,
+} from './rbac-util'
 import { waitForNocks } from './test-util'
+
+// Mock the shared-recoil module
+const mockNamespaces: Namespace[] = [
+  {
+    ...(NamespaceDefinition as Pick<Namespace, 'apiVersion' | 'kind'>),
+    metadata: { name: 'test-namespace-1' },
+  },
+  {
+    ...(NamespaceDefinition as Pick<Namespace, 'apiVersion' | 'kind'>),
+    metadata: { name: 'test-namespace-2' },
+  },
+]
+
+jest.mock('../shared-recoil', () => ({
+  useSharedAtoms: () => ({
+    namespacesState: 'namespacesState',
+  }),
+  useRecoilValue: () => mockNamespaces,
+}))
 
 const adminAccess = { name: '*', namespace: '*', resource: '*', verb: '*' }
 const createDeployment = {
@@ -125,5 +150,93 @@ describe('areAllNamespacesUnauthorized', () => {
       ]).promise
     ).toEqual(false)
     await waitForNocks(nocks)
+  })
+})
+
+describe('useIsAnyNamespaceAuthorized', () => {
+  it('does not repeat RBAC network requests when resourceAttributes is a new object reference with the same values', async () => {
+    nockIgnoreApiPaths()
+
+    // Create initial resourceAttributes
+    const resourceAttributes1: ResourceAttributes = {
+      name: 'test-deployment',
+      resource: 'clusterdeployments',
+      verb: 'create',
+      group: 'hive.openshift.io',
+    }
+
+    // Set up nocks for the initial request - should only be called once
+    const nocks = [
+      nockRBAC(adminAccess, false),
+      nockRBAC({ ...resourceAttributes1, namespace: 'test-namespace-1' }, false),
+      nockRBAC({ ...resourceAttributes1, namespace: 'test-namespace-2' }, true),
+    ]
+
+    // Render the hook with the first resourceAttributes object
+    const { rerender, waitForNextUpdate } = renderHook(
+      ({ attrs }: { attrs: ResourceAttributes }) => useIsAnyNamespaceAuthorized(Promise.resolve(attrs)),
+      { initialProps: { attrs: resourceAttributes1 } }
+    )
+
+    // Wait for the initial network requests to complete
+    await waitForNextUpdate()
+    await waitForNocks(nocks)
+
+    // Create a NEW object with the SAME values (different object reference)
+    // This simulates what happens when a component re-renders and creates a new
+    // resourceAttributes object inline, even though the values haven't changed
+    const resourceAttributes2: ResourceAttributes = {
+      name: 'test-deployment',
+      resource: 'clusterdeployments',
+      verb: 'create',
+      group: 'hive.openshift.io',
+    }
+
+    // Rerender with the new object that has the same values
+    // This should NOT trigger new network requests because the hook uses
+    // JSON.stringify to compare the resourceAttributes, preventing unnecessary re-fetches
+    rerender({ attrs: resourceAttributes2 })
+
+    // If additional network requests were made, the test would fail because
+    // we haven't set up additional nock mocks for them
+    // Give it a moment to ensure no additional requests are made
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  })
+
+  it('does not repeat RBAC network requests on multiple rerenders with new promise objects', async () => {
+    nockIgnoreApiPaths()
+
+    const resourceAttributes: ResourceAttributes = {
+      name: 'test-deployment',
+      resource: 'clusterdeployments',
+      verb: 'create',
+      group: 'hive.openshift.io',
+    }
+
+    // Set up nocks for the initial request - should only be called once across all rerenders
+    const nocks = [
+      nockRBAC(adminAccess, false),
+      nockRBAC({ ...resourceAttributes, namespace: 'test-namespace-1' }, false),
+      nockRBAC({ ...resourceAttributes, namespace: 'test-namespace-2' }, true),
+    ]
+
+    // The hook callback creates a new Promise on each render, simulating
+    // a common pattern where Promise.resolve({...}) is called inline
+    const { rerender, waitForNextUpdate } = renderHook(() =>
+      useIsAnyNamespaceAuthorized(Promise.resolve({ ...resourceAttributes }))
+    )
+
+    await waitForNextUpdate()
+    await waitForNocks(nocks)
+
+    // Rerender multiple times - each creates a new Promise object
+    // but should NOT trigger new network requests
+    rerender()
+    rerender()
+    rerender()
+
+    // If additional network requests were made, the test would fail because
+    // we haven't set up additional nock mocks for them
+    await new Promise((resolve) => setTimeout(resolve, 100))
   })
 })

--- a/frontend/src/lib/rbac-util.ts
+++ b/frontend/src/lib/rbac-util.ts
@@ -248,6 +248,8 @@ export function useIsAnyNamespaceAuthorized(resourceAttributes: Promise<Resource
   const namespaces = useRecoilValue(namespacesState)
   const [someNamespaceIsAuthorized, setSomeNamespaceIsAuthorized] = useState(false)
 
+  const resourceAttributesAsString = JSON.stringify(resourceAttributes)
+
   useEffect(() => {
     const result = (someNamespaceIsAuthorized ? areAllNamespacesUnauthorized : isAnyNamespaceAuthorized)(
       resourceAttributes,
@@ -259,8 +261,9 @@ export function useIsAnyNamespaceAuthorized(resourceAttributes: Promise<Resource
 
     return () => result.abort?.()
     // exclude someNamespaceIsAuthorized from dependency list to avoid update loop
+    // use resourceAttributesAsString instead of resourceAttributes because the object is currently created on every render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resourceAttributes, namespaces])
+  }, [resourceAttributesAsString, namespaces])
 
   return someNamespaceIsAuthorized
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
When logged in as a custom user for GRC, the console invokes too many selfsubjectaccessreviews api calls

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-33997

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression
