### PR TITLE
ACM-31328 Improve responsiveness of diagram and reorganize CSS

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/HypershiftDiagram.css
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/HypershiftDiagram.css
@@ -32,7 +32,7 @@
 .hypershift-diagram-subtext {
   display: block;
   padding-bottom: 20px;
-  color: var(--pf-t--global--text--color--200);
+  color: var(--pf-t--global--text--color--subtle);
 }
 
 .hypershift-diagram-column > .hypershift-diagram-heading,
@@ -59,12 +59,8 @@
 .hypershift-diagram-panel {
   display: flex;
   flex-direction: column;
-  background-color: #f3f3f3;
+  background-color: var(--pf-t--global--background--color--secondary--default);
   padding: 20px;
-}
-
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-panel {
-  background-color: #3f3f3f;
 }
 
 .hypershift-diagram-bordered {
@@ -72,15 +68,14 @@
   background-color: var(--pf-t--global--background--color--primary--default);
   border: 2px solid #0e5ecd;
   padding: 18px;
-  overflow: hidden;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-bordered {
+:where(.pf-v6-theme-dark) .hypershift-diagram-bordered {
   background-color: #4e4e4e;
 }
 
 .hypershift-diagram-cell {
-  background-color: var(--pf-t--global--background--color--200);
+  background-color: var(--pf-t--global--background--color--secondary--default);
   padding: 18px;
 }
 
@@ -103,7 +98,7 @@
   background-color: #d9e8f6;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-block--blue {
+:where(.pf-v6-theme-dark) .hypershift-diagram-block--blue {
   background-color: #003f79;
 }
 
@@ -111,10 +106,10 @@
   background-color: #dfebc1;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-block--green {
+:where(.pf-v6-theme-dark) .hypershift-diagram-block--green {
   background-color: #435e00;
 }
 
 .hypershift-diagram-block--neutral {
-  background-color: var(--pf-t--global--background--color--200);
+  background-color: var(--pf-t--global--background--color--secondary--default);
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/HypershiftDiagram.css
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/HypershiftDiagram.css
@@ -1,71 +1,120 @@
-.hypershift-diagram-majorRectStyle {
-  background-color: var(--pf-t--global--background--color--primary--default);
-  padding: 24px;
-  width: 50%;
+/* Layout */
+.hypershift-diagram {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
-.hypershift-diagram-middleRectStyle {
+.hypershift-diagram-column {
+  flex: 1 1 300px;
+  min-width: 0;
+  background-color: var(--pf-t--global--background--color--primary--default);
+  padding: 24px;
+}
+
+.hypershift-diagram-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.hypershift-diagram-row > * {
+  flex: 1 1 140px;
+  min-width: 0;
+}
+
+/* Text — font-size determined by parent container */
+.hypershift-diagram-heading {
+  font-weight: bold;
+  display: block;
+}
+
+.hypershift-diagram-subtext {
+  display: block;
+  padding-bottom: 20px;
+  color: var(--pf-t--global--text--color--200);
+}
+
+.hypershift-diagram-column > .hypershift-diagram-heading,
+.hypershift-diagram-column > .hypershift-diagram-subtext {
+  font-size: 18px;
+}
+
+.hypershift-diagram-panel > .hypershift-diagram-heading,
+.hypershift-diagram-panel > .hypershift-diagram-subtext {
+  font-size: 16px;
+}
+
+.hypershift-diagram-cell > .hypershift-diagram-heading,
+.hypershift-diagram-cell > .hypershift-diagram-subtext {
+  font-size: 14px;
+}
+
+.hypershift-diagram-label {
+  display: block;
+  padding-bottom: 20px;
+}
+
+/* Containers */
+.hypershift-diagram-panel {
+  display: flex;
+  flex-direction: column;
   background-color: #f3f3f3;
   padding: 20px;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-middleRectStyle {
+:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-panel {
   background-color: #3f3f3f;
-  padding: 20px;
 }
 
-.hypershift-diagram-minorRectStyle {
+.hypershift-diagram-bordered {
+  flex: 1;
   background-color: var(--pf-t--global--background--color--primary--default);
   border: 2px solid #0e5ecd;
   padding: 18px;
+  overflow: hidden;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-minorRectStyle {
+:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-bordered {
   background-color: #4e4e4e;
-  border: 2px solid #0e5ecd;
+}
+
+.hypershift-diagram-cell {
+  background-color: var(--pf-t--global--background--color--200);
   padding: 18px;
 }
 
-.hypershift-diagram-blueBlockStyle {
+/* Blocks */
+.hypershift-diagram-block {
+  text-align: center;
+  padding: 12px;
+  font-weight: bold;
+}
+
+.hypershift-diagram-block + .hypershift-diagram-block {
+  margin-top: 10px;
+}
+
+.hypershift-diagram-block > span {
+  display: block;
+}
+
+.hypershift-diagram-block--blue {
   background-color: #d9e8f6;
-  text-align: center;
-  padding: 12px 24px 12px 24px;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-blueBlockStyle {
+:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-block--blue {
   background-color: #003f79;
-  text-align: center;
-  padding: 12px 24px 12px 24px;
 }
 
-.hypershift-diagram-blueBlockStyle-noTextAlign {
-  background-color: #d9e8f6;
-  padding: 12px 24px 12px 24px;
-}
-
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-blueBlockStyle-noTextAlign {
-  background-color: #003f79;
-  padding: 12px 24px 12px 24px;
-}
-
-.hypershift-diagram-greenBlockStyle {
+.hypershift-diagram-block--green {
   background-color: #dfebc1;
-  text-align: center;
-  padding: 12px 24px 12px 24px;
 }
 
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-greenBlockStyle {
+:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-block--green {
   background-color: #435e00;
-  text-align: center;
-  padding: 12px 24px 12px 24px;
 }
 
-.hypershift-diagram-greenBlockStyle-noTextAlign {
-  background-color: #dfebc1;
-  padding: 12px 24px 12px 24px;
-}
-
-:where(.pf-v5-theme-dark, .pf-v6-theme-dark) .hypershift-diagram-greenBlockStyle-noTextAlign {
-  background-color: #435e00;
-  padding: 12px 24px 12px 24px;
+.hypershift-diagram-block--neutral {
+  background-color: var(--pf-t--global--background--color--200);
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/HypershiftDiagram.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/HypershiftDiagram.tsx
@@ -1,195 +1,107 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { Split, SplitItem } from '@patternfly/react-core'
 import { useTranslation } from '../../../../../../lib/acm-i18next'
 import './HypershiftDiagram.css'
 
+function Block({ labels, color }: Readonly<{ labels: string[]; color: 'blue' | 'green' | 'neutral' }>) {
+  return (
+    <div className={`hypershift-diagram-block hypershift-diagram-block--${color}`}>
+      {labels.map((label) => (
+        <span key={label}>{label}</span>
+      ))}
+    </div>
+  )
+}
+
+function ControlPlaneCell({ clusterName, color }: Readonly<{ clusterName: string; color: 'blue' | 'green' }>) {
+  const [t] = useTranslation()
+  return (
+    <div className="hypershift-diagram-cell">
+      <span className="hypershift-diagram-heading">{clusterName}</span>
+      <span className="hypershift-diagram-heading">{t('namespace')}</span>
+      <span className="hypershift-diagram-subtext">({t('control plane')})</span>
+      <Block labels={['api-server']} color={color} />
+      <Block labels={['etcd']} color={color} />
+      <Block labels={[t('Other'), t('components')]} color={color} />
+    </div>
+  )
+}
+
+function WorkerCell({ clusterName, color }: Readonly<{ clusterName: string; color: 'blue' | 'green' }>) {
+  const [t] = useTranslation()
+  return (
+    <div className="hypershift-diagram-cell">
+      <span className="hypershift-diagram-heading">{clusterName}</span>
+      <span className="hypershift-diagram-heading" style={{ paddingBottom: '20px' }}>
+        {t('worker nodes')}
+      </span>
+      <Block labels={[t('Worker'), t('nodes xN')]} color={color} />
+    </div>
+  )
+}
+
 export function HypershiftDiagram() {
   const [t] = useTranslation()
-  const titleOne = {
-    fontSize: '18px',
-    fontWeight: 'bolder',
-    display: 'block',
-  }
-  const subtitleOne = {
-    fontSize: '18px',
-    display: 'block',
-    paddingBottom: '20px',
-    color: 'var(--pf-t--global--text--color--200)',
-  }
-  const controlPlaneStyle = {
-    backgroundColor: 'var(--pf-t--global--background--color--200)',
-    padding: '18px',
-  }
-  const controlPlaneTitleStyle = {
-    fontSize: '14px',
-    display: 'block',
-    fontWeight: 'bolder',
-  }
-  const controlPlaneSubTitleStyle = {
-    fontSize: '14px',
-    display: 'block',
-    paddingBottom: '20px',
-    color: 'var(--pf-t--global--text--color--200)',
-  }
-  const standardOCPComponentStyle = {
-    textAlign: 'center' as const,
-    padding: '12px 24px 12px 24px',
-    backgroundColor: 'var(--pf-t--global--background--color--200)',
-  }
+
   return (
-    <Split hasGutter style={{ width: '69%' }}>
-      <SplitItem isFilled className="hypershift-diagram-majorRectStyle">
-        <span style={titleOne}>{t('Hosted control plane')}</span>
-        <span style={subtitleOne}>({t('decoupled control plane and workers')})</span>
-        <div className="hypershift-diagram-middleRectStyle">
-          <span style={{ fontSize: '16px', display: 'block', fontWeight: 'bolder' }}>
-            {t('Hosting service cluster')}
-          </span>
-          <span
-            style={{
-              fontSize: '16px',
-              display: 'block',
-              paddingBottom: '20px',
-              color: 'var(--pf-t--global--text--color--200)',
-            }}
-          >
-            ({t('hosts the control planes')})
-          </span>
-          <div className="hypershift-diagram-minorRectStyle">
-            <span style={{ paddingBottom: '20px', display: 'block' }}>{t('Hosting service cluster node')}</span>
-            <Split hasGutter>
-              <SplitItem isFilled style={controlPlaneStyle}>
-                <span style={controlPlaneTitleStyle}>{t('Cluster 1')}</span>
-                <span style={controlPlaneTitleStyle}>{t('namespace')}</span>
-                <span style={controlPlaneSubTitleStyle}>({t('control plane')})</span>
-                <div className="hypershift-diagram-blueBlockStyle">
-                  <span style={{ fontWeight: 'bolder' }}>api-server</span>
-                </div>
-                <div style={{ paddingTop: '10px' }}></div>
-                <div className="hypershift-diagram-blueBlockStyle">
-                  <span style={{ fontWeight: 'bolder' }}>etcd</span>
-                </div>
-                <div style={{ paddingTop: '10px' }}></div>
-                <div className="hypershift-diagram-blueBlockStyle">
-                  <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('Other')}</span>
-                  <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('components')}</span>
-                </div>
-              </SplitItem>
-              <SplitItem isFilled style={controlPlaneStyle}>
-                <span style={controlPlaneTitleStyle}>{t('Cluster 2')}</span>
-                <span style={controlPlaneTitleStyle}>{t('namespace')}</span>
-                <span style={controlPlaneSubTitleStyle}>({t('control plane')})</span>
-                <div className="hypershift-diagram-greenBlockStyle">
-                  <span style={{ fontWeight: 'bolder' }}>api-server</span>
-                </div>
-                <div style={{ paddingTop: '10px' }}></div>
-                <div className="hypershift-diagram-greenBlockStyle">
-                  <span style={{ fontWeight: 'bolder' }}>etcd</span>
-                </div>
-                <div style={{ paddingTop: '10px' }}></div>
-                <div className="hypershift-diagram-greenBlockStyle">
-                  <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('Other')}</span>
-                  <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('components')}</span>
-                </div>
-              </SplitItem>
-            </Split>
+    <div className="hypershift-diagram">
+      {/* Hosted control plane */}
+      <div className="hypershift-diagram-column">
+        <span className="hypershift-diagram-heading">{t('Hosted control plane')}</span>
+        <span className="hypershift-diagram-subtext">({t('decoupled control plane and workers')})</span>
+
+        <div className="hypershift-diagram-panel">
+          <span className="hypershift-diagram-heading">{t('Hosting service cluster')}</span>
+          <span className="hypershift-diagram-subtext">({t('hosts the control planes')})</span>
+
+          <div className="hypershift-diagram-bordered">
+            <span className="hypershift-diagram-label">{t('Hosting service cluster node')}</span>
+            <div className="hypershift-diagram-row">
+              <ControlPlaneCell clusterName={t('Cluster 1')} color="blue" />
+              <ControlPlaneCell clusterName={t('Cluster 2')} color="green" />
+            </div>
           </div>
         </div>
-        <div style={{ padding: '18px 40px 18px 40px' }}>
-          <Split hasGutter>
-            <SplitItem
-              isFilled
-              style={{
-                backgroundColor: 'var(--pf-t--global--background--color--200)',
-                padding: '18px',
-              }}
-            >
-              <span style={{ fontSize: '14px', display: 'block', fontWeight: 'bolder' }}>{t('Cluster 1')}</span>
-              <span style={{ fontSize: '14px', display: 'block', fontWeight: 'bolder', paddingBottom: '20px' }}>
-                {t('worker nodes')}
-              </span>
-              <div className="hypershift-diagram-blueBlockStyle-noTextAlign">
-                <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('Worker')}</span>
-                <span style={{ fontWeight: 'bolder' }}>{t('nodes xN')}</span>
-              </div>
-            </SplitItem>
-            <SplitItem
-              isFilled
-              style={{
-                backgroundColor: 'var(--pf-t--global--background--color--200)',
-                padding: '18px',
-              }}
-            >
-              <span style={{ fontSize: '14px', display: 'block', fontWeight: 'bolder' }}>{t('Cluster 2')}</span>
-              <span style={{ fontSize: '14px', display: 'block', fontWeight: 'bolder', paddingBottom: '20px' }}>
-                {t('worker nodes')}
-              </span>
-              <div className="hypershift-diagram-greenBlockStyle-noTextAlign">
-                <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('Worker')}</span>
-                <span style={{ fontWeight: 'bolder' }}>{t('nodes xN')}</span>
-              </div>
-            </SplitItem>
-          </Split>
+
+        <div className="hypershift-diagram-row" style={{ paddingTop: '18px' }}>
+          <WorkerCell clusterName={t('Cluster 1')} color="blue" />
+          <WorkerCell clusterName={t('Cluster 2')} color="green" />
         </div>
-      </SplitItem>
-      <SplitItem isFilled className="hypershift-diagram-majorRectStyle">
-        <span style={titleOne}>{t('Standalone control plane')}</span>
-        <span style={subtitleOne}>({t('dedicated control plane nodes')})</span>
-        <Split hasGutter>
-          <SplitItem isFilled className="hypershift-diagram-middleRectStyle">
-            <span style={{ fontSize: '16px', display: 'block', fontWeight: 'bolder' }}>{t('Single cluster')}</span>
-            <span style={{ fontSize: '16px', display: 'block', fontWeight: 'bolder', paddingBottom: '20px' }}>
+      </div>
+
+      {/* Standalone control plane */}
+      <div className="hypershift-diagram-column">
+        <span className="hypershift-diagram-heading">{t('Standalone control plane')}</span>
+        <span className="hypershift-diagram-subtext">({t('dedicated control plane nodes')})</span>
+
+        <div className="hypershift-diagram-row">
+          <div className="hypershift-diagram-panel">
+            <span className="hypershift-diagram-heading">{t('Single cluster')}</span>
+            <span className="hypershift-diagram-heading" style={{ paddingBottom: '20px' }}>
               {t('control plane')}
             </span>
-            <div className="hypershift-diagram-minorRectStyle">
-              <span style={{ display: 'block', paddingBottom: '20px' }}>{t('Control nodes x3')}</span>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>api-server</span>
-              </div>
-              <div style={{ paddingTop: '10px' }}></div>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>etcd</span>
-              </div>
-              <div style={{ paddingTop: '10px' }}></div>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>kcm</span>
-              </div>
-              <div style={{ paddingTop: '10px' }}></div>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('Other')}</span>
-                <span style={{ fontWeight: 'bolder', display: 'block' }}>{t('components')}</span>
-              </div>
-              <div style={{ paddingTop: '60px' }}></div>
+            <div className="hypershift-diagram-bordered">
+              <span className="hypershift-diagram-label">{t('Control nodes x3')}</span>
+              <Block labels={['api-server']} color="neutral" />
+              <Block labels={['etcd']} color="neutral" />
+              <Block labels={['kcm']} color="neutral" />
+              <Block labels={[t('Other'), t('components')]} color="neutral" />
             </div>
-          </SplitItem>
-          <SplitItem isFilled className="hypershift-diagram-middleRectStyle">
-            <span style={{ fontSize: '16px', display: 'block', fontWeight: 'bolder', paddingBottom: '44px' }}>
+          </div>
+          <div className="hypershift-diagram-panel">
+            <span className="hypershift-diagram-heading" style={{ paddingBottom: '44px' }}>
               {t('Worker pool')}
             </span>
-            <div className="hypershift-diagram-minorRectStyle">
-              <span style={{ display: 'block', paddingBottom: '20px' }}>{t('Worker nodes xN')}</span>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>{t('Workloads xN')}</span>
-              </div>
-              <div style={{ paddingTop: '10px' }}></div>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>SDN</span>
-              </div>
-              <div style={{ paddingTop: '10px' }}></div>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>Kubelet</span>
-              </div>
-              <div style={{ paddingTop: '10px' }}></div>
-              <div style={standardOCPComponentStyle}>
-                <span style={{ fontWeight: 'bolder' }}>CRI-O</span>
-                <div style={{ paddingTop: '20px' }}></div>
-              </div>
-              <div style={{ paddingTop: '65px' }}></div>
+            <div className="hypershift-diagram-bordered">
+              <span className="hypershift-diagram-label">{t('Worker nodes xN')}</span>
+              <Block labels={[t('Workloads xN')]} color="neutral" />
+              <Block labels={['SDN']} color="neutral" />
+              <Block labels={['Kubelet']} color="neutral" />
+              <Block labels={['CRI-O']} color="neutral" />
             </div>
-          </SplitItem>
-        </Split>
-      </SplitItem>
-    </Split>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Hosting service cluster node boxes are not responsive

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-31328

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

## Before
<img width="1076" height="1316" alt="image" src="https://github.com/user-attachments/assets/49846d79-f23a-41cb-98f1-c2807fd44862" />

## After
Diagram is responsive and contrast issues with the dark theme are fixed
<img width="1116" height="1316" alt="image" src="https://github.com/user-attachments/assets/b081f188-0f53-4801-ad3b-754957f95269" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the cluster diagram into a cleaner, component-driven layout with standardized CSS-based structure for rows, columns, panels, and cells.

* **Style**
  * Replaced legacy block/rect styling with reusable block modifiers and improved typography controls.
  * Improved dark-mode visuals and contrast for the diagram.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->