### PR TITLE
ACM-34019 ACM 2.17 ApplicationSet is not displayed correctly

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -322,7 +322,7 @@ export async function getAppSetTopology(
       }
       const types = getResourceTypes(resources as Record<string, unknown>[])
       types.forEach((type) => allApplicationTypes.add(type))
-      resources.forEach((r: any) => allResourcesForApp.push({ ...r, cluster: clusterName }))
+      resources.forEach((r: any) => allResourcesForApp.push({ ...r, cluster: clusterName, isChild: true }))
     })
     processResources(allResourcesForApp, parentNodeId, appClusterNames, hubClusterName, activeTypes ?? [], links, nodes)
   })

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/nodeStyle.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/components/nodeStyle.ts
@@ -56,6 +56,9 @@ function getLabel(type: string | undefined, specs: any) {
     case 'application':
       return specs?.applicationName ? specs.applicationName : 'Application'
     case 'applicationset':
+      if (specs?.raw?.isChild) {
+        return 'Application Set'
+      }
       return `${specs?.isAppSetPullModel ? 'Pull' : 'Push'} Application Set`
     case 'git':
     case 'chart':


### PR DESCRIPTION
# 📝 Summary
Don't show Push ApplicationSet when appset is a resource of another appset

**Ticket Summary (Title):**  
https://redhat.atlassian.net/browse/ACM-34019

**Ticket Link:**  
 ACM 2.17 ApplicationSet is not displayed correctly

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->