### PR TITLE
ACM-33685: Fix gap between cluster rows in match modal

### DIFF
--- a/frontend/src/wizards/Placement/MatchedClustersModal.tsx
+++ b/frontend/src/wizards/Placement/MatchedClustersModal.tsx
@@ -59,7 +59,7 @@ export function MatchedClustersModal(props: MatchedClustersModalProps) {
             onClear={() => setSearchTerm('')}
           />
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxHeight: '400px', overflowY: 'auto' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', maxHeight: '400px', overflowY: 'auto' }}>
             {hasLimit && filteredMatched.length > 0 && (
               <div>
                 <h4 style={{ marginBottom: '0.5rem', fontWeight: 'bold' }}>
@@ -77,7 +77,7 @@ export function MatchedClustersModal(props: MatchedClustersModalProps) {
             )}
 
             {hasLimit && filteredNotMatched.length > 0 && (
-              <div>
+              <div style={filteredMatched.length > 0 ? { marginTop: '1rem' } : undefined}>
                 <h4 style={{ marginBottom: '0.5rem', fontWeight: 'bold' }}>
                   {t('Not matched')}{' '}
                   <Tooltip


### PR DESCRIPTION
## Summary
- Removed `gap: 1rem` from the scrollable cluster list container in MatchedClustersModal which was causing visible spacing between each cluster row in the flat list (no-limit) view
- Applied `marginTop: 1rem` only between the "Matched" and "Not matched" sections to preserve section separation when a limit is set

## Test plan
- [x] All 310 placement-related unit tests pass
- [x] ESLint clean
- [x] CodeRabbit review — 0 findings
- [x] Manual verification: open cluster match modal without a limit set — cluster rows should have no gaps
- [x] Manual verification: open cluster match modal with a limit set — Matched and Not matched sections should have spacing between them

Ref: https://redhat.atlassian.net/browse/ACM-33685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined spacing inside the matched clusters modal: removed uniform gap, preserved a scrollable container for long lists, and added a conditional top margin before the "Not matched" section when matched entries are present to improve visual separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Before: 
<img width="883" height="325" alt="Screenshot 2026-05-13 at 10 24 22 AM" src="https://github.com/user-attachments/assets/2f1cebf6-7196-4d66-b32b-ce56187c8589" />

After:
<img width="922" height="343" alt="Screenshot 2026-05-13 at 10 23 55 AM" src="https://github.com/user-attachments/assets/d9d4e8f4-26c0-43a2-8fc6-c1369a96cb51" />
