### PR TITLE
ACM-34074 Test: Node.js 24 override health check (release-2.14)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/krypton

--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:8e253ccce2a7e8767d5ffeb6b82fcd1c0fc5abaea7a6d7f9c62dc83691b1de58 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:920a22bf794c1e3806b1279a26337ba02d18af7370df18045f5ffd5bf5d54dbc AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:acm
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:8e253ccce2a7e8767d5ffeb6b82fcd1c0fc5abaea7a6d7f9c62dc83691b1de58
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:920a22bf794c1e3806b1279a26337ba02d18af7370df18045f5ffd5bf5d54dbc
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:8e253ccce2a7e8767d5ffeb6b82fcd1c0fc5abaea7a6d7f9c62dc83691b1de58 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:920a22bf794c1e3806b1279a26337ba02d18af7370df18045f5ffd5bf5d54dbc AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:mce
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:8e253ccce2a7e8767d5ffeb6b82fcd1c0fc5abaea7a6d7f9c62dc83691b1de58
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:920a22bf794c1e3806b1279a26337ba02d18af7370df18045f5ffd5bf5d54dbc
 
 WORKDIR /app
 ENV NODE_ENV production


### PR DESCRIPTION
## Purpose

**This is a test PR — do not merge.** It tests whether the npm overrides for `@openshift-console/dynamic-plugin-sdk` within `@openshift-assisted/ui-lib` cause issues with Node.js 24 (npm 11) during Konflux hermetic builds.

## Context

- Jira: [ACM-34074](https://redhat.atlassian.net/browse/ACM-34074)
- Kevin confirmed this works on `release-2.16`. Testing older release branches.
- This branch has override: `SDK → 1.0.0` (ui-lib declares `0.0.3`)

## What to look for in CI

- **`npm ci` passes**: Override is compatible with npm 11. ACM-34074 is unnecessary for this branch.
- **`npm ci` fails with network/fetch error**: Override breaks hermetic build. Upstream `ui-lib` fix needed.
- **Build fails after `npm ci`**: Expected — this PR only swaps the base image, no code changes for Node 24 compatibility.

## Changes

- `Containerfile.acm.konflux`: nodejs-20-minimal → nodejs-24-minimal
- `Containerfile.mce.konflux`: nodejs-20-minimal → nodejs-24-minimal
- `.nvmrc`: lts/iron → lts/krypton

[ACM-34074]: https://redhat.atlassian.net/browse/ACM-34074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ