### PR TITLE
ACM-33619 Add dev workflow docs and fix CLAUDE.md port values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,8 @@ All ports are customizable via environment variables defined in `port-defaults.s
 - `FRONTEND_PORT` (default 3000) - Standalone console
 - `BACKEND_PORT` (default 4000) - Backend APIs
 - `CONSOLE_PORT` (default 9000) - OpenShift console
-- `ACM_PORT` (default 3001) - ACM plugin
-- `MCE_PORT` (default 3002) - MCE plugin
+- `MCE_PORT` (default 3001) - MCE plugin
+- `ACM_PORT` (default 3002) - ACM plugin
 
 ### Authentication Flow
 1. Frontend uses `acm-access-token-cookie` for user tokens

--- a/README.md
+++ b/README.md
@@ -196,6 +196,53 @@ Enabling this feature will allow the user to create a cluster that only contains
 
 ## Development
 
+### Testing
+
+```bash
+npm test                  # Run all tests (frontend + backend)
+npm run test:frontend     # Run frontend tests only
+npm run test:backend      # Run backend tests only
+npm test -- <pattern>     # Run tests matching a file pattern
+```
+
+### Linting and Formatting
+
+```bash
+npm run check             # Run linting, formatting, and type checking
+npm run check:fix         # Auto-fix all linting and formatting issues
+npm run lint              # Lint frontend and backend code
+npm run lint:fix          # Auto-fix linting issues
+```
+
+### Building
+
+```bash
+npm run build             # Production build for frontend and backend
+```
+
+### Internationalization
+
+```bash
+npm run i18n              # Validate i18n translation files
+npm run i18n:fix          # Auto-fix i18n issues
+```
+
+### Commit Requirements
+
+All commits must include a `Signed-off-by` trailer. This is enforced by a Husky pre-commit hook — commits without it will be rejected.
+
+Add it automatically with the `-s` flag:
+
+```bash
+git commit -s -m "Your commit message"
+```
+
+This produces a trailer in the format:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
 ### Feature Flags
 
 It is possible to enable/disable certain features by changing `spec.overrides.components[*].enabled` values from the ACM MultiClusterHub. In order to take a particular flag into account just add a new entry to `FEATURE_FLAGS` from `frontend/src/utils/flags/consts.ts` file, meaning the key as the name for the feature flag on console application side, and the value as the `spec.overrides.components[*].name`.


### PR DESCRIPTION
## Summary
- Add Testing, Linting/Formatting, Building, i18n, and Commit Requirements subsections to README.md under `## Development`
- Fix swapped `ACM_PORT`/`MCE_PORT` default values in CLAUDE.md to match `port-defaults.sh`

## Details
**README.md** — New contributors currently have no documentation on how to run tests, lint, build, or handle i18n. The `Signed-off-by` commit requirement (enforced by Husky) is also undocumented, causing first-time contributors to have commits rejected with no explanation. This PR adds five new subsections covering all of these.

**CLAUDE.md** — `ACM_PORT` and `MCE_PORT` defaults were swapped (3001/3002 reversed). Corrected to match `port-defaults.sh`: MCE=3001, ACM=3002.

## Test plan
- [ ] Verify all documented npm scripts exist in `package.json`
- [ ] Verify port values match `port-defaults.sh`
- [ ] Review markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Reordered port configuration entries for clearer presentation.
* Added a new "Development" section with instructions for testing, linting & formatting, building, internationalization checks/fixes, and commit signing requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->