### PR TITLE
chore(deps): update registry.redhat.io/ubi9/nodejs-24-minimal docker digest to f42698c (main)

### DIFF
--- a/Containerfile.acm
+++ b/Containerfile.acm
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:1770f8731fa5fe4053203fa72a26f30229126c20c7435dd46eda0ae212ba018f
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
 
 FROM ${NODE_BASE} as build-base
 USER root

--- a/Containerfile.mce
+++ b/Containerfile.mce
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:1770f8731fa5fe4053203fa72a26f30229126c20c7435dd46eda0ae212ba018f
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
 
 FROM ${NODE_BASE} as build-base
 USER root


### PR DESCRIPTION
## Summary
- Update `registry.redhat.io/ubi9/nodejs-24-minimal` base image digest
- Previous SHA: `sha256:1770f8731fa5fe4053203fa72a26f30229126c20c7435dd46eda0ae212ba018f`
- Updated SHA: `sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base images to the latest Node.js 24 minimal builds across build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->