### PR TITLE
ACM-30906: Create ACM Ansible credential during AAP installation

### DIFF
--- a/scripts/aap-automation/install-aap.sh
+++ b/scripts/aap-automation/install-aap.sh
@@ -491,7 +491,7 @@ log_info "To retrieve the password later, run:"
 log_info "  oc get secret ${PLATFORM_NAME}-admin-password -n $AAP_NAMESPACE -o jsonpath='{.data.password}' | base64 -d"
 if [ -n "$OAUTH_TOKEN" ]; then
     log_info "To retrieve the OAuth token, run:"
-    log_info "  oc get secret ${PLATFORM_NAME}-oauth-token -n $AAP_NAMESPACE -o jsonpath='{.data.token}'"
+    log_info "  oc get secret ${PLATFORM_NAME}-oauth-token -n $AAP_NAMESPACE -o jsonpath='{.data.token}' | base64 -d"
     log_info "To retrieve the ACM credential secret, run:"
     log_info "  oc get secret ${ACM_CREDENTIAL_NAME} -n $AAP_NAMESPACE -o yaml"
 fi

--- a/scripts/aap-automation/install-aap.sh
+++ b/scripts/aap-automation/install-aap.sh
@@ -432,6 +432,25 @@ if [ -n "$ROUTE_URL" ] && [ -n "$ADMIN_PASSWORD" ]; then
             --from-literal=host="$ROUTE_URL" \
             --dry-run=client -o yaml | oc apply -f -
         log_info "Token stored in secret: ${PLATFORM_NAME}-oauth-token"
+
+        # Create ACM Ansible credential so AAP is usable from ACM immediately
+        ACM_CREDENTIAL_NAME="aap-shared-credential"
+        log_info "Creating ACM Ansible credential: ${ACM_CREDENTIAL_NAME}"
+        cat <<CREDENTIAL_EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: ${ACM_CREDENTIAL_NAME}
+  namespace: ${AAP_NAMESPACE}
+  labels:
+    cluster.open-cluster-management.io/type: "ans"
+    cluster.open-cluster-management.io/credentials: ""
+stringData:
+  host: "${AAP_URL}"
+  token: "${OAUTH_TOKEN}"
+CREDENTIAL_EOF
+        log_info "ACM credential created in namespace: ${AAP_NAMESPACE}"
     else
         log_warn "Failed to generate OAuth token"
     fi
@@ -451,6 +470,7 @@ log_info "Username:         admin"
 log_info "Password:         (retrieve via command below)"
 if [ -n "$OAUTH_TOKEN" ]; then
     log_info "OAuth Secret:     ${PLATFORM_NAME}-oauth-token"
+    log_info "ACM Credential:   ${ACM_CREDENTIAL_NAME} (namespace: ${AAP_NAMESPACE})"
 fi
 echo ""
 log_info "Deployed Components:"
@@ -470,6 +490,8 @@ echo ""
 log_info "To retrieve the password later, run:"
 log_info "  oc get secret ${PLATFORM_NAME}-admin-password -n $AAP_NAMESPACE -o jsonpath='{.data.password}' | base64 -d"
 if [ -n "$OAUTH_TOKEN" ]; then
-    log_info "To retrieve the OAuth token later, run:"
+    log_info "To retrieve the OAuth token, run:"
     log_info "  oc get secret ${PLATFORM_NAME}-oauth-token -n $AAP_NAMESPACE -o jsonpath='{.data.token}'"
+    log_info "To retrieve the ACM credential secret, run:"
+    log_info "  oc get secret ${ACM_CREDENTIAL_NAME} -n $AAP_NAMESPACE -o yaml"
 fi


### PR DESCRIPTION
## Summary
- After generating the OAuth token during AAP installation, create an ACM-discoverable credential Secret (`aap-shared-credential`) so AAP is usable from ACM immediately without manual credential setup
- The credential uses the required ACM labels (`cluster.open-cluster-management.io/type: "ans"` and `cluster.open-cluster-management.io/credentials: ""`) so it is auto-discovered by the ACM Ansible integration
- Updates the installation summary to display the credential name and retrieval command

## Test plan
- [x] Run `install-aap.sh` on a cluster with ACM installed
- [x] Verify `aap-shared-credential` Secret is created in the AAP namespace with correct labels
- [x] Verify the credential appears in ACM console under Credentials
- [ ] Verify re-running the script is idempotent (credential is updated, not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creates an ACM Ansible credential secret containing AAP host and token when an OAuth token is generated.
  * Enhances install output to show the ACM credential name/namespace and provides separate commands to retrieve the OAuth token and the ACM credential YAML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->