### PR TITLE
ACM-33393-Duplicate-pods-in-Appset-topology-when-selecting-multiple-clusters-2

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -519,22 +519,24 @@ describe('getAppSetTopology', () => {
 
     const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
 
-    // CRD should appear exactly once (deduplicated across clusters)
-    const crdNodes = result.nodes.filter(
-      (n) => n.type === 'customresourcedefinition' && n.name === 'widgets.example.com'
-    )
+    // CRD should appear as a single merged node (processMultiples groups by kind)
+    const crdNodes = result.nodes.filter((n) => n.type === 'customresourcedefinition')
     expect(crdNodes).toHaveLength(1)
 
-    // The single CRD node should have both clusters in clustersNames
+    // The merged CRD node should have both clusters in clustersNames
     const crdNode = crdNodes[0]
     expect((crdNode as any).specs.clustersNames).toContain('local-cluster')
     expect((crdNode as any).specs.clustersNames).toContain('managed-cluster-1')
 
-    // Namespaced Deployment should still have separate entries per cluster
-    const deployNodes = result.nodes.filter((n) => n.type === 'deployment' && n.name === 'my-app')
-    expect(deployNodes).toHaveLength(2)
-    const deployIds = deployNodes.map((n) => n.id)
-    expect(deployIds[0]).not.toEqual(deployIds[1])
+    // specs.resources should contain per-cluster entries so the detail panel shows all clusters
+    const crdResources = (crdNode as any).specs.resources as any[]
+    expect(crdResources).toHaveLength(2)
+    expect(crdResources.map((r: any) => r.cluster).sort()).toEqual(['local-cluster', 'managed-cluster-1'])
+
+    // Namespaced Deployment should be merged into a single node across clusters
+    const deployNodes = result.nodes.filter((n) => n.type === 'deployment')
+    expect(deployNodes).toHaveLength(1)
+    expect(deployNodes[0].specs?.resourceCount).toBe(2)
   })
 
   it('should handle ApplicationSet with app status information', async () => {
@@ -1320,7 +1322,7 @@ describe('getAppSetTopology', () => {
 
     // Uniform sources array — only one fleet request needed
     expect(mockFleetResourceRequest).toHaveBeenCalledTimes(1)
-    expect(result.nodes.find((n) => n.type === 'deployment' && n.name === 'multi-src-deploy')).toBeDefined()
+    expect(result.nodes.find((n) => n.type === 'deployment')).toBeDefined()
   })
 
   it('should filter by active applications when provided', async () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -632,34 +632,37 @@ function processResources(
     })
   }
 
-  // Deduplicate cluster-scoped resources (no namespace) that appear on multiple clusters.
-  // They should become a single node with all target clusters in clustersNames.
-  const deduplicatedResources = deduplicateClusterScopedResources(allResources)
-
   // Map of VM UID -> ControllerRevision name for VM-owned controller revisions
   const vmControllerRevisions = new Map<string, string[]>()
+  const vmOwnedCrNames = new Set<string>()
 
   // pre-emptively find controller revisions that are owned by a VirtualMachine
-  deduplicatedResources.forEach((deployable: Record<string, unknown>) => {
+  allResources.forEach((deployable: Record<string, unknown>) => {
     const typedDeployable = deployable as unknown as ProcessedDeployableResource
     const { name: deployableName, kind } = typedDeployable
     const type = kind.toLowerCase()
 
-    // ControllerRevision resources owned by a VirtualMachine are already
-    // represented as child nodes created by createControllerRevisionChild —
-    // skip them to avoid duplicates. Detected via the
-    // "revision-start-vm-<vmUid>-<rev>" naming convention.
     if (type === 'controllerrevision') {
       const uidMatch = deployableName.match(/.+-vm-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-\d+$/)
       if (uidMatch) {
         vmControllerRevisions.set(uidMatch[1], [...(vmControllerRevisions.get(uidMatch[1]) || []), deployableName])
-        return
+        vmOwnedCrNames.add(deployableName)
       }
     }
   })
 
+  // Filter out VM-owned ControllerRevisions before processMultiples merges them
+  // into a single entry (which loses individual names and breaks the skip logic).
+  const resourcesToProcess = allResources.filter((deployable: Record<string, unknown>) => {
+    const typedDeployable = deployable as unknown as ProcessedDeployableResource
+    if (typedDeployable.kind.toLowerCase() === 'controllerrevision' && vmOwnedCrNames.has(typedDeployable.name)) {
+      return false
+    }
+    return true
+  })
+
   // create nodes for each resource
-  processMultiples(deduplicatedResources).forEach((deployable: Record<string, unknown>) => {
+  processMultiples(resourcesToProcess).forEach((deployable: Record<string, unknown>) => {
     const typedDeployable = deployable as unknown as ProcessedDeployableResource
     const {
       name: deployableName,
@@ -678,13 +681,6 @@ function processResources(
     if (type === 'virtualmachineinstance') {
       const labelStr: string = (deployable as any).label || ''
       if (labelStr.split(';').some((entry: string) => entry.trim().startsWith('kubevirt.io/vm='))) {
-        return
-      }
-    }
-
-    if (type === 'controllerrevision') {
-      const uidMatch = deployableName.match(/.+-vm-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-\d+$/)
-      if (uidMatch) {
         return
       }
     }
@@ -717,10 +713,7 @@ function processResources(
       raw.apiVersion = apiVersion
     }
 
-    // For cluster-scoped resources, use all target clusters; for namespaced, use parent clusters
-    const nodeClusters = deployableNamespace
-      ? parentClusterNames
-      : (typedDeployable as any)._targetClusters || parentClusterNames
+    const nodeClusters = parentClusterNames
 
     // Create deployable resource node
     let deployableObj: TopologyNode = {
@@ -764,38 +757,6 @@ function processResources(
     // Create virtual machine instance child nodes (for KubeVirt)
     createVirtualMachineInstance(deployableObj, parentClusterNames || [], activeTypes, links, nodes)
   })
-}
-
-/**
- * Deduplicates cluster-scoped resources (those without a namespace) that appear
- * multiple times for different clusters. Combines them into a single entry with
- * _targetClusters containing all clusters where the resource should be deployed.
- * Namespaced resources are returned unchanged.
- */
-function deduplicateClusterScopedResources(resources: ResourceItem[]): ResourceItem[] {
-  const clusterScoped: Map<string, ResourceItem> = new Map()
-  const namespaced: ResourceItem[] = []
-
-  resources.forEach((resource: ResourceItem) => {
-    if (resource.namespace) {
-      namespaced.push(resource)
-    } else {
-      const key = `${(resource.kind || '').toLowerCase()}/${resource.name || ''}`
-      const existing = clusterScoped.get(key)
-      if (existing) {
-        const clusters = (existing as any)._targetClusters || [existing.cluster]
-        if (resource.cluster && !clusters.includes(resource.cluster)) {
-          clusters.push(resource.cluster)
-        }
-        ;(existing as any)._targetClusters = clusters
-      } else {
-        const entry = { ...resource, _targetClusters: resource.cluster ? [resource.cluster] : [] }
-        clusterScoped.set(key, entry)
-      }
-    }
-  })
-
-  return [...namespaced, ...Array.from(clusterScoped.values())]
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -33,6 +33,7 @@ import {
   fetchArgoAppStatusResources,
   getClusterName,
   getResourceTypes,
+  processMultiples,
 } from './topologyUtils'
 
 /** Window after ApplicationSet creation during which `isCreating` is true on the topology node. */
@@ -658,7 +659,7 @@ function processResources(
   })
 
   // create nodes for each resource
-  deduplicatedResources.forEach((deployable: Record<string, unknown>) => {
+  processMultiples(deduplicatedResources).forEach((deployable: Record<string, unknown>) => {
     const typedDeployable = deployable as unknown as ProcessedDeployableResource
     const {
       name: deployableName,


### PR DESCRIPTION
# 📝 Summary

hi @KevinFCormier , @fxiang1 
I'm including you as reviewers since my fix touches your recent fixes

somewhere along the road this was removed:
  **processMultiples**(...).forEach((deployable: Record<string, unknown>) => {

this creates a single node for all deployment types with the same kind so that we just show one node per type
it returns this special node definition:
      return {
        kind,  << the duplicated kind (ex: Service)
        name: '', << no name because the topology node represents multiple resources
        namespace: '',
        resources: typedResourcesGroup, << all of the resources that have that type--used in details view
        resourceCount:  << the number displayed on. the node
          numOfDeployedClusters > 0 ? typedResourcesGroup.length * numOfDeployedClusters : typedResourcesGroup.length,
      }

and it shows this:

<img width="748" height="262" alt="CleanShot 2026-05-27 at 11 21 15@2x" src="https://github.com/user-attachments/assets/ccb58dda-ec73-4047-91e4-ba47051065d1" />

Please make sure I didn't screw anything up :)


**Ticket Summary (Title):**  
Duplicate pods in Appset topology when selecting multiple clusters

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33393

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application topology display to properly consolidate cluster-scoped resources deployed across multiple clusters into unified nodes, rather than showing separate entries per cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->