### PR TITLE
ACM-34610 Duplicate pods in Appset topology when selecting multiple clusters for 2.17.1

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -519,22 +519,24 @@ describe('getAppSetTopology', () => {
 
     const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
 
-    // CRD should appear exactly once (deduplicated across clusters)
-    const crdNodes = result.nodes.filter(
-      (n) => n.type === 'customresourcedefinition' && n.name === 'widgets.example.com'
-    )
+    // CRD should appear as a single merged node (processMultiples groups by kind)
+    const crdNodes = result.nodes.filter((n) => n.type === 'customresourcedefinition')
     expect(crdNodes).toHaveLength(1)
 
-    // The single CRD node should have both clusters in clustersNames
+    // The merged CRD node should have both clusters in clustersNames
     const crdNode = crdNodes[0]
     expect((crdNode as any).specs.clustersNames).toContain('local-cluster')
     expect((crdNode as any).specs.clustersNames).toContain('managed-cluster-1')
 
-    // Namespaced Deployment should still have separate entries per cluster
-    const deployNodes = result.nodes.filter((n) => n.type === 'deployment' && n.name === 'my-app')
-    expect(deployNodes).toHaveLength(2)
-    const deployIds = deployNodes.map((n) => n.id)
-    expect(deployIds[0]).not.toEqual(deployIds[1])
+    // specs.resources should contain per-cluster entries so the detail panel shows all clusters
+    const crdResources = (crdNode as any).specs.resources as any[]
+    expect(crdResources).toHaveLength(2)
+    expect(crdResources.map((r: any) => r.cluster).sort()).toEqual(['local-cluster', 'managed-cluster-1'])
+
+    // Namespaced Deployment should be merged into a single node across clusters
+    const deployNodes = result.nodes.filter((n) => n.type === 'deployment')
+    expect(deployNodes).toHaveLength(1)
+    expect(deployNodes[0].specs?.resourceCount).toBe(2)
   })
 
   it('should handle ApplicationSet with app status information', async () => {
@@ -1320,7 +1322,7 @@ describe('getAppSetTopology', () => {
 
     // Uniform sources array — only one fleet request needed
     expect(mockFleetResourceRequest).toHaveBeenCalledTimes(1)
-    expect(result.nodes.find((n) => n.type === 'deployment' && n.name === 'multi-src-deploy')).toBeDefined()
+    expect(result.nodes.find((n) => n.type === 'deployment')).toBeDefined()
   })
 
   it('should filter by active applications when provided', async () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.test.ts
@@ -1396,4 +1396,281 @@ describe('getAppSetTopology', () => {
     expect(result.links).toBeDefined()
     expect(toolbarWithActiveApps.setAllApplications).toHaveBeenCalled()
   })
+
+  it('should skip VM-owned ControllerRevision resources and create them as children of VirtualMachine', async () => {
+    const vmUid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    mockSearchClient.query.mockResolvedValue({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'local-cluster/app-uid-vm',
+                name: 'vm-appset-local-cluster',
+                namespace: 'openshift-gitops',
+                cluster: 'local-cluster',
+                kind: 'Application',
+              },
+            ],
+            related: [
+              {
+                kind: 'VirtualMachine',
+                items: [
+                  {
+                    _uid: `local-cluster/${vmUid}`,
+                    _relatedUids: ['local-cluster/app-uid-vm'],
+                    name: 'my-vm',
+                    namespace: 'vm-ns',
+                    cluster: 'local-cluster',
+                    kind: 'VirtualMachine',
+                    apiversion: 'v1',
+                    apigroup: 'kubevirt.io',
+                  },
+                ],
+              },
+              {
+                kind: 'ControllerRevision',
+                items: [
+                  {
+                    _uid: 'local-cluster/cr-uid-1',
+                    _relatedUids: ['local-cluster/app-uid-vm'],
+                    name: `revision-start-vm-${vmUid}-1`,
+                    namespace: 'vm-ns',
+                    cluster: 'local-cluster',
+                    kind: 'ControllerRevision',
+                    apiversion: 'v1',
+                    apigroup: 'apps',
+                  },
+                  {
+                    _uid: 'local-cluster/cr-uid-2',
+                    _relatedUids: ['local-cluster/app-uid-vm'],
+                    name: `revision-start-vm-${vmUid}-2`,
+                    namespace: 'vm-ns',
+                    cluster: 'local-cluster',
+                    kind: 'ControllerRevision',
+                    apiversion: 'v1',
+                    apigroup: 'apps',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'vm-appset',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'vm-appset', namespace: 'openshift-gitops' },
+        spec: {
+          generators: [{ list: { elements: [{ cluster: 'local-cluster' }] } }],
+          template: { spec: { source: { path: 'apps/vm' } } },
+        },
+      },
+      placementDecision: undefined,
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'local-cluster' }],
+      appSetApps: [{ metadata: { name: 'vm-appset-local-cluster' }, spec: {} }] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    const vmNode = result.nodes.find((n) => n.type === 'virtualmachine')
+    expect(vmNode).toBeDefined()
+
+    // VM-owned ControllerRevisions should appear as children of the VM, not as standalone nodes
+    const crNodes = result.nodes.filter((n) => n.type === 'controllerrevision')
+    crNodes.forEach((crNode) => {
+      expect((crNode.specs?.parent as any)?.parentType).toBe('virtualmachine')
+    })
+    expect(crNodes.length).toBe(2)
+    expect(crNodes.map((n) => n.name).sort()).toEqual([`revision-start-vm-${vmUid}-1`, `revision-start-vm-${vmUid}-2`])
+  })
+
+  it('should skip VirtualMachineInstance resources that have kubevirt.io/vm label', async () => {
+    mockSearchClient.query.mockResolvedValue({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'local-cluster/app-uid-vmi',
+                name: 'vmi-appset-local-cluster',
+                namespace: 'openshift-gitops',
+                cluster: 'local-cluster',
+                kind: 'Application',
+              },
+            ],
+            related: [
+              {
+                kind: 'VirtualMachine',
+                items: [
+                  {
+                    _uid: 'local-cluster/vm-uid-1',
+                    _relatedUids: ['local-cluster/app-uid-vmi'],
+                    name: 'my-vm',
+                    namespace: 'vm-ns',
+                    cluster: 'local-cluster',
+                    kind: 'VirtualMachine',
+                    apiversion: 'v1',
+                    apigroup: 'kubevirt.io',
+                  },
+                ],
+              },
+              {
+                kind: 'VirtualMachineInstance',
+                items: [
+                  {
+                    _uid: 'local-cluster/vmi-uid-1',
+                    _relatedUids: ['local-cluster/app-uid-vmi'],
+                    name: 'my-vm',
+                    namespace: 'vm-ns',
+                    cluster: 'local-cluster',
+                    kind: 'VirtualMachineInstance',
+                    apiversion: 'v1',
+                    apigroup: 'kubevirt.io',
+                    label: 'kubevirt.io/vm=my-vm; other-label=value',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'vmi-appset',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'vmi-appset', namespace: 'openshift-gitops' },
+        spec: {
+          generators: [{ list: { elements: [{ cluster: 'local-cluster' }] } }],
+          template: { spec: { source: { path: 'apps/vm' } } },
+        },
+      },
+      placementDecision: undefined,
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'local-cluster' }],
+      appSetApps: [{ metadata: { name: 'vmi-appset-local-cluster' }, spec: {} }] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // The VM-owned VMI should NOT appear as a standalone top-level node
+    const standaloneVmiNodes = result.nodes.filter(
+      (n) => n.type === 'virtualmachineinstance' && (n.specs?.parent as any)?.parentType !== 'virtualmachine'
+    )
+    expect(standaloneVmiNodes).toHaveLength(0)
+
+    // But the VM should exist, and it should have a VMI child created by createVirtualMachineInstance
+    const vmNode = result.nodes.find((n) => n.type === 'virtualmachine')
+    expect(vmNode).toBeDefined()
+    const vmiChildNodes = result.nodes.filter(
+      (n) => n.type === 'virtualmachineinstance' && (n.specs?.parent as any)?.parentType === 'virtualmachine'
+    )
+    expect(vmiChildNodes).toHaveLength(1)
+  })
+
+  it('should keep ControllerRevision resources not owned by a VM as top-level nodes', async () => {
+    mockSearchClient.query.mockResolvedValue({
+      loading: false,
+      networkStatus: 7,
+      data: {
+        searchResult: [
+          {
+            items: [
+              {
+                _uid: 'local-cluster/app-uid-ds',
+                name: 'ds-appset-local-cluster',
+                namespace: 'openshift-gitops',
+                cluster: 'local-cluster',
+                kind: 'Application',
+              },
+            ],
+            related: [
+              {
+                kind: 'DaemonSet',
+                items: [
+                  {
+                    _uid: 'local-cluster/ds-uid-1',
+                    _relatedUids: ['local-cluster/app-uid-ds'],
+                    name: 'my-daemonset',
+                    namespace: 'ds-ns',
+                    cluster: 'local-cluster',
+                    kind: 'DaemonSet',
+                    apiversion: 'v1',
+                    apigroup: 'apps',
+                  },
+                ],
+              },
+              {
+                kind: 'ControllerRevision',
+                items: [
+                  {
+                    _uid: 'local-cluster/cr-uid-normal',
+                    _relatedUids: ['local-cluster/app-uid-ds'],
+                    name: 'my-daemonset-revision-abc123',
+                    namespace: 'ds-ns',
+                    cluster: 'local-cluster',
+                    kind: 'ControllerRevision',
+                    apiversion: 'v1',
+                    apigroup: 'apps',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const application: ApplicationModel = {
+      name: 'ds-appset',
+      namespace: 'openshift-gitops',
+      app: {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'ApplicationSet',
+        metadata: { name: 'ds-appset', namespace: 'openshift-gitops' },
+        spec: {
+          generators: [{ list: { elements: [{ cluster: 'local-cluster' }] } }],
+          template: { spec: { source: { path: 'apps/ds' } } },
+        },
+      },
+      placementDecision: undefined,
+      isArgoApp: false,
+      isAppSet: true,
+      isOCPApp: false,
+      isFluxApp: false,
+      isAppSetPullModel: true,
+      appSetClusters: [{ name: 'local-cluster' }],
+      appSetApps: [{ metadata: { name: 'ds-appset-local-cluster' }, spec: {} }] as any,
+    }
+
+    const result: ExtendedTopology = await getAppSetTopology(mockToolbarControl, application, 'local-cluster')
+
+    // Non-VM ControllerRevision should still appear as a regular top-level resource node
+    const crNodes = result.nodes.filter(
+      (n) => n.type === 'controllerrevision' && n.name === 'my-daemonset-revision-abc123'
+    )
+    expect(crNodes.length).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.ts
@@ -31,6 +31,7 @@ import {
   fetchArgoAppStatusResources,
   getClusterName,
   getResourceTypes,
+  processMultiples,
 } from './topologyUtils'
 import { PlacementDecision } from '../../../../../resources/placement-decision'
 import { Placement } from '../../../../../resources/placement'
@@ -631,12 +632,37 @@ function processResources(
     })
   }
 
-  // Deduplicate cluster-scoped resources (no namespace) that appear on multiple clusters.
-  // They should become a single node with all target clusters in clustersNames.
-  const deduplicatedResources = deduplicateClusterScopedResources(allResources)
+  // Map of VM UID -> ControllerRevision name for VM-owned controller revisions
+  const vmControllerRevisions = new Map<string, string[]>()
+  const vmOwnedCrNames = new Set<string>()
+
+  // pre-emptively find controller revisions that are owned by a VirtualMachine
+  allResources.forEach((deployable: Record<string, unknown>) => {
+    const typedDeployable = deployable as unknown as ProcessedDeployableResource
+    const { name: deployableName, kind } = typedDeployable
+    const type = kind.toLowerCase()
+
+    if (type === 'controllerrevision') {
+      const uidMatch = deployableName.match(/.+-vm-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-\d+$/)
+      if (uidMatch) {
+        vmControllerRevisions.set(uidMatch[1], [...(vmControllerRevisions.get(uidMatch[1]) || []), deployableName])
+        vmOwnedCrNames.add(deployableName)
+      }
+    }
+  })
+
+  // Filter out VM-owned ControllerRevisions before processMultiples merges them
+  // into a single entry (which loses individual names and breaks the skip logic).
+  const resourcesToProcess = allResources.filter((deployable: Record<string, unknown>) => {
+    const typedDeployable = deployable as unknown as ProcessedDeployableResource
+    if (typedDeployable.kind.toLowerCase() === 'controllerrevision' && vmOwnedCrNames.has(typedDeployable.name)) {
+      return false
+    }
+    return true
+  })
 
   // create nodes for each resource
-  deduplicatedResources.forEach((deployable: Record<string, unknown>) => {
+  processMultiples(resourcesToProcess).forEach((deployable: Record<string, unknown>) => {
     const typedDeployable = deployable as unknown as ProcessedDeployableResource
     const {
       name: deployableName,
@@ -648,6 +674,17 @@ function processResources(
       resources: deployableResources,
     } = typedDeployable
     const type = kind.toLowerCase()
+
+    // VirtualMachineInstance resources owned by a VirtualMachine (indicated by the
+    // kubevirt.io/vm label) are already represented as child nodes created by
+    // createVirtualMachineInstance — skip them to avoid duplicates.
+    if (type === 'virtualmachineinstance') {
+      const labelStr: string = (deployable as any).label || ''
+      if (labelStr.split(';').some((entry: string) => entry.trim().startsWith('kubevirt.io/vm='))) {
+        return
+      }
+    }
+
     // Use cluster from deployable when present (e.g. concatenated resources from multiple clusters)
     const deployableCluster =
       (typedDeployable as any).cluster ??
@@ -676,10 +713,7 @@ function processResources(
       raw.apiVersion = apiVersion
     }
 
-    // For cluster-scoped resources, use all target clusters; for namespaced, use parent clusters
-    const nodeClusters = deployableNamespace
-      ? parentClusterNames
-      : (typedDeployable as any)._targetClusters || parentClusterNames
+    const nodeClusters = parentClusterNames
 
     // Create deployable resource node
     let deployableObj: TopologyNode = {
@@ -708,7 +742,14 @@ function processResources(
     createReplicaChild(deployableObj, parentClusterNames || [], template, activeTypes, links, nodes)
 
     // Create controller revision child nodes (for DaemonSets, StatefulSets)
-    createControllerRevisionChild(deployableObj, parentClusterNames || [], activeTypes, links, nodes)
+    createControllerRevisionChild(
+      deployableObj,
+      parentClusterNames || [],
+      activeTypes,
+      links,
+      nodes,
+      vmControllerRevisions
+    )
 
     // Create data volume child nodes (for KubeVirt)
     createDataVolumeChild(deployableObj, parentClusterNames || [], activeTypes, links, nodes)
@@ -716,38 +757,6 @@ function processResources(
     // Create virtual machine instance child nodes (for KubeVirt)
     createVirtualMachineInstance(deployableObj, parentClusterNames || [], activeTypes, links, nodes)
   })
-}
-
-/**
- * Deduplicates cluster-scoped resources (those without a namespace) that appear
- * multiple times for different clusters. Combines them into a single entry with
- * _targetClusters containing all clusters where the resource should be deployed.
- * Namespaced resources are returned unchanged.
- */
-function deduplicateClusterScopedResources(resources: ResourceItem[]): ResourceItem[] {
-  const clusterScoped: Map<string, ResourceItem> = new Map()
-  const namespaced: ResourceItem[] = []
-
-  resources.forEach((resource: ResourceItem) => {
-    if (resource.namespace) {
-      namespaced.push(resource)
-    } else {
-      const key = `${(resource.kind || '').toLowerCase()}/${resource.name || ''}`
-      const existing = clusterScoped.get(key)
-      if (existing) {
-        const clusters = (existing as any)._targetClusters || [existing.cluster]
-        if (resource.cluster && !clusters.includes(resource.cluster)) {
-          clusters.push(resource.cluster)
-        }
-        ;(existing as any)._targetClusters = clusters
-      } else {
-        const entry = { ...resource, _targetClusters: resource.cluster ? [resource.cluster] : [] }
-        clusterScoped.set(key, entry)
-      }
-    }
-  })
-
-  return [...namespaced, ...Array.from(clusterScoped.values())]
 }
 
 /**

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyUtils.ts
@@ -378,18 +378,39 @@ export const createControllerRevisionChild = (
   clustersNames: string[],
   activeTypes: string[] | undefined,
   links: TopologyLink[],
-  nodes: TopologyNode[]
+  nodes: TopologyNode[],
+  vmControllerRevisions?: Map<string, string[]>
 ): TopologyNode | undefined => {
   const parentType = parentNode?.type || ''
-  if (parentType === 'daemonset' || parentType === 'statefulset' || parentType === 'virtualmachine') {
-    const pNode = createChildNode(parentNode, clustersNames, 'controllerrevision', activeTypes, links, nodes)
 
-    // Create pod children for non-virtual machine types
-    if (parentType !== 'virtualmachine') {
-      return createChildNode(pNode, clustersNames, 'pod', activeTypes, links, nodes)
-    }
-    return pNode
+  if (parentType === 'daemonset' || parentType === 'statefulset') {
+    const pNode = createChildNode(parentNode, clustersNames, 'controllerrevision', activeTypes, links, nodes)
+    return createChildNode(pNode, clustersNames, 'pod', activeTypes, links, nodes)
   }
+
+  if (parentType === 'virtualmachine') {
+    if (vmControllerRevisions) {
+      const rawUid = (parentNode.specs as any)?.raw?._uid as string | undefined
+      const k8sUid = rawUid?.includes('/') ? rawUid.split('/').pop() : rawUid
+      const revisionNames = k8sUid ? vmControllerRevisions.get(k8sUid) : undefined
+      if (revisionNames && revisionNames.length > 0) {
+        let lastNode: TopologyNode | undefined
+        for (const revName of revisionNames) {
+          lastNode = createChildNode(
+            { ...parentNode, name: revName },
+            clustersNames,
+            'controllerrevision',
+            activeTypes,
+            links,
+            nodes
+          )
+        }
+        return lastNode
+      }
+    }
+    return createChildNode(parentNode, clustersNames, 'controllerrevision', activeTypes, links, nodes)
+  }
+
   return undefined
 }
 


### PR DESCRIPTION
# 📝 Summary
clone of https://redhat.atlassian.net/browse/ACM-33393 for 2.17.1

**Ticket Summary (Title):**  
ACM-34610 CLONE - Duplicate pods in Appset topology when selecting multiple clusters for 2.17

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-34610

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->