### PR TITLE
Pass version to bridge

### DIFF
--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -43,6 +43,7 @@ BRIDGE_CA_FILE="/tmp/ca.crt"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SERVICE_ACCOUNT_BEARER_TOKEN_FILE="/tmp/token"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
 BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
+BRIDGE_RELEASE_VERSION="${CONSOLE_VERSION}"
 
 # The monitoring operator is not always installed (e.g. for local OpenShift). Tolerate missing config maps.
 set +e


### PR DESCRIPTION
OpenShift console bridge has a new `release-version` flag that is used for the 4.23 vs. 5.0 case where the same PF code is shipped, but the glass theme is only used for 5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration to synchronize the release version with the console version for improved consistency in off-cluster console deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->