### PR TITLE
Guard GPU metric parsing

### DIFF
--- a/frontend/src/components/Clusters/ClustersTableHelper.tsx
+++ b/frontend/src/components/Clusters/ClustersTableHelper.tsx
@@ -522,7 +522,7 @@ export function useGPUCountColumn(): IAcmTableColumn<Cluster> {
       const resultData = gpuData?.data?.result ?? []
       resultData.forEach((data) => {
         // increase count by 1 for each gpu metric instance
-        counts[data.metric.clusterID] = (counts[data.metric.clusterID] ?? 0) + 1
+        counts[data.metric?.clusterID] = (counts[data.metric?.clusterID] ?? 0) + 1
       })
     }
     return counts

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterNodes/ClusterNodes.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterNodes/ClusterNodes.tsx
@@ -121,7 +121,8 @@ export function NodesPoolsTable() {
     if (isObservabilityInstalled && !gpuDataLoading && !gpuDataError) {
       const resultData = gpuData?.data?.result ?? []
       resultData.forEach((data) => {
-        const metricNodeName = data.metric?.instance.split(':')[0]
+        const metricNodeName = data.metric?.instance?.split(':')[0]
+        if (!metricNodeName) return
         // increase count by 1 for each gpu metric instance
         counts[metricNodeName] = (counts[metricNodeName] ?? 0) + 1
       })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterNodes/ClusterNodes.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterNodes/ClusterNodes.tsx
@@ -121,7 +121,7 @@ export function NodesPoolsTable() {
     if (isObservabilityInstalled && !gpuDataLoading && !gpuDataError) {
       const resultData = gpuData?.data?.result ?? []
       resultData.forEach((data) => {
-        const metricNodeName = data.metric.instance.split(':')[0]
+        const metricNodeName = data.metric?.instance.split(':')[0]
         // increase count by 1 for each gpu metric instance
         counts[metricNodeName] = (counts[metricNodeName] ?? 0) + 1
       })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Change adds a guard to the GPU metric parsing for the case of empty/missing fields.

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes in cluster and node monitoring when GPU metric data is missing or incomplete by adding defensive handling; improves dashboard stability.
  * GPU counts are now only incremented for valid metric entries, avoiding runtime errors while preserving existing behavior for valid data.
  * Improves reliability of GPU reporting in the infrastructure dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->