### PR TITLE
ACM-33140 fill Revision/Path selections from a list of all existing appsets

### DIFF
--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -192,6 +192,8 @@ export function ArgoWizard(props: ArgoWizardProps) {
     return [...(sourceGitChannels ?? []), ...(gitArgoAppSetRepoURLs ?? [])].filter(onlyUnique)
   }, [props.applicationSets, sourceGitChannels])
 
+  const gitSourceCache = useMemo(() => buildGitSourceCache(props.applicationSets), [props.applicationSets])
+
   const gitGeneratorRepos = useMemo(() => {
     const urls: string[] = []
     const versions: string[] = []
@@ -569,6 +571,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
                   channels={props.channels}
                   helmChannels={helmChannels}
                   secrets={props.repoSecrets ?? []}
+                  gitSourceCache={gitSourceCache}
                 />
               ) : (
                 <MultipleSourcesSelector
@@ -576,6 +579,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
                   gitChannels={gitChannels}
                   helmChannels={helmChannels}
                   secrets={props.repoSecrets ?? []}
+                  gitSourceCache={gitSourceCache}
                 />
               )}
             </Section>
@@ -1053,4 +1057,81 @@ export function setRepositoryTypeForSources(resources: any[] | undefined): any[]
     }
     return resource
   })
+}
+
+export type GitSourceCache = {
+  revisionsByRepoURL: Record<string, string[]>
+  pathsByRepoURLAndRevision: Record<string, Record<string, string[]>>
+}
+
+function addTimedEntry(entries: Map<string, string>, value: string, lastTransitionTime: string) {
+  const existing = entries.get(value)
+  if (!existing || lastTransitionTime.localeCompare(existing) > 0) {
+    entries.set(value, lastTransitionTime)
+  }
+}
+
+function sortTimedEntries(entries: Map<string, string>): string[] {
+  return [...entries.entries()].sort(([, timeA], [, timeB]) => timeB.localeCompare(timeA)).map(([value]) => value)
+}
+
+export function sortWithCachedFirst(cached: string[], items: string[]): string[] {
+  const cachedSet = new Set(cached)
+  const remaining = items.filter((item) => !cachedSet.has(item))
+  return [...cached, ...remaining]
+}
+
+export function buildGitSourceCache(applicationSets?: ApplicationSet[]): GitSourceCache {
+  const revisionsByRepoURL: Record<string, Map<string, string>> = {}
+  const pathsByRepoURLAndRevision: Record<string, Record<string, Map<string, string>>> = {}
+
+  const processSource = (source: RepositoryProps, lastTransitionTime: string) => {
+    if (source.chart || !source.repoURL) {
+      return
+    }
+    const { repoURL, targetRevision, path } = source
+
+    if (targetRevision) {
+      if (!revisionsByRepoURL[repoURL]) {
+        revisionsByRepoURL[repoURL] = new Map()
+      }
+      addTimedEntry(revisionsByRepoURL[repoURL], targetRevision, lastTransitionTime)
+    }
+
+    if (targetRevision && path) {
+      if (!pathsByRepoURLAndRevision[repoURL]) {
+        pathsByRepoURLAndRevision[repoURL] = {}
+      }
+      if (!pathsByRepoURLAndRevision[repoURL][targetRevision]) {
+        pathsByRepoURLAndRevision[repoURL][targetRevision] = new Map()
+      }
+      addTimedEntry(pathsByRepoURLAndRevision[repoURL][targetRevision], path, lastTransitionTime)
+    }
+  }
+
+  applicationSets?.forEach((appset) => {
+    const lastTransitionTime = get(appset, 'status.conditions[0].lastTransitionTime') ?? ''
+    const source = get(appset, 'spec.template.spec.source') as RepositoryProps | undefined
+    const sources = get(appset, 'spec.template.spec.sources') as RepositoryProps[] | undefined
+
+    if (sources) {
+      sources.forEach((src) => processSource(src, lastTransitionTime))
+    } else if (source) {
+      processSource(source, lastTransitionTime)
+    }
+  })
+
+  return {
+    revisionsByRepoURL: Object.fromEntries(
+      Object.entries(revisionsByRepoURL).map(([repoURL, entries]) => [repoURL, sortTimedEntries(entries)])
+    ),
+    pathsByRepoURLAndRevision: Object.fromEntries(
+      Object.entries(pathsByRepoURLAndRevision).map(([repoURL, revisions]) => [
+        repoURL,
+        Object.fromEntries(
+          Object.entries(revisions).map(([targetRevision, paths]) => [targetRevision, sortTimedEntries(paths)])
+        ),
+      ])
+    ),
+  }
 }

--- a/frontend/src/wizards/Argo/MultipleSourcesSelector.tsx
+++ b/frontend/src/wizards/Argo/MultipleSourcesSelector.tsx
@@ -13,7 +13,7 @@ import { Label, Title } from '@patternfly/react-core'
 import { GitAltIcon } from '@patternfly/react-icons'
 import { Fragment } from 'react'
 import { useTranslation } from '../../lib/acm-i18next'
-import { Channel } from './ArgoWizard'
+import { Channel, GitSourceCache } from './ArgoWizard'
 import { RepoURL } from './common'
 import { GitPathSelect } from './common/GitPathSelect'
 import { GitRevisionSelect } from './common/GitRevisionSelect'
@@ -26,10 +26,11 @@ export interface MultipleSourcesSelectorProps {
   gitChannels: string[]
   helmChannels: string[]
   secrets: Secret[]
+  gitSourceCache?: GitSourceCache
 }
 
 export function MultipleSourcesSelector(props: MultipleSourcesSelectorProps) {
-  const { gitChannels, helmChannels, channels, secrets } = props
+  const { gitChannels, helmChannels, channels, secrets, gitSourceCache } = props
   const editMode = useEditMode()
   const { t } = useTranslation()
   return (
@@ -69,8 +70,8 @@ export function MultipleSourcesSelector(props: MultipleSourcesSelectorProps) {
       <WizHidden hidden={(data) => data.repositoryType !== 'git'}>
         {/* git repository */}
         <RepoURL name="git" channels={gitChannels} secrets={secrets} />
-        <GitRevisionSelect channels={channels ?? []} secrets={secrets} />
-        <GitPathSelect channels={channels ?? []} secrets={secrets} />
+        <GitRevisionSelect channels={channels ?? []} secrets={secrets} gitSourceCache={gitSourceCache} />
+        <GitPathSelect channels={channels ?? []} secrets={secrets} gitSourceCache={gitSourceCache} />
       </WizHidden>
 
       {/* helm repository */}

--- a/frontend/src/wizards/Argo/SourceSelector.tsx
+++ b/frontend/src/wizards/Argo/SourceSelector.tsx
@@ -5,7 +5,7 @@ import { GitAltIcon } from '@patternfly/react-icons'
 import { Fragment } from 'react'
 import { useTranslation } from '../../lib/acm-i18next'
 import { ApplicationSet, Secret } from '../../resources'
-import { Channel } from './ArgoWizard'
+import { Channel, GitSourceCache } from './ArgoWizard'
 import { RepoURL } from './common'
 import { GitPathSelect } from './common/GitPathSelect'
 import { GitRevisionSelect } from './common/GitRevisionSelect'
@@ -45,10 +45,11 @@ export interface SourceSelectorProps {
   channels: Channel[] | undefined
   helmChannels: string[]
   secrets: Secret[]
+  gitSourceCache?: GitSourceCache
 }
 
 export function SourceSelector(props: SourceSelectorProps) {
-  const { gitChannels, helmChannels, channels, secrets } = props
+  const { gitChannels, helmChannels, channels, secrets, gitSourceCache } = props
   const data = useItem<ApplicationSet>()
   const { t } = useTranslation()
   return (
@@ -78,8 +79,8 @@ export function SourceSelector(props: SourceSelectorProps) {
         <WizHidden hidden={(data) => data.path === undefined}>
           <RepoURL name="git" channels={gitChannels} secrets={secrets} />
           <WizHidden hidden={(data) => data.repoURL === ''}>
-            <GitRevisionSelect channels={channels ?? []} secrets={secrets} />
-            <GitPathSelect channels={channels ?? []} secrets={secrets} />
+            <GitRevisionSelect channels={channels ?? []} secrets={secrets} gitSourceCache={gitSourceCache} />
+            <GitPathSelect channels={channels ?? []} secrets={secrets} gitSourceCache={gitSourceCache} />
           </WizHidden>
         </WizHidden>
         {/* Helm repo */}

--- a/frontend/src/wizards/Argo/common/GitPathSelect.tsx
+++ b/frontend/src/wizards/Argo/common/GitPathSelect.tsx
@@ -4,7 +4,7 @@ import { ItemContext, useData, useItem, WizAsyncSelect } from '@patternfly-labs/
 import { useCallback, useContext } from 'react'
 import set from 'set-value'
 import { useTranslation } from '../../../lib/acm-i18next'
-import { Channel, getGitPathList } from '../ArgoWizard'
+import { Channel, GitSourceCache, getGitPathList, sortWithCachedFirst } from '../ArgoWizard'
 import { getGitChannelPaths } from '../../../resources'
 import { usePrevious } from '../../../components/usePrevious'
 import { Secret } from '../../../resources'
@@ -12,9 +12,10 @@ import { Secret } from '../../../resources'
 type GitPathSelectProps = {
   channels: Channel[]
   secrets: Secret[]
+  gitSourceCache?: GitSourceCache
 }
 
-export const GitPathSelect = ({ channels, secrets }: GitPathSelectProps) => {
+export const GitPathSelect = ({ channels, secrets, gitSourceCache }: GitPathSelectProps) => {
   const { t } = useTranslation()
   const repoURL = useItem('repoURL')
   const revision = useItem('targetRevision')
@@ -30,6 +31,7 @@ export const GitPathSelect = ({ channels, secrets }: GitPathSelectProps) => {
       return Promise.resolve([])
     }
 
+    const cachedPaths = gitSourceCache?.pathsByRepoURLAndRevision[repoURL]?.[revision] ?? []
     const channel = channels?.find((channel) => channel?.spec?.pathname === repoURL)
     const secret = secrets?.find((secret) => {
       if (!repoURL) {
@@ -57,7 +59,12 @@ export const GitPathSelect = ({ channels, secrets }: GitPathSelectProps) => {
           user: Buffer.from(secret.data?.username ?? '', 'base64').toString(),
           accessToken: Buffer.from(secret.data?.password ?? '', 'base64').toString(),
         }
-      ).then((paths) => (paths ?? []).filter((p): p is string => p !== undefined))
+      ).then((paths) =>
+        sortWithCachedFirst(
+          cachedPaths,
+          (paths ?? []).filter((p): p is string => p !== undefined)
+        )
+      )
     }
     return getGitPathList(
       {
@@ -73,8 +80,8 @@ export const GitPathSelect = ({ channels, secrets }: GitPathSelectProps) => {
       revision,
       getGitChannelPaths,
       repoURL
-    )
-  }, [channels, repoURL, revision, secrets])
+    ).then((paths) => sortWithCachedFirst(cachedPaths, paths))
+  }, [channels, gitSourceCache, repoURL, revision, secrets])
 
   // Clear path when repoURL or revision changes (update during render)
   const repoChanged = previousRepoURL !== repoURL && previousRepoURL !== undefined

--- a/frontend/src/wizards/Argo/common/GitRevisionSelect.tsx
+++ b/frontend/src/wizards/Argo/common/GitRevisionSelect.tsx
@@ -4,7 +4,7 @@ import { ItemContext, useData, useItem, WizAsyncSelect } from '@patternfly-labs/
 import { useCallback, useContext } from 'react'
 import set from 'set-value'
 import { useTranslation } from '../../../lib/acm-i18next'
-import { Channel, getGitBranchList } from '../ArgoWizard'
+import { Channel, getGitBranchList, GitSourceCache, sortWithCachedFirst } from '../ArgoWizard'
 import { getGitChannelBranches } from '../../../resources'
 import { usePrevious } from '../../../components/usePrevious'
 import { Secret } from '../../../resources'
@@ -15,11 +15,19 @@ type GitRevisionSelectProps = {
   revisions?: string[]
   channels: Channel[]
   secrets: Secret[]
+  gitSourceCache?: GitSourceCache
 }
 
 type WizardItem = Record<string, unknown>
 
-export const GitRevisionSelect = ({ channels, path, target, revisions, secrets }: GitRevisionSelectProps) => {
+export const GitRevisionSelect = ({
+  channels,
+  path,
+  target,
+  revisions,
+  secrets,
+  gitSourceCache,
+}: GitRevisionSelectProps) => {
   const { t } = useTranslation()
   const repoURL = useItem(path ?? 'repoURL')
   const targetRevision = useItem(target ?? 'targetRevision')
@@ -29,6 +37,7 @@ export const GitRevisionSelect = ({ channels, path, target, revisions, secrets }
   const previousRepoURL = usePrevious(repoURL)
 
   const gitRevisionsAsyncCallback = useCallback(() => {
+    const cachedRevisions = gitSourceCache?.revisionsByRepoURL[repoURL] ?? revisions ?? []
     const channel = channels?.find((channel) => channel.spec.pathname === repoURL)
     const secret = secrets?.find((secret) => {
       if (!repoURL) {
@@ -53,7 +62,7 @@ export const GitRevisionSelect = ({ channels, path, target, revisions, secrets }
           user: Buffer.from(secret.data?.username ?? '', 'base64').toString(),
           accessToken: Buffer.from(secret.data?.password ?? '', 'base64').toString(),
         }
-      ).then((branches) => [...(revisions ?? []), ...(branches ?? [])])
+      ).then((branches) => sortWithCachedFirst(cachedRevisions, branches ?? []))
     } else {
       return getGitBranchList(
         {
@@ -64,9 +73,9 @@ export const GitRevisionSelect = ({ channels, path, target, revisions, secrets }
           spec: { pathname: repoURL, type: 'git' },
         },
         getGitChannelBranches
-      ).then((branches) => [...(revisions ?? []), ...branches])
+      ).then((branches) => sortWithCachedFirst(cachedRevisions, branches))
     }
-  }, [channels, repoURL, revisions, secrets])
+  }, [channels, gitSourceCache, repoURL, revisions, secrets])
 
   // Clear targetRevision and path when repoURL changes (update during render)
   if (previousRepoURL !== repoURL && previousRepoURL !== undefined) {

--- a/frontend/src/wizards/Argo/common/GitSelectors.test.tsx
+++ b/frontend/src/wizards/Argo/common/GitSelectors.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../../../resources', () => ({
 }))
 
 jest.mock('../ArgoWizard', () => ({
+  ...jest.requireActual('../ArgoWizard'),
   getGitBranchList: jest.fn((channel: any, getGitChannelBranches: any) =>
     getGitChannelBranches(channel).then((branches: string[]) => branches)
   ),


### PR DESCRIPTION
# 📝 Summary
Using the same type of logic to fill the repo dropdown, look at existing applications to see what the latest apps used for branch and project to move those items to the top of the list:
<img width="1036" height="778" alt="CleanShot 2026-06-01 at 15 43 55@2x" src="https://github.com/user-attachments/assets/7bd7fd1a-9b54-46ca-ad84-e8040796eb8a" />

**Ticket Summary (Title):**  
ACM-33140 fill Revision/Path selections from a list of all existing appsets

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-33140

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [x] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git repository and revision selections in the Argo wizard now prioritize previously used items, displaying them first in selection lists for faster access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->