### PR TITLE
ACM-34514 customize hcp destroy instructions per platform

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1589,6 +1589,8 @@
   "Find by name": "Find by name",
   "Find clusters": "Find clusters",
   "Find the Amazon Web Services (AWS) STS credential and role ARN that you used to create your hosted cluster. The STS credential by default expires in 12 hours so a new one may be needed.": "Find the Amazon Web Services (AWS) STS credential and role ARN that you used to create your hosted cluster. The STS credential by default expires in 12 hours so a new one may be needed.",
+  "Find the Azure credentials file that you used to create your hosted cluster. You will need the path to your credentials file, your managed resource group name, and your DNS zone resource group name.": "Find the Azure credentials file that you used to create your hosted cluster. You will need the path to your credentials file, your managed resource group name, and your DNS zone resource group name.",
+  "Find the credentials that you used to create your hosted cluster. Use the help command below to determine the required parameters for your platform.": "Find the credentials that you used to create your hosted cluster. Use the help command below to determine the required parameters for your platform.",
   "find.label": "Find",
   "Fit to Screen": "Fit to Screen",
   "Fix editor syntax errors": "Fix editor syntax errors",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -506,6 +506,7 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
         open={showDestroyHostedModal}
         close={() => setShowDestroyHostedModal(false)}
         clusterName={cluster.name}
+        provider={cluster.provider}
       />
       <UpdateAutomationModal
         clusters={[cluster]}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DestroyHostedModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DestroyHostedModal.test.tsx
@@ -1,0 +1,103 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { render, screen, within } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import { Provider } from '../../../../../ui-components'
+import { DestroyHostedModal } from './DestroyHostedModal'
+import { clickByText } from '../../../../../lib/test-util'
+
+const mockClose = jest.fn()
+
+function renderModal(provider?: Provider, clusterName = 'test-cluster') {
+  render(<DestroyHostedModal open={true} close={mockClose} clusterName={clusterName} provider={provider} />)
+  return screen.getByRole('dialog', { name: /permanently destroy/i })
+}
+
+describe('DestroyHostedModal', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('has no accessibility violations', async () => {
+    renderModal(Provider.aws)
+    expect(await axe(document.body)).toHaveNoViolations()
+  })
+
+  test('renders the modal title and cluster name in the description', () => {
+    const dialog = renderModal(Provider.aws)
+    expect(within(dialog).getByText('Permanently destroy clusters?')).toBeInTheDocument()
+    expect(within(dialog).getByText('test-cluster', { exact: false })).toBeInTheDocument()
+    expect(within(dialog).getByText('can only be destroyed through the CLI', { exact: false })).toBeInTheDocument()
+  })
+
+  test('calls close when the Close button is clicked', async () => {
+    renderModal(Provider.aws)
+    await clickByText('Close')
+    expect(mockClose).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not render when open is false', () => {
+    render(<DestroyHostedModal open={false} close={mockClose} clusterName="test-cluster" provider={Provider.aws} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  describe('AWS provider', () => {
+    test('shows AWS-specific destroy instructions', () => {
+      const dialog = renderModal(Provider.aws)
+      expect(within(dialog).getByText(/--sts-creds/)).toBeInTheDocument()
+      expect(within(dialog).getByText(/--role-arn/)).toBeInTheDocument()
+      expect(within(dialog).getByText('hcp destroy cluster aws --help')).toBeInTheDocument()
+    })
+
+    test('shows AWS credential guidance', () => {
+      const dialog = renderModal(Provider.aws)
+      expect(within(dialog).getByText(/Amazon Web Services \(AWS\) STS credential and role ARN/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Azure provider', () => {
+    test('shows Azure-specific destroy instructions', () => {
+      const dialog = renderModal(Provider.azure)
+      expect(within(dialog).getByText(/--azure-creds/)).toBeInTheDocument()
+      expect(within(dialog).getByText(/--resource-group-name/)).toBeInTheDocument()
+      expect(within(dialog).getByText(/--dns-zone-rg-name/)).toBeInTheDocument()
+      expect(within(dialog).getByText('hcp destroy cluster azure --help')).toBeInTheDocument()
+    })
+
+    test('shows Azure credential guidance', () => {
+      const dialog = renderModal(Provider.azure)
+      expect(within(dialog).getByText(/Azure credentials file/)).toBeInTheDocument()
+      expect(within(dialog).getByText(/managed resource group name/)).toBeInTheDocument()
+    })
+
+    test('does not show AWS-specific content', () => {
+      const dialog = renderModal(Provider.azure)
+      expect(within(dialog).queryByText(/--sts-creds/)).not.toBeInTheDocument()
+      expect(within(dialog).queryByText(/--role-arn/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('unknown provider (generic fallback)', () => {
+    test('shows generic destroy instructions', () => {
+      const dialog = renderModal(Provider.gcp)
+      expect(within(dialog).getByText(/hcp destroy cluster <platform>/)).toBeInTheDocument()
+      expect(within(dialog).getByText('hcp destroy cluster --help')).toBeInTheDocument()
+    })
+
+    test('shows generic credential guidance', () => {
+      const dialog = renderModal(Provider.gcp)
+      expect(
+        within(dialog).getByText(/Find the credentials that you used to create your hosted cluster/)
+      ).toBeInTheDocument()
+    })
+
+    test('falls back to generic when provider is undefined', () => {
+      const dialog = renderModal()
+      expect(within(dialog).getByText(/hcp destroy cluster <platform>/)).toBeInTheDocument()
+    })
+
+    test('does not show AWS or Azure-specific content', () => {
+      const dialog = renderModal(Provider.gcp)
+      expect(within(dialog).queryByText(/--sts-creds/)).not.toBeInTheDocument()
+      expect(within(dialog).queryByText(/--azure-creds/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DestroyHostedModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DestroyHostedModal.tsx
@@ -2,27 +2,75 @@
 
 import { Button, CodeBlock, CodeBlockCode, Content, ContentVariants } from '@patternfly/react-core'
 import { ModalVariant } from '@patternfly/react-core/deprecated'
-import { AcmModal } from '../../../../../ui-components'
+import { AcmModal, Provider } from '../../../../../ui-components'
 import { Trans, useTranslation } from '../../../../../lib/acm-i18next'
 import DocPage from '../CreateCluster/components/assisted-installer/hypershift/common/DocPage'
 import { Fragment } from 'react'
 import { Actions, GetOCLogInCommand } from '../CreateCluster/components/assisted-installer/hypershift/common/common'
+import type { TFunction } from 'react-i18next'
 
-export function DestroyHostedModal(props: { open: boolean; close: () => void; clusterName: string }) {
-  const { open, close, clusterName } = props
-  const { t } = useTranslation()
+interface DestroyHostedModalProps {
+  readonly open: boolean
+  readonly close: () => void
+  readonly clusterName: string
+  readonly provider?: Provider
+}
 
-  const destroyCode = `# Set environment variables
+function getDestroyInstructions(t: TFunction, provider?: Provider) {
+  switch (provider) {
+    case Provider.azure:
+      return {
+        destroyCode: String.raw`# Set environment variables
 export CLUSTER_NAME="example"
-export STS_CREDS="example-sts-creds-json"  # The credential name from step 1.
+export AZURE_CREDS="/path/to/azure-credentials.json"
+export MANAGED_RG_NAME="example-managed-resource-group"
+export DNS_ZONE_RG_NAME="example-dns-zone-resource-group"
+
+hcp destroy cluster azure \
+  --name $CLUSTER_NAME \
+  --azure-creds $AZURE_CREDS \
+  --resource-group-name $MANAGED_RG_NAME \
+  --dns-zone-rg-name $DNS_ZONE_RG_NAME`,
+        helperCommand: `hcp destroy cluster azure --help`,
+        credentialStep: t(
+          'Find the Azure credentials file that you used to create your hosted cluster. You will need the path to your credentials file, your managed resource group name, and your DNS zone resource group name.'
+        ),
+      }
+    case Provider.aws:
+      return {
+        destroyCode: String.raw`# Set environment variables
+export CLUSTER_NAME="example"
+export STS_CREDS="example-sts-creds.json"  # The credential name from step 1.
 export ROLE_ARN="example-role-arn" # Role ARN from step 1
 
-hcp destroy cluster aws \\
-  --name $CLUSTER_NAME \\
-  --sts-creds $STS_CREDS \\
-  --role-arn $ROLE_ARN`
+hcp destroy cluster aws \
+  --name $CLUSTER_NAME \
+  --sts-creds $STS_CREDS \
+  --role-arn $ROLE_ARN`,
+        helperCommand: `hcp destroy cluster aws --help`,
+        credentialStep: t(
+          'Find the Amazon Web Services (AWS) STS credential and role ARN that you used to create your hosted cluster. The STS credential by default expires in 12 hours so a new one may be needed.'
+        ),
+      }
+    default:
+      return {
+        destroyCode: String.raw`export CLUSTER_NAME="example"
 
-  const destroyhelperCommand = `hcp destroy cluster aws --help`
+hcp destroy cluster <platform> \
+  --name $CLUSTER_NAME`,
+        helperCommand: `hcp destroy cluster --help`,
+        credentialStep: t(
+          'Find the credentials that you used to create your hosted cluster. Use the help command below to determine the required parameters for your platform.'
+        ),
+      }
+  }
+}
+
+export function DestroyHostedModal(props: DestroyHostedModalProps) {
+  const { open, close, clusterName, provider } = props
+  const { t } = useTranslation()
+
+  const { destroyCode, helperCommand, credentialStep } = getDestroyInstructions(t, provider)
 
   const listItems = [
     {
@@ -30,11 +78,7 @@ hcp destroy cluster aws \\
       content: (
         <Fragment>
           {GetOCLogInCommand()}
-          <Content component={ContentVariants.p}>
-            {t(
-              'Find the Amazon Web Services (AWS) STS credential and role ARN that you used to create your hosted cluster. The STS credential by default expires in 12 hours so a new one may be needed.'
-            )}
-          </Content>
+          <Content component={ContentVariants.p}>{credentialStep}</Content>
         </Fragment>
       ),
     },
@@ -51,8 +95,8 @@ hcp destroy cluster aws \\
           <Content component="p" style={{ marginTop: '1em' }}>
             {t('Use the following command to get a list of available parameters:')}
           </Content>
-          <CodeBlock actions={Actions(destroyhelperCommand, 'helper-command')}>
-            <CodeBlockCode id="helper-command">{destroyhelperCommand}</CodeBlockCode>
+          <CodeBlock actions={Actions(helperCommand, 'helper-command')}>
+            <CodeBlockCode id="helper-command">{helperCommand}</CodeBlockCode>
           </CodeBlock>
         </Fragment>
       ),

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DestroyHostedModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DestroyHostedModal.tsx
@@ -40,7 +40,7 @@ hcp destroy cluster azure \
       return {
         destroyCode: String.raw`# Set environment variables
 export CLUSTER_NAME="example"
-export STS_CREDS="example-sts-creds.json"  # The credential name from step 1.
+export STS_CREDS="/path/to/example-sts-creds.json"  # The credential name from step 1.
 export ROLE_ARN="example-role-arn" # Role ARN from step 1
 
 hcp destroy cluster aws \


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
MCE Console Shows Wrong Platform Destroy Instructions for deletion of Azure HCP cluster

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-34514

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

Screenshots of the modals after changes. (Thanks @fxiang1 for test clusters.)

## AWS
<img width="962" height="933" alt="image" src="https://github.com/user-attachments/assets/e1e60886-e215-46d7-a683-746baadcdb71" />

## Azure
<img width="945" height="959" alt="image" src="https://github.com/user-attachments/assets/24bcef2a-b6a1-4b00-9b9e-5b42b93578e5" />

##Other
<img width="988" height="830" alt="image" src="https://github.com/user-attachments/assets/5b6427a8-bdb4-4571-b3a3-f24183ad9acb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Destruction modal now shows tailored CLI instructions and credential guidance for AWS, Azure, and other providers.

* **Tests**
  * Added thorough test coverage and accessibility checks for the destruction modal, including provider-specific content, fallback behavior, visibility toggles, and close action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->