### PR TITLE
ACM-34279 fix compression dictionary memory leak

### DIFF
--- a/backend/src/lib/compression.ts
+++ b/backend/src/lib/compression.ts
@@ -19,21 +19,30 @@ import { getEventDict } from '../routes/events'
 import { getAppDict, type ICompressedResource, type ITransformedResource } from '../routes/aggregators/applications'
 import { promisify } from 'node:util'
 
+const MAX_RECENTLY_ADDED = 200
+
 type Dictionary = {
   arr: string[]
   map: Record<string, string>
   add: (key: string) => string
   get: (inx: number) => string
   has: (key: string) => string
+  recentlyAdded: string[]
+  snapshotSize: () => number
+  drainRecentlyAdded: () => string[]
 }
 
 export function createDictionary(): Dictionary {
   const arr: string[] = []
   const map: Record<string, string> = {}
+  const recentlyAdded: string[] = []
   const add = (key: string): string => {
     if (!(key in map)) {
       map[key] = `${arr.length}`
       arr.push(key)
+      if (logger.isLevelEnabled('debug') && recentlyAdded.length < MAX_RECENTLY_ADDED) {
+        recentlyAdded.push(key)
+      }
     }
     return map[key]
   }
@@ -43,12 +52,17 @@ export function createDictionary(): Dictionary {
   const has = (key: string) => {
     return map[key]
   }
+  const snapshotSize = () => arr.length
+  const drainRecentlyAdded = () => recentlyAdded.splice(0)
   return {
     arr,
     map,
     add,
     get,
     has,
+    recentlyAdded,
+    snapshotSize,
+    drainRecentlyAdded,
   }
 }
 

--- a/backend/src/lib/compression.ts
+++ b/backend/src/lib/compression.ts
@@ -88,6 +88,19 @@ type CompressedResourceType = Record<number, any> | Record<number, any[]> | stri
 const NUMBER_MARKER = '#!%'
 const JSON_MARKER = '#!&'
 
+// Detects ISO 8601 timestamps to avoid permanently indexing unique time values.
+// Covers: "2026-05-27T20:18:12Z" (20), "2026-05-27T20:18:12.000Z" (24), "2026-05-27T20:18:12+05:30" (25)
+export function isTimestamp(s: string): boolean {
+  return (
+    (s.length === 20 || s.length === 24 || s.length === 25) &&
+    s[4] === '-' &&
+    s[7] === '-' &&
+    s[10] === 'T' &&
+    s[13] === ':' &&
+    (s.endsWith('Z') || s[19] === '+' || s[19] === '-')
+  )
+}
+
 export class FifoSet<T> {
   private readonly values: T[] = []
   private readonly membership: Set<T> = new Set()
@@ -185,6 +198,10 @@ function compressResource(resource: UncompressedResourceType, dictionary: Dictio
         }
       }
       if (resource.length < 32 && !resource.endsWith('=')) {
+        // skip indexing of all timestamps
+        if (isTimestamp(resource)) {
+          return resource
+        }
         // index short strings that aren't a base64
         return dictionary.add(resource)
       }

--- a/backend/src/routes/aggregators/utils.ts
+++ b/backend/src/routes/aggregators/utils.ts
@@ -1044,16 +1044,40 @@ export function logApplicationCountChanges(applicationCache: ApplicationCacheTyp
       .toString()
       .replaceAll(/\B(?=(\d{3})+(?!\d))/g, ',')} KB`
   }
+
+  const appDictObj = getAppDict()
+  const eventDictObj = getEventDict()
+
   logger.info({
     msg: 'memory',
     caches: {
       clients: Object.keys(ServerSideEvents.getClients()).length,
       appCache: memUsed(applicationCache),
-      appDict: memUsed(getAppDict()),
+      appDict: memUsed(appDictObj),
       eventCache: memUsed(getEventCache()),
-      eventDict: memUsed(getEventDict()),
+      eventDict: memUsed(eventDictObj),
     },
   })
+  if (logger.isLevelEnabled('debug')) {
+    const recentAppDict = appDictObj.drainRecentlyAdded()
+    const recentEventDict = eventDictObj.drainRecentlyAdded()
+    if (recentAppDict.length > 0) {
+      logger.debug({
+        msg: 'appDict growth',
+        appDictEntries: appDictObj.snapshotSize(),
+        newEntries: recentAppDict.length,
+        sample: recentAppDict.slice(0, 50),
+      })
+    }
+    if (recentEventDict.length > 0) {
+      logger.debug({
+        msg: 'eventDict growth',
+        eventDictEntries: eventDictObj.snapshotSize(),
+        newEntries: recentEventDict.length,
+        sample: recentEventDict.slice(0, 50),
+      })
+    }
+  }
 }
 
 export function sizeOf(data: unknown) {

--- a/backend/test/lib/compression.test.ts
+++ b/backend/test/lib/compression.test.ts
@@ -1,0 +1,150 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { createDictionary, deflateResource, inflateResource, isTimestamp } from '../../src/lib/compression'
+import type { IResource } from '../../src/resources/resource'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asResource = (obj: Record<string, any>) => obj as unknown as IResource
+
+describe('isTimestamp', () => {
+  it('detects UTC timestamps with Z suffix', () => {
+    expect(isTimestamp('2026-05-27T20:18:12Z')).toBe(true)
+  })
+
+  it('detects timestamps with milliseconds', () => {
+    expect(isTimestamp('2026-05-27T20:18:12.000Z')).toBe(true)
+  })
+
+  it('detects timestamps with timezone offset', () => {
+    expect(isTimestamp('2026-05-27T20:18:12+05:30')).toBe(true)
+    expect(isTimestamp('2026-05-27T20:18:12-04:00')).toBe(true)
+  })
+
+  it('rejects non-timestamp strings of similar length', () => {
+    expect(isTimestamp('this-is-not-a-timest')).toBe(false)
+    expect(isTimestamp('abcdefghijklmnopqrst')).toBe(false)
+    expect(isTimestamp('192.168.1.1:8080/api')).toBe(false)
+  })
+
+  it('rejects near-valid timestamp shapes', () => {
+    expect(isTimestamp('2026/05/27T12:34:56Z')).toBe(false) // wrong date separator
+    expect(isTimestamp('2026-05-27 12:34:56Z')).toBe(false) // space instead of T
+    expect(isTimestamp('2026-05-27T12:34:56UTC')).toBe(false) // wrong length, "UTC" suffix
+    expect(isTimestamp('2026-05-27T12.34.56Z')).toBe(false) // dots instead of colons in time
+    expect(isTimestamp('026-05-27T12:34:56Z')).toBe(false) // wrong length, 3-digit year
+    expect(isTimestamp('2026-05-27T12:34:56+0530')).toBe(true) // colonless offset is still a valid timestamp
+  })
+
+  it('rejects strings of wrong length', () => {
+    expect(isTimestamp('short')).toBe(false)
+    expect(isTimestamp('2026-05-27')).toBe(false)
+    expect(isTimestamp('a-very-long-string-that-is-definitely-not-a-timestamp')).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(isTimestamp('')).toBe(false)
+  })
+})
+
+describe('compressResource timestamp handling', () => {
+  it('does not add timestamp values to the dictionary', async () => {
+    const dict = createDictionary()
+    const resource = asResource({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: {
+        name: 'test-app',
+        uid: 'test-uid',
+      },
+      status: {
+        reconciledAt: '2026-05-27T20:18:12Z',
+        operationState: {
+          startedAt: '2026-05-27T20:18:10Z',
+          finishedAt: '2026-05-27T20:18:12Z',
+        },
+      },
+    })
+
+    await deflateResource(resource, dict)
+    const dictEntries = dict.arr
+
+    expect(dictEntries).not.toContain('2026-05-27T20:18:12Z')
+    expect(dictEntries).not.toContain('2026-05-27T20:18:10Z')
+  })
+
+  it('still adds non-timestamp short strings to the dictionary', async () => {
+    const dict = createDictionary()
+    const resource = asResource({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: {
+        name: 'test-app',
+        uid: 'test-uid',
+      },
+      status: {
+        health: {
+          status: 'Healthy',
+        },
+        sync: {
+          status: 'Synced',
+        },
+      },
+    })
+
+    await deflateResource(resource, dict)
+    const dictEntries = dict.arr
+
+    expect(dictEntries).toContain('Healthy')
+    expect(dictEntries).toContain('Synced')
+  })
+
+  it('round-trips resources with timestamp values correctly', async () => {
+    const dict = createDictionary()
+    const resource = asResource({
+      apiVersion: 'argoproj.io/v1alpha1',
+      kind: 'Application',
+      metadata: {
+        name: 'test-app',
+        uid: 'test-uid',
+      },
+      status: {
+        reconciledAt: '2026-05-27T20:18:12Z',
+        health: {
+          status: 'Healthy',
+        },
+      },
+    })
+
+    const compressed = await deflateResource(resource, dict)
+    const inflated = structuredClone(await inflateResource(compressed, dict)) as unknown as {
+      apiVersion: string
+      metadata: { name: string }
+      status: { reconciledAt: string; health: { status: string } }
+    }
+
+    expect(inflated.status.reconciledAt).toBe('2026-05-27T20:18:12Z')
+    expect(inflated.status.health.status).toBe('Healthy')
+    expect(inflated.apiVersion).toBe('argoproj.io/v1alpha1')
+    expect(inflated.metadata.name).toBe('test-app')
+  })
+
+  it('does not grow the dictionary on repeated compression with changing timestamps', async () => {
+    const dict = createDictionary()
+    const makeResource = (ts: string) =>
+      asResource({
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'Application',
+        metadata: { name: 'test-app', uid: 'uid-1' },
+        status: { reconciledAt: ts },
+      })
+
+    await deflateResource(makeResource('2026-05-27T10:00:00Z'), dict)
+    const sizeAfterFirst = dict.arr.length
+
+    await deflateResource(makeResource('2026-05-27T10:03:00Z'), dict)
+    await deflateResource(makeResource('2026-05-27T10:06:00Z'), dict)
+    await deflateResource(makeResource('2026-05-27T10:09:00Z'), dict)
+    const sizeAfterFourth = dict.arr.length
+
+    expect(sizeAfterFourth).toBe(sizeAfterFirst)
+  })
+})

--- a/backend/test/lib/compression.test.ts
+++ b/backend/test/lib/compression.test.ts
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { createDictionary, deflateResource, inflateResource, isTimestamp } from '../../src/lib/compression'
 import type { IResource } from '../../src/resources/resource'
+import { logger } from '../../src/lib/logger'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const asResource = (obj: Record<string, any>) => obj as unknown as IResource
@@ -42,6 +43,40 @@ describe('isTimestamp', () => {
 
   it('rejects empty string', () => {
     expect(isTimestamp('')).toBe(false)
+  })
+})
+
+describe('dictionary tracking', () => {
+  let isLevelEnabledSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    isLevelEnabledSpy = jest.spyOn(logger, 'isLevelEnabled').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    isLevelEnabledSpy.mockRestore()
+  })
+
+  it('tracks recently added entries and exposes snapshot size', () => {
+    const dict = createDictionary()
+    dict.add('alpha')
+    dict.add('beta')
+    dict.add('alpha')
+
+    expect(dict.snapshotSize()).toBe(2)
+    expect(dict.recentlyAdded).toContain('alpha')
+    expect(dict.recentlyAdded).toContain('beta')
+  })
+
+  it('drains recently added entries', () => {
+    const dict = createDictionary()
+    dict.add('one')
+    dict.add('two')
+
+    const drained = dict.drainRecentlyAdded()
+    expect(drained).toEqual(['one', 'two'])
+    expect(dict.recentlyAdded).toHaveLength(0)
+    expect(dict.snapshotSize()).toBe(2)
   })
 })
 

--- a/backend/test/routes/aggregators/utils.test.ts
+++ b/backend/test/routes/aggregators/utils.test.ts
@@ -19,8 +19,9 @@ import {
   getClusterProxyServiceURL,
   keyBy,
   sizeOf,
+  logApplicationCountChanges,
 } from '../../../src/routes/aggregators/utils'
-import { cacheResource, getEventCache } from '../../../src/routes/events'
+import { cacheResource, getEventCache, getEventDict } from '../../../src/routes/events'
 import type {
   IResource,
   IArgoApplication,
@@ -32,7 +33,9 @@ import type {
   IService,
 } from '../../../src/resources/resource'
 import type { ApplicationClusterStatusMap, ITransformedResource } from '../../../src/routes/aggregators/applications'
+import { getAppDict } from '../../../src/routes/aggregators/applications'
 import { ServerSideEvents } from '../../../src/lib/server-side-events'
+import { logger } from '../../../src/lib/logger'
 
 describe('aggregators utils', () => {
   beforeEach(() => {
@@ -1352,6 +1355,47 @@ describe('aggregators utils', () => {
 
       expect(clusters).toHaveLength(1)
       expect(clusters[0]).toBe('local-cluster')
+    })
+  })
+
+  describe('logApplicationCountChanges', () => {
+    it('logs memory usage and dictionary growth at debug level', () => {
+      const isLevelEnabledSpy = jest.spyOn(logger, 'isLevelEnabled').mockReturnValue(true)
+      const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {})
+      const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {})
+
+      const appDict = getAppDict()
+      appDict.add('test-app-key-for-coverage')
+      const eventDict = getEventDict()
+      eventDict.add('test-event-key-for-coverage')
+
+      logApplicationCountChanges({}, 1)
+
+      expect(infoSpy).toHaveBeenCalledWith(expect.objectContaining({ msg: 'memory' }))
+      expect(debugSpy).toHaveBeenCalledWith(expect.objectContaining({ msg: 'appDict growth' }))
+      expect(debugSpy).toHaveBeenCalledWith(expect.objectContaining({ msg: 'eventDict growth' }))
+
+      isLevelEnabledSpy.mockRestore()
+      debugSpy.mockRestore()
+      infoSpy.mockRestore()
+    })
+
+    it('does not log dictionary growth when there are no new entries', () => {
+      const isLevelEnabledSpy = jest.spyOn(logger, 'isLevelEnabled').mockReturnValue(true)
+      const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {})
+      const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {})
+
+      const appDict = getAppDict()
+      appDict.drainRecentlyAdded()
+
+      logApplicationCountChanges({}, 50)
+
+      expect(infoSpy).toHaveBeenCalledWith(expect.objectContaining({ msg: 'memory' }))
+      expect(debugSpy).not.toHaveBeenCalledWith(expect.objectContaining({ msg: 'appDict growth' }))
+
+      isLevelEnabledSpy.mockRestore()
+      debugSpy.mockRestore()
+      infoSpy.mockRestore()
     })
   })
 })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
console-mce-console: compression dictionaries (eventDict/appDict) grow monotonically without cleanup

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-34279

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
This PR does not solve the core issue that the compression dictionaries will continue to grow as new values are indexed. Removing values from the index would require us to implement reference counting. This does not seem warranted because while there is some growth in the compression dictionaries, it does not explain the overall pod memory usage growth seen by a customer. We are indexing timestamps from several fields that escaped the current filters, and that does contribute some unnecessary growth that we can eliminate.

Customer logs showed growth in the `appDict` with 5 local ArgoCD applications:
```
{"level":30,"time":1779078387586,"msg":"memory","caches":{"clients":0,"appCache":"62 KB","appDict":"2,282 KB","eventCache":"36 KB","eventDict":"59 KB"}}
```

On a test cluster with 100 local ArgoCD applications I was able to observe significant growth in the `appDict`:
```
{"level":30,"time":1780668374600,"msg":"memory","caches":{"clients":0,"appCache":"152 KB","appDict":"10,199 KB","eventCache":"38 KB","eventDict":"51 KB"}}
```

But pod memory growth remains modest:
<img width="1177" height="566" alt="image" src="https://github.com/user-attachments/assets/82375682-900d-4a8b-ba04-a4b1c8a89edf" />

Claude correctly identified that the source was timestamps escaping the field-name based filter for fields containing the string "Time". Several ArgoCD fields end with "At" like "reconciledAt". This PR adds logging for up to 200 new entries in the dictionary when debug logging is enabled and checks all short values to avoid adding timestamps.

On the test cluster, debug logging confirmed that after initial data loading, all new `appDict` entries were timestamps:
```
[backend]  INFO:memory, caches{ clients:0, appCache:152 KB, appDict:21 KB, eventCache:38 KB, eventDict:48 KB }
[backend] DEBUG:appDict growth, appDictEntries:460, newEntries:15, sample[ 2026-06-05T14:15:09Z, 2026-06-05T14:15:02Z, 2026-06-05T14:15:03Z, 2026-06-05T14:15:25Z, 2026-06-05T14:15:24Z, 2026-06-05T14:15:11Z, 2026-06-05T14:15:20Z, 2026-06-05T14:15:22Z, 2026-06-05T14:15:12Z, 2026-06-05T14:15:18Z, 2026-06-05T14:15:19Z, 2026-06-05T14:15:10Z, 2026-06-05T14:15:26Z, 2026-06-05T14:15:13Z, 2026-06-05T14:15:15Z ]
[backend]  INFO:memory, caches{ clients:0, appCache:152 KB, appDict:23 KB, eventCache:38 KB, eventDict:48 KB }
[backend] DEBUG:appDict growth, appDictEntries:485, newEntries:25, sample[ 2026-06-05T14:15:37Z, 2026-06-05T14:15:40Z, 2026-06-05T14:15:41Z, 2026-06-05T14:15:36Z, 2026-06-05T14:15:32Z, 2026-06-05T14:15:39Z, 2026-06-05T14:15:35Z, 2026-06-05T14:15:29Z, 2026-06-05T14:15:33Z, 2026-06-05T14:15:34Z, 2026-06-05T14:15:53Z, 2026-06-05T14:15:52Z, 2026-06-05T14:15:54Z, 2026-06-05T14:15:47Z, 2026-06-05T14:15:50Z, 2026-06-05T14:15:51Z, 2026-06-05T14:15:45Z, 2026-06-05T14:15:43Z, 2026-06-05T14:15:56Z, 2026-06-05T14:15:49Z, 2026-06-05T14:15:48Z, 2026-06-05T14:15:55Z, 2026-06-05T14:16:00Z, 2026-06-05T14:15:59Z, 2026-06-05T14:16:01Z ]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exclude ISO-8601-like timestamp strings from compression to reduce memory growth.
  * Added timestamp-detection to recognize and preserve timestamp fields.
  * Enhanced debug logging to report dictionary growth and recent-entry details.

* **Tests**
  * Added comprehensive tests for timestamp detection, compression behavior, round-trip preservation, and dictionary stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->