### PR TITLE
ACM-30906: Auto-detect AAP operator channel when unavailable

### DIFF
--- a/scripts/aap-automation/install-aap.sh
+++ b/scripts/aap-automation/install-aap.sh
@@ -133,7 +133,7 @@ fi
 rm -f "$OC_PKG_STDERR"
 
 if [ -n "$OPERATOR_CHANNEL" ] && ! echo "$AVAILABLE_CHANNELS" | grep -qx "$OPERATOR_CHANNEL"; then
-    log_warn "Requested channel '$OPERATOR_CHANNEL' not available — will auto-select the latest stable-* channel"
+    log_warn "Requested channel '$OPERATOR_CHANNEL' not available — will auto-select the latest stable-* channel, or the latest available channel if none match"
     OPERATOR_CHANNEL=""
 fi
 

--- a/scripts/aap-automation/install-aap.sh
+++ b/scripts/aap-automation/install-aap.sh
@@ -120,16 +120,20 @@ log_info "Creating namespace: $AAP_NAMESPACE"
 oc create namespace "$AAP_NAMESPACE" --dry-run=client -o yaml | oc apply -f -
 
 # Auto-detect operator channel if not set or if the requested channel is unavailable
+OC_PKG_STDERR=$(mktemp)
 AVAILABLE_CHANNELS=$(oc get packagemanifest ansible-automation-platform-operator \
-    -n openshift-marketplace -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' 2>/dev/null)
+    -n openshift-marketplace -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' 2>"$OC_PKG_STDERR")
 
 if [ -z "$AVAILABLE_CHANNELS" ]; then
-    log_error "AAP operator not found in OperatorHub catalog"
+    OC_ERR=$(cat "$OC_PKG_STDERR")
+    rm -f "$OC_PKG_STDERR"
+    log_error "AAP operator not found in OperatorHub catalog (oc get packagemanifest failed: ${OC_ERR:-no output})"
     exit 1
 fi
+rm -f "$OC_PKG_STDERR"
 
 if [ -n "$OPERATOR_CHANNEL" ] && ! echo "$AVAILABLE_CHANNELS" | grep -qx "$OPERATOR_CHANNEL"; then
-    log_warn "Requested channel '$OPERATOR_CHANNEL' not available, auto-detecting..."
+    log_warn "Requested channel '$OPERATOR_CHANNEL' not available — will auto-select the latest stable-* channel"
     OPERATOR_CHANNEL=""
 fi
 

--- a/scripts/aap-automation/install-aap.sh
+++ b/scripts/aap-automation/install-aap.sh
@@ -119,17 +119,22 @@ log_info "Starting AAP installation on OpenShift cluster: $(oc whoami --show-ser
 log_info "Creating namespace: $AAP_NAMESPACE"
 oc create namespace "$AAP_NAMESPACE" --dry-run=client -o yaml | oc apply -f -
 
-# Auto-detect operator channel if not explicitly set
+# Auto-detect operator channel if not set or if the requested channel is unavailable
+AVAILABLE_CHANNELS=$(oc get packagemanifest ansible-automation-platform-operator \
+    -n openshift-marketplace -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' 2>/dev/null)
+
+if [ -z "$AVAILABLE_CHANNELS" ]; then
+    log_error "AAP operator not found in OperatorHub catalog"
+    exit 1
+fi
+
+if [ -n "$OPERATOR_CHANNEL" ] && ! echo "$AVAILABLE_CHANNELS" | grep -qx "$OPERATOR_CHANNEL"; then
+    log_warn "Requested channel '$OPERATOR_CHANNEL' not available, auto-detecting..."
+    OPERATOR_CHANNEL=""
+fi
+
 if [ -z "$OPERATOR_CHANNEL" ]; then
     log_info "Detecting available AAP operator channels..."
-    AVAILABLE_CHANNELS=$(oc get packagemanifest ansible-automation-platform-operator \
-        -n openshift-marketplace -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' 2>/dev/null)
-
-    if [ -z "$AVAILABLE_CHANNELS" ]; then
-        log_error "AAP operator not found in OperatorHub catalog"
-        exit 1
-    fi
-
     OPERATOR_CHANNEL=$(echo "$AVAILABLE_CHANNELS" | grep '^stable-' | grep -v 'cluster-scoped' \
         | sort -t. -k2 -n | tail -1)
 


### PR DESCRIPTION
## Summary

- Validate the requested operator channel against the OperatorHub catalog before installing
- If the channel doesn't exist (e.g. `stable-2.5-cluster-scoped` on OCP 4.22), fall back to auto-detecting the latest available `stable-*` channel
- This allows callers like rhacmstackem to keep their existing defaults without needing updates when OCP drops older AAP channels

## Test plan

- [x] Tested with `OPERATOR_CHANNEL=stable-2.5-cluster-scoped` on OCP 4.22 — detected unavailable, auto-fell back to `stable-2.7`
- [x] Full end-to-end pass: operator install, platform deploy, subscription activation, OAuth token, ACM credential
- [x] Cluster: `cs-aws-422-m4jn6` (OCP 4.22, AAP 2.7 / controller v4.8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always verify operator channels against OperatorHub before installation.
  * If no channels are returned, installation now fails fast with an error.
  * If a configured channel is invalid, a warning is shown and the installer auto-detects a channel.
  * Auto-detection prefers stable-* channels (excluding cluster-scoped) or selects the highest available version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->