### PR TITLE
ACM-34294 Missing UI Validation on Empty Policy Template Submission

### DIFF
--- a/frontend/packages/react-form-wizard/wizards/Policy/PolicyWizard.tsx
+++ b/frontend/packages/react-form-wizard/wizards/Policy/PolicyWizard.tsx
@@ -68,7 +68,7 @@ export function PolicyWizard(props: {
           {
             ...PolicyType,
             metadata: { name: '', namespace: '' },
-            spec: { disabled: false },
+            spec: { disabled: false, 'policy-templates': [] },
           },
         ]
       }

--- a/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
+++ b/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
@@ -84,7 +84,7 @@ export function PolicyWizard(props: {
     {
       ...PolicyType,
       metadata: { name: '', namespace: '' },
-      spec: { disabled: false },
+      spec: { disabled: false, 'policy-templates': [] },
     },
   ]
 


### PR DESCRIPTION
# 📝 Summary
When creating a new policy, the default data has spec: { disabled: false } but NO policy-templates field. This means:
If user never touches templates →spec.policy-templatesisundefined→ API error
If user adds then removes all templates →spec.policy-templatesis[]→ API accepts it

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
ACM-34294 Missing UI Validation on Empty Policy Template Submission

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://redhat.atlassian.net/browse/ACM-34294

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->
Before:

https://github.com/user-attachments/assets/9601617f-c3f1-4468-91ea-7e0c7c01810c


After:

https://github.com/user-attachments/assets/6219ff8b-48c0-440e-8b32-f9e9c85d850e

