### PR TITLE
chore(deps): update registry.redhat.io/ubi9/nodejs-24-minimal docker digest to e76548c (release-2.17)

### DIFF
--- a/Containerfile.acm
+++ b/Containerfile.acm
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:e76548c58c4a29907cef1e01cb6a4cab426eb071ffe28ac1f25dd58d14a89569
 
 FROM ${NODE_BASE} as build-base
 USER root

--- a/Containerfile.mce
+++ b/Containerfile.mce
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:e76548c58c4a29907cef1e01cb6a4cab426eb071ffe28ac1f25dd58d14a89569
 
 FROM ${NODE_BASE} as build-base
 USER root


### PR DESCRIPTION
## Summary
- Update `registry.redhat.io/ubi9/nodejs-24-minimal` docker digest from `f42698c` to `e76548c` on the release-2.17 branch
- Backport of PR #6267 (main)

| Package | Update | Change |
|---|---|---|
| registry.redhat.io/ubi9/nodejs-24-minimal | digest | `f42698c` → `e76548c` |