### PR TITLE
ACM-34249: Add Kyverno CEL-based discovered policy types

### DIFF
--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -4,7 +4,10 @@
 import { render } from '@testing-library/react'
 import {
   hasInformOnlyPolicies,
+  getEngineString,
   getPolicyRemediation,
+  isKyvernoApiGroup,
+  isLegacyKyvernoApiGroup,
   resolveExternalStatus,
   parseStringMap,
   policyHasDeletePruneBehavior,
@@ -1029,6 +1032,44 @@ describe('Test policyHasDeletePruneBehavior', () => {
     const policy = cloneDeep(basePolicy)
     delete policy.spec['policy-templates']
     expect(policyHasDeletePruneBehavior(policy)).toBe(false)
+  })
+})
+
+describe('isKyvernoApiGroup', () => {
+  test.each([
+    ['kyverno.io', true],
+    ['policies.kyverno.io', true],
+    ['constraints.gatekeeper.sh', false],
+    ['policy.open-cluster-management.io', false],
+    ['admissionregistration.k8s.io', false],
+    ['', false],
+  ])('isKyvernoApiGroup(%s) should be %s', (apiGroup, expected) => {
+    expect(isKyvernoApiGroup(apiGroup)).toBe(expected)
+  })
+})
+
+describe('isLegacyKyvernoApiGroup', () => {
+  test.each([
+    ['kyverno.io', true],
+    ['policies.kyverno.io', false],
+    ['constraints.gatekeeper.sh', false],
+    ['', false],
+  ])('isLegacyKyvernoApiGroup(%s) should be %s', (apiGroup, expected) => {
+    expect(isLegacyKyvernoApiGroup(apiGroup)).toBe(expected)
+  })
+})
+
+describe('getEngineString for Kyverno API groups', () => {
+  test.each([
+    ['kyverno.io', 'Kyverno'],
+    ['policies.kyverno.io', 'Kyverno'],
+    ['policy.open-cluster-management.io', 'Open Cluster Management'],
+    ['constraints.gatekeeper.sh', 'Gatekeeper'],
+    ['mutations.gatekeeper.sh', 'Gatekeeper'],
+    ['admissionregistration.k8s.io', 'Kubernetes'],
+    ['unknown.api.group', 'Unknown'],
+  ])('getEngineString(%s) should return %s', (apiGroup, expected) => {
+    expect(getEngineString(apiGroup)).toBe(expected)
   })
 })
 

--- a/frontend/src/routes/Governance/common/util.tsx
+++ b/frontend/src/routes/Governance/common/util.tsx
@@ -694,6 +694,14 @@ export function getPolicySource(
   return source
 }
 
+export function isKyvernoApiGroup(apiGroup: string): boolean {
+  return apiGroup === 'kyverno.io' || apiGroup === 'policies.kyverno.io'
+}
+
+export function isLegacyKyvernoApiGroup(apiGroup: string): boolean {
+  return apiGroup === 'kyverno.io'
+}
+
 export function getEngineString(apiGroup: string): string {
   switch (apiGroup) {
     case 'policy.open-cluster-management.io':
@@ -705,6 +713,7 @@ export function getEngineString(apiGroup: string): string {
     case 'admissionregistration.k8s.io':
       return 'Kubernetes'
     case 'kyverno.io':
+    case 'policies.kyverno.io':
       return 'Kyverno'
     default:
       return 'Unknown'

--- a/frontend/src/routes/Governance/discovered/DiscoveredPolicies.test.tsx
+++ b/frontend/src/routes/Governance/discovered/DiscoveredPolicies.test.tsx
@@ -666,7 +666,7 @@ describe('useFetchPolicies custom hook', () => {
 
     expect(
       screen.getByRole('row', {
-        name: /require-owner-labels Kyverno ClusterPolicy - Audit Medium 1 Local/,
+        name: /require-owner-labels Deprecated Kyverno ClusterPolicy - Audit Medium 1 Local/,
       })
     ).toBeInTheDocument()
 

--- a/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
@@ -1,5 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { EmptyState, PageSection, Spinner } from '@patternfly/react-core'
+import { EmptyState, Label, PageSection, Spinner, Split, SplitItem } from '@patternfly/react-core'
+import { ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { isEqual } from 'lodash'
 import { ReactNode, useMemo } from 'react'
 import { generatePath, Link } from 'react-router'
@@ -15,7 +16,7 @@ import {
   IAcmTableColumn,
   ITableFilter,
 } from '../../../ui-components'
-import { getEngineString, getEngineWithSvg } from '../common/util'
+import { getEngineString, getEngineWithSvg, isKyvernoApiGroup, isLegacyKyvernoApiGroup } from '../common/util'
 import { ClusterPolicyViolationIcons2 } from '../components/ClusterPolicyViolations'
 import {
   discoveredSourceCell,
@@ -29,9 +30,9 @@ import {
 } from './details/common'
 import { DiscoveredPolicyTableItem, useFetchPolicies } from './useFetchPolicies'
 
-function nameCell(item: DiscoveredPolicyTableItem): ReactNode {
+function nameCell(item: DiscoveredPolicyTableItem, t: (key: string) => string): ReactNode {
   const destination = NavigationPath.discoveredResources
-  return (
+  const link = (
     <Link
       to={generatePath(destination, {
         kind: item.kind,
@@ -46,6 +47,21 @@ function nameCell(item: DiscoveredPolicyTableItem): ReactNode {
       {item.name}
     </Link>
   )
+
+  if (isLegacyKyvernoApiGroup(item.apigroup)) {
+    return (
+      <Split hasGutter>
+        <SplitItem>{link}</SplitItem>
+        <SplitItem>
+          <Label icon={<ExclamationTriangleIcon />} color="orange" isCompact>
+            {t('deprecated')}
+          </Label>
+        </SplitItem>
+      </Split>
+    )
+  }
+
+  return link
 }
 
 function clusterCell(item: DiscoveredPolicyTableItem): ReactNode | string {
@@ -89,8 +105,7 @@ export default function DiscoveredPolicies() {
     () => [
       {
         header: t('Name'),
-        cell: nameCell,
-        // Policy name
+        cell: (item: DiscoveredPolicyTableItem) => nameCell(item, t),
         sort: 'name',
         search: 'name',
         id: 'name',
@@ -226,6 +241,14 @@ export default function DiscoveredPolicies() {
           { label: 'ValidatingAdmissionPolicyBinding', value: 'ValidatingAdmissionPolicyBinding' },
           { label: 'Kyverno ClusterPolicy', value: 'ClusterPolicy' },
           { label: 'Kyverno Policy', value: 'Policy' },
+          { label: 'Kyverno ValidatingPolicy', value: 'ValidatingPolicy' },
+          { label: 'Kyverno MutatingPolicy', value: 'MutatingPolicy' },
+          { label: 'Kyverno GeneratingPolicy', value: 'GeneratingPolicy' },
+          { label: 'Kyverno ImageValidatingPolicy', value: 'ImageValidatingPolicy' },
+          { label: 'Kyverno NamespacedValidatingPolicy', value: 'NamespacedValidatingPolicy' },
+          { label: 'Kyverno NamespacedMutatingPolicy', value: 'NamespacedMutatingPolicy' },
+          { label: 'Kyverno NamespacedGeneratingPolicy', value: 'NamespacedGeneratingPolicy' },
+          { label: 'Kyverno NamespacedImageValidatingPolicy', value: 'NamespacedImageValidatingPolicy' },
         ],
         tableFilterFn: (selectedValues, item) => {
           if (item.apigroup === 'constraints.gatekeeper.sh') {
@@ -236,13 +259,8 @@ export default function DiscoveredPolicies() {
             return selectedValues.includes('Gatekeeper Mutations')
           }
 
-          if (item.apigroup === 'kyverno.io') {
-            if (selectedValues.includes('ClusterPolicy') && item.kind === 'ClusterPolicy') {
-              return true
-            }
-            if (selectedValues.includes('Policy') && item.kind === 'Policy') {
-              return true
-            }
+          if (isKyvernoApiGroup(item.apigroup)) {
+            return selectedValues.includes(item.kind)
           }
 
           return selectedValues.includes(item.kind)

--- a/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
@@ -1,6 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { EmptyState, Label, PageSection, Spinner, Split, SplitItem } from '@patternfly/react-core'
-import { ExclamationTriangleIcon } from '@patternfly/react-icons'
+import { EmptyState, PageSection, Spinner } from '@patternfly/react-core'
 import { isEqual } from 'lodash'
 import { ReactNode, useMemo } from 'react'
 import { generatePath, Link } from 'react-router'
@@ -17,6 +16,7 @@ import {
   ITableFilter,
 } from '../../../ui-components'
 import { getEngineString, getEngineWithSvg, isKyvernoApiGroup, isLegacyKyvernoApiGroup } from '../common/util'
+import { DeprecatedTitle } from '../../Applications/components/DeprecatedTitle'
 import { ClusterPolicyViolationIcons2 } from '../components/ClusterPolicyViolations'
 import {
   discoveredSourceCell,
@@ -30,7 +30,7 @@ import {
 } from './details/common'
 import { DiscoveredPolicyTableItem, useFetchPolicies } from './useFetchPolicies'
 
-function nameCell(item: DiscoveredPolicyTableItem, t: (key: string) => string): ReactNode {
+function nameCell(item: DiscoveredPolicyTableItem): ReactNode {
   const destination = NavigationPath.discoveredResources
   const link = (
     <Link
@@ -49,16 +49,7 @@ function nameCell(item: DiscoveredPolicyTableItem, t: (key: string) => string): 
   )
 
   if (isLegacyKyvernoApiGroup(item.apigroup)) {
-    return (
-      <Split hasGutter>
-        <SplitItem>{link}</SplitItem>
-        <SplitItem>
-          <Label icon={<ExclamationTriangleIcon />} color="orange" isCompact>
-            {t('deprecated')}
-          </Label>
-        </SplitItem>
-      </Split>
-    )
+    return <DeprecatedTitle title={link} />
   }
 
   return link
@@ -105,7 +96,7 @@ export default function DiscoveredPolicies() {
     () => [
       {
         header: t('Name'),
-        cell: (item: DiscoveredPolicyTableItem) => nameCell(item, t),
+        cell: nameCell,
         sort: 'name',
         search: 'name',
         id: 'name',

--- a/frontend/src/routes/Governance/discovered/details/DiscoveredByCluster.tsx
+++ b/frontend/src/routes/Governance/discovered/details/DiscoveredByCluster.tsx
@@ -20,6 +20,7 @@ import {
   getTotalViolationsCompliance,
   policyViolationSummary,
 } from './common'
+import { isKyvernoApiGroup } from '../../common/util'
 import { getLabelFilterOptions, matchesSelectedLabels } from '../../utils/label-utils'
 import { useMemo } from 'react'
 import { useLocation } from 'react-router'
@@ -62,7 +63,10 @@ export default function DiscoveredByCluster() {
           exportContent: (item: DiscoveredPolicyItem) => convertYesNoCell(item.upgradeAvailable, t),
         },
       ]
-    } else if (apiGroup === 'kyverno.io' && policyKind === 'Policy') {
+    } else if (
+      (apiGroup === 'kyverno.io' && policyKind === 'Policy') ||
+      (apiGroup === 'policies.kyverno.io' && policyKind.startsWith('Namespaced'))
+    ) {
       extraColumns = [
         {
           header: t('Namespace'),
@@ -155,7 +159,7 @@ export default function DiscoveredByCluster() {
               ],
               tableFilterFn: (selectedValues: string[], item: DiscoveredPolicyItem): boolean => {
                 let compliant: string
-                if (['constraints.gatekeeper.sh', 'kyverno.io'].includes(item.apigroup)) {
+                if (item.apigroup === 'constraints.gatekeeper.sh' || isKyvernoApiGroup(item.apigroup)) {
                   compliant = getTotalViolationsCompliance(item?.totalViolations)
                 } else {
                   compliant = item?.compliant?.toLowerCase() ?? ''

--- a/frontend/src/routes/Governance/discovered/details/DiscoveredResources.tsx
+++ b/frontend/src/routes/Governance/discovered/details/DiscoveredResources.tsx
@@ -15,7 +15,7 @@ import { AcmTable, AcmTableStateProvider, compareStrings, IAcmTableColumn } from
 import { DiffModal } from '../../components/DiffModal'
 
 import { fleetResourceRequest } from '../../../../resources/utils/fleet-resource-request'
-import { emptyResources, preserveWhitespace } from '../../common/util'
+import { emptyResources, isKyvernoApiGroup, preserveWhitespace } from '../../common/util'
 import { flexKyvernoMessages } from '../../policies/policy-details/PolicyTemplateDetail/KyvernoTable'
 import { useDiscoveredDetailsContext } from './DiscoveredPolicyDetailsPage'
 
@@ -215,14 +215,14 @@ export function DiscoveredResources() {
 
     if (
       apiGroup === 'policy.open-cluster-management.io' ||
-      apiGroup === 'kyverno.io' ||
+      isKyvernoApiGroup(apiGroup) ||
       apiGroup === 'constraints.gatekeeper.sh'
     ) {
       return {
         header: t('Reason'),
         cell: (item: any) => {
           const tmpl: any =
-            apiGroup === 'kyverno.io' && item.policyReport
+            isKyvernoApiGroup(apiGroup) && item.policyReport
               ? {
                   ...item.policyReport,
                   clusterName: item.policyReport.cluster,
@@ -240,7 +240,7 @@ export function DiscoveredResources() {
           if (foundReasons === undefined) {
             resetReasonCacheForTemplate(tmplKey, tmpl)
           } else if (foundReasons.loading === false) {
-            if (apiGroup === 'kyverno.io' && foundReasons?.kyvernoMessages) {
+            if (isKyvernoApiGroup(apiGroup) && foundReasons?.kyvernoMessages) {
               return flexKyvernoMessages(foundReasons.kyvernoMessages)
             } else if (
               policyKind === 'ConfigurationPolicy' ||

--- a/frontend/src/routes/Governance/discovered/details/common.test.tsx
+++ b/frontend/src/routes/Governance/discovered/details/common.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 import { DiscoveredPolicyItem } from '../useFetchPolicies'
 import {
   convertYesNoCell,
+  getResponseActionFilter,
   getTotalViolationsCompliance,
   DiscoveredViolationsCard,
   policyViolationSummary,
@@ -160,6 +161,126 @@ describe('getTotalViolationsCompliance', () => {
     expect(getTotalViolationsCompliance(0)).toEqual('compliant')
     expect(getTotalViolationsCompliance(1)).toEqual('noncompliant')
     expect(getTotalViolationsCompliance(undefined)).toEqual('-')
+  })
+})
+
+describe('policyViolationSummary with policies.kyverno.io types', () => {
+  test('should count violations for new ValidatingPolicy type via totalViolations', () => {
+    const mockData: DiscoveredPolicyItem[] = [
+      {
+        _hubClusterResource: true,
+        _uid: 'local-cluster/aaa',
+        apigroup: 'policies.kyverno.io',
+        apiversion: 'v1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:00:00Z',
+        kind: 'ValidatingPolicy',
+        kind_plural: 'validatingpolicies',
+        name: 'check-team-label',
+        responseAction: 'Audit',
+        severity: 'low',
+        disabled: false,
+        totalViolations: 3,
+      },
+      {
+        _hubClusterResource: true,
+        _uid: 'local-cluster/bbb',
+        apigroup: 'policies.kyverno.io',
+        apiversion: 'v1',
+        cluster: 'managed1',
+        created: '2026-06-01T10:00:00Z',
+        kind: 'ValidatingPolicy',
+        kind_plural: 'validatingpolicies',
+        name: 'deny-privileged',
+        responseAction: 'Deny',
+        severity: 'critical',
+        disabled: false,
+        totalViolations: 0,
+      },
+    ]
+
+    const summary = policyViolationSummary(mockData)
+    expect(summary.noncompliant).toBe(1)
+    expect(summary.compliant).toBe(1)
+    expect(summary.pending).toBe(0)
+    expect(summary.unknown).toBe(0)
+  })
+
+  test('should deduplicate NamespacedValidatingPolicy by cluster:name', () => {
+    const mockData: DiscoveredPolicyItem[] = [
+      {
+        _hubClusterResource: true,
+        _uid: 'local-cluster/ccc',
+        apigroup: 'policies.kyverno.io',
+        apiversion: 'v1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:00:00Z',
+        kind: 'NamespacedValidatingPolicy',
+        kind_plural: 'namespacedvalidatingpolicies',
+        name: 'require-limits',
+        namespace: 'default',
+        responseAction: 'Audit',
+        severity: 'medium',
+        disabled: false,
+        totalViolations: 1,
+      },
+      {
+        _hubClusterResource: true,
+        _uid: 'local-cluster/ddd',
+        apigroup: 'policies.kyverno.io',
+        apiversion: 'v1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:00:00Z',
+        kind: 'NamespacedValidatingPolicy',
+        kind_plural: 'namespacedvalidatingpolicies',
+        name: 'require-limits',
+        namespace: 'kube-system',
+        responseAction: 'Audit',
+        severity: 'medium',
+        disabled: false,
+        totalViolations: 0,
+      },
+    ]
+
+    const summary = policyViolationSummary(mockData)
+    expect(summary.noncompliant).toBe(1)
+    expect(summary.compliant).toBe(0)
+    expect(summary.pending).toBe(0)
+    expect(summary.unknown).toBe(0)
+  })
+})
+
+describe('getResponseActionFilter with Kyverno Deny', () => {
+  test('should include Kyverno Deny option', () => {
+    const t = i18next.t.bind(i18next)
+    const filter = getResponseActionFilter(t)
+    const denyOption = filter.options.find((o: any) => o.value === 'Deny')
+    expect(denyOption).toBeDefined()
+    expect(denyOption?.label).toBe('Kyverno Deny')
+  })
+
+  test('should match policies.kyverno.io items with Deny filter', () => {
+    const t = i18next.t.bind(i18next)
+    const filter = getResponseActionFilter(t)
+    const item = {
+      apigroup: 'policies.kyverno.io',
+      responseAction: 'Deny',
+    } as any
+
+    expect(filter.tableFilterFn(['Deny'], item)).toBe(true)
+    expect(filter.tableFilterFn(['Audit'], item)).toBe(false)
+  })
+
+  test('should match kyverno.io items with Audit filter', () => {
+    const t = i18next.t.bind(i18next)
+    const filter = getResponseActionFilter(t)
+    const item = {
+      apigroup: 'kyverno.io',
+      responseAction: 'Audit',
+    } as any
+
+    expect(filter.tableFilterFn(['Audit'], item)).toBe(true)
+    expect(filter.tableFilterFn(['Deny'], item)).toBe(false)
   })
 })
 

--- a/frontend/src/routes/Governance/discovered/details/common.tsx
+++ b/frontend/src/routes/Governance/discovered/details/common.tsx
@@ -3,7 +3,7 @@ import { ViolationsCard, ViolationSummary } from '../../overview/PolicyViolation
 import { DiscoveredPolicyItem, DiscoveredPolicyTableItem, ISourceType } from '../useFetchPolicies'
 import { compareStrings, IAcmTableColumn, ITableFilter, AcmLabels } from '../../../../ui-components'
 import { TFunction } from 'react-i18next'
-import { getPolicySource } from '../../common/util'
+import { getPolicySource, isKyvernoApiGroup, isLegacyKyvernoApiGroup } from '../../common/util'
 import { generatePath, Link } from 'react-router'
 import { NavigationPath } from '../../../../NavigationPath'
 import { Channel, HelmRelease, Subscription } from '../../../../resources'
@@ -35,7 +35,10 @@ export const policyViolationSummary = (discoveredPolicyItems: DiscoveredPolicyIt
   for (const policy of discoveredPolicyItems) {
     const compliance = getCompliance(policy)
 
-    if (policy.apigroup === 'kyverno.io' && policy.kind === 'Policy') {
+    const isNamespacedKyverno =
+      (isLegacyKyvernoApiGroup(policy.apigroup) && policy.kind === 'Policy') ||
+      (policy.apigroup === 'policies.kyverno.io' && policy.kind.startsWith('Namespaced'))
+    if (isNamespacedKyverno) {
       addComplianceToKyvernoPolicyViolations(policy, compliance, kyvernoPolicyViolations)
       continue
     }
@@ -85,7 +88,7 @@ const addComplianceToKyvernoPolicyViolations = (
 
 const getCompliance = (policy: DiscoveredPolicyItem) => {
   // Kyverno resources also use the totalViolations field
-  if (['constraints.gatekeeper.sh', 'kyverno.io'].includes(policy.apigroup)) {
+  if (policy.apigroup === 'constraints.gatekeeper.sh' || isKyvernoApiGroup(policy.apigroup)) {
     return getTotalViolationsCompliance(policy?.totalViolations)
   }
   return policy?.compliant?.toLowerCase() ?? ''
@@ -195,7 +198,7 @@ export const byClusterCols = (
           tooltip: t('discoveredPolicies.tooltip.clusterViolation'),
           cell: (item: DiscoveredPolicyItem) => {
             let compliant: string
-            if (['constraints.gatekeeper.sh', 'kyverno.io'].includes(item.apigroup)) {
+            if (item.apigroup === 'constraints.gatekeeper.sh' || isKyvernoApiGroup(item.apigroup)) {
               compliant = getTotalViolationsCompliance(item?.totalViolations)
             } else {
               compliant = item?.compliant?.toLowerCase() ?? ''
@@ -254,7 +257,7 @@ export const byClusterCols = (
           sort: 'compliant',
           id: 'violations',
           exportContent: (item: DiscoveredPolicyItem) => {
-            if (['constraints.gatekeeper.sh', 'kyverno.io'].includes(item.apigroup)) {
+            if (item.apigroup === 'constraints.gatekeeper.sh' || isKyvernoApiGroup(item.apigroup)) {
               const compliant = getTotalViolationsCompliance(item?.totalViolations)
 
               if (compliant === 'noncompliant') {
@@ -398,6 +401,7 @@ export function getResponseActionFilter(t: TFunction): ITableFilter<DiscoveredPo
       { label: 'audit', value: 'audit' },
       { label: 'Kyverno Audit', value: 'Audit' },
       { label: 'Kyverno Enforce', value: 'Enforce' },
+      { label: 'Kyverno Deny', value: 'Deny' },
     ],
     tableFilterFn: (selectedValues, item) => {
       for (const selectedValue of selectedValues) {
@@ -405,11 +409,14 @@ export function getResponseActionFilter(t: TFunction): ITableFilter<DiscoveredPo
           return false
         }
 
-        if (item.apigroup === 'kyverno.io') {
+        if (isKyvernoApiGroup(item.apigroup)) {
           if (selectedValues.includes('Audit') && item.responseAction.includes('Audit')) {
             return true
           }
           if (selectedValues.includes('Enforce') && item.responseAction.includes('Enforce')) {
+            return true
+          }
+          if (selectedValues.includes('Deny') && item.responseAction.includes('Deny')) {
             return true
           }
         }

--- a/frontend/src/routes/Governance/discovered/details/common.tsx
+++ b/frontend/src/routes/Governance/discovered/details/common.tsx
@@ -33,6 +33,8 @@ export const policyViolationSummary = (discoveredPolicyItems: DiscoveredPolicyIt
   const kyvernoPolicyViolations: IKyvernoPolicyViolation = {}
 
   for (const policy of discoveredPolicyItems) {
+    if (policy.disabled) continue
+
     const compliance = getCompliance(policy)
 
     const isNamespacedKyverno =
@@ -43,7 +45,7 @@ export const policyViolationSummary = (discoveredPolicyItems: DiscoveredPolicyIt
       continue
     }
 
-    if (policy.disabled || !compliance) continue
+    if (!compliance) continue
     switch (compliance) {
       case 'compliant':
         compliant++

--- a/frontend/src/routes/Governance/discovered/grouping.test.ts
+++ b/frontend/src/routes/Governance/discovered/grouping.test.ts
@@ -731,6 +731,109 @@ describe('OnMessage test', () => {
     ])
   })
 
+  test('Should create totalViolations for new policies.kyverno.io ValidatingPolicy', () => {
+    const mock = [
+      {
+        _hubClusterResource: 'true',
+        _isExternal: 'false',
+        _uid: 'local-cluster/aaa-bbb-ccc',
+        apigroup: 'policies.kyverno.io',
+        apiversion: 'v1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:00:00Z',
+        kind: 'ValidatingPolicy',
+        kind_plural: 'validatingpolicies',
+        name: 'check-team-label',
+        severity: 'low',
+        validationFailureAction: 'Audit',
+      },
+      {
+        _hubClusterResource: 'true',
+        _isExternal: 'false',
+        _uid: 'local-cluster/ddd-eee-fff',
+        apigroup: 'policies.kyverno.io',
+        apiversion: 'v1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:00:00Z',
+        kind: 'NamespacedValidatingPolicy',
+        kind_plural: 'namespacedvalidatingpolicies',
+        name: 'require-limits',
+        namespace: 'default',
+        severity: 'medium',
+        validationFailureAction: 'Deny',
+      },
+    ]
+
+    const relatedMock: any[] = [
+      {
+        _hubClusterResource: 'true',
+        _relatedUids: ['local-cluster/aaa-bbb-ccc'],
+        _uid: 'local-cluster/report-111',
+        apigroup: 'wgpolicyk8s.io',
+        apiversion: 'v1beta1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:05:00Z',
+        kind: 'ClusterPolicyReport',
+        kind_plural: 'clusterpolicyreports',
+        label: 'app.kubernetes.io/managed-by=kyverno',
+        name: 'report-for-check-team',
+        _policyViolationCounts: 'check-team-label=3',
+        rules: 'check-team-label',
+      },
+      {
+        _hubClusterResource: 'true',
+        _relatedUids: ['local-cluster/ddd-eee-fff'],
+        _uid: 'local-cluster/report-222',
+        apigroup: 'wgpolicyk8s.io',
+        apiversion: 'v1beta1',
+        cluster: 'local-cluster',
+        created: '2026-06-01T10:05:00Z',
+        kind: 'PolicyReport',
+        kind_plural: 'policyreports',
+        label: 'app.kubernetes.io/managed-by=kyverno',
+        name: 'report-for-limits',
+        namespace: 'default',
+        _policyViolationCounts: 'default/require-limits=2',
+        rules: 'default/require-limits',
+      },
+    ]
+
+    const result = createMessage(
+      {
+        searchResult: [
+          {
+            items: mock,
+            related: [
+              { kind: 'ClusterPolicyReport', items: [relatedMock[0]] },
+              { kind: 'PolicyReport', items: [relatedMock[1]] },
+            ],
+          },
+        ],
+      },
+      helmRelease,
+      channels,
+      subscriptions,
+      resolveSource.toString(),
+      getSourceText.toString(),
+      parseStringMap.toString(),
+      parseDiscoveredPolicies.toString()
+    )
+
+    expect(result.policyItems).toHaveLength(2)
+
+    const validatingPolicy = result.policyItems.find((p: any) => p.kind === 'ValidatingPolicy')
+    expect(validatingPolicy).toBeDefined()
+    expect(validatingPolicy.apigroup).toBe('policies.kyverno.io')
+    expect(validatingPolicy.responseAction).toBe('Audit')
+    expect(validatingPolicy.policies[0].totalViolations).toBe(3)
+
+    const namespacedPolicy = result.policyItems.find((p: any) => p.kind === 'NamespacedValidatingPolicy')
+    expect(namespacedPolicy).toBeDefined()
+    expect(namespacedPolicy.apigroup).toBe('policies.kyverno.io')
+    expect(namespacedPolicy.responseAction).toBe('Deny')
+    expect(namespacedPolicy.policies[0].totalViolations).toBe(2)
+  })
+
   test('Should create multiple _policyViolationCounts for kyverno policies', () => {
     const mock = [
       {

--- a/frontend/src/routes/Governance/discovered/grouping.ts
+++ b/frontend/src/routes/Governance/discovered/grouping.ts
@@ -106,6 +106,11 @@ export function grouping(): {
     return (parseStringMap(policy.annotation)['policy.open-cluster-management.io/severity'] ?? '').toLowerCase()
   }
 
+  // Duplicated from common/util — Web Worker cannot import from that module
+  const isKyvernoApiGroup = (apiGroup: string): boolean => {
+    return apiGroup === 'kyverno.io' || apiGroup === 'policies.kyverno.io'
+  }
+
   const getResponseAction = (policy: any): string | null => {
     if (policy?.remediationAction) {
       return policy.remediationAction.toLowerCase()
@@ -122,7 +127,7 @@ export function grouping(): {
           .sort() //NOSONAR
           .join('/')
       }
-    } else if (policy.apigroup === 'kyverno.io') {
+    } else if (isKyvernoApiGroup(policy.apigroup)) {
       return policy.validationFailureAction
     }
 
@@ -169,7 +174,7 @@ export function grouping(): {
             return
           case 'wgpolicyk8s.io:PolicyReport':
           case 'wgpolicyk8s.io:ClusterPolicyReport':
-            if (polInfo?.apigroup === 'kyverno.io') return
+            if (isKyvernoApiGroup(polInfo?.apigroup)) return
             break
           case 'admissionregistration.k8s.io:ValidatingAdmissionPolicy':
             if (polInfo?.apigroup === 'admissionregistration.k8s.io') return
@@ -235,7 +240,7 @@ export function grouping(): {
       const polInfo = result?.items?.[0] // useful for most template information
       templateName = polInfo?.namespace ? polInfo.namespace + '/' + polInfo?.name : polInfo?.name
 
-      if (polInfo?.apigroup === 'kyverno.io') {
+      if (isKyvernoApiGroup(polInfo?.apigroup)) {
         result.related?.forEach((related: any) => {
           if (['PolicyReport', 'ClusterPolicyReport'].includes(related?.kind ?? ''))
             kyvernoPolicyReports = kyvernoPolicyReports.concat(related?.items || [])
@@ -334,7 +339,7 @@ export function grouping(): {
           ),
         }
         // Add violation to kyverno
-        if (policy.apigroup === 'kyverno.io') {
+        if (isKyvernoApiGroup(policy.apigroup)) {
           const nsName = policy.namespace ? policy.namespace + '/' + policy.name : policy.name
           const key = policy.cluster + '/' + nsName
           return {

--- a/frontend/src/routes/Governance/discovered/useFetchPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/useFetchPolicies.tsx
@@ -7,6 +7,7 @@ import { searchClient } from '../../Search/search-sdk/search-client'
 import { SearchInput, useSearchResultItemsAndRelatedItemsQuery } from '../../Search/search-sdk/search-sdk'
 import {
   getSourceText,
+  isKyvernoApiGroup,
   parseDiscoveredPolicies,
   parseDiscoveredPolicyLabels,
   parseStringMap,
@@ -49,7 +50,7 @@ export interface DiscoveredPolicyItem {
   policyName?: string
   _ownedByGatekeeper?: boolean
   validationActions?: string
-  // Kyverno resources: ClusterPolicy, Policy
+  // Kyverno resources: ClusterPolicy, Policy (kyverno.io) and ValidatingPolicy, MutatingPolicy, etc. (policies.kyverno.io)
   validationFailureAction?: string
   _missingResources?: string
   _nonCompliantResources?: string
@@ -83,7 +84,7 @@ export function useFetchPolicies(policyName?: string, policyKind?: string, apiGr
   let searchQuery: SearchInput[]
 
   const discoveredRelatedKinds = (apiGroup: string, kind: string) => {
-    if (apiGroup === 'kyverno.io') {
+    if (isKyvernoApiGroup(apiGroup)) {
       if (policyName) {
         return [] // All resources when the page is specific to one kyverno policy
       } else {
@@ -183,6 +184,29 @@ export function useFetchPolicies(policyName?: string, policyKind?: string, apiGr
           {
             property: 'kind',
             values: ['ClusterPolicy', 'Policy'],
+          },
+        ],
+        relatedKinds: ['ClusterPolicyReport', 'PolicyReport'],
+        limit: 100000,
+      },
+      {
+        filters: [
+          {
+            property: 'apigroup',
+            values: ['policies.kyverno.io'],
+          },
+          {
+            property: 'kind',
+            values: [
+              'ValidatingPolicy',
+              'MutatingPolicy',
+              'GeneratingPolicy',
+              'ImageValidatingPolicy',
+              'NamespacedValidatingPolicy',
+              'NamespacedMutatingPolicy',
+              'NamespacedGeneratingPolicy',
+              'NamespacedImageValidatingPolicy',
+            ],
           },
         ],
         relatedKinds: ['ClusterPolicyReport', 'PolicyReport'],


### PR DESCRIPTION
## Summary

Adds support for the 8 new Kyverno CEL-based policy types (`policies.kyverno.io/v1`) to the Discovered Policies page, alongside the existing legacy types (`kyverno.io/v1`). Legacy types now display a deprecation label.

**Changes:**
- Search queries expanded with 8 new kinds: `ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, `ImageValidatingPolicy`, and their `Namespaced` variants
- Kind filter dropdown includes all new types (prefixed with "Kyverno")
- Deprecation label (orange `ExclamationTriangleIcon`) on legacy `kyverno.io` policy names
- Response action filter adds `Kyverno Deny` option for new types using `validationActions[]`
- Violation summary deduplicates namespaced types by `cluster:name`
- Helper functions: `isKyvernoApiGroup()`, `isLegacyKyvernoApiGroup()`; `getEngineString()` handles `policies.kyverno.io`
- All `apiGroup === 'kyverno.io'` checks updated to `isKyvernoApiGroup()` for both API groups

**Design doc:** [ACM-DDR-074](https://docs.google.com/document/d/1trTlDQcJG_8b88zbhfoDwcx8GHteJfBhzDC19MOk_9U/edit?usp=sharing)

## Test plan

- [x] Verify 8 new Kyverno types appear in the Kind filter dropdown
- [x] Verify legacy `kyverno.io` ClusterPolicy/Policy rows show orange "Deprecated" label
- [x] Verify new `policies.kyverno.io` types do NOT show deprecation label
- [x] Verify violation counts are correct for new types (uses `totalViolations`)
- [x] Verify namespaced types show Namespace column in detail views
- [x] Verify `Kyverno Deny` response action filter works for new types
- [ ] Verify existing Gatekeeper, OPA, and Kubernetes policy types are unaffected
- [x] Unit tests pass (98 total, 23 new)

Signed-off-by: Randy Bruno Piverger <21374229+Randy424@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader Kyverno support: detect legacy and newer Kyverno API groups and update engine labeling; policy compliance/violation counting unified across Kyverno groups.

* **UI/UX Improvements**
  * Show “Deprecated” badge for legacy Kyverno policies; expanded Kind filter options and updated columns; response-action filter now includes Kyverno Deny/Audit/Enforce.

* **Tests**
  * Added coverage for detection, grouping, filtering, and violation aggregation across Kyverno API groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Screenshots:**
New Kyverno types appear in Discovered Policy Table, ClusterPolicy and Policy types now render alongside "Deprecated" tag
<img width="1967" height="919" alt="Screenshot 2026-06-12 at 3 53 14 PM" src="https://github.com/user-attachments/assets/81b36f47-bd89-4c11-a232-f362971697be" />

Table filter supports new types:
<img width="936" height="621" alt="Screenshot 2026-06-12 at 3 53 31 PM" src="https://github.com/user-attachments/assets/354d14df-12e1-42fc-875c-dc8a1a92050c" />

Discovered Policies > Details > Clusters displays namespace for namespaced Kyverno.
<img width="1950" height="815" alt="Screenshot 2026-06-12 at 3 56 40 PM" src="https://github.com/user-attachments/assets/99360901-2489-418c-85f7-e7028eb11271" />


Discovered Policies > Details > Related resources supports "Reason" column for new Kyverno types
<img width="1942" height="934" alt="Screenshot 2026-06-12 at 4 01 24 PM" src="https://github.com/user-attachments/assets/a2e00b99-14e5-4a46-84a5-b81bcdbf65ef" />

Discovered Policies > Details > Clusters new Kyverno filter values for "Response action"
<img width="1962" height="793" alt="Screenshot 2026-06-12 at 4 03 27 PM" src="https://github.com/user-attachments/assets/94225a45-25da-4930-a572-ba297ad09bb9" />
