### PR TITLE
ACM-34280 client purge timeout of 4 hours causes memory waste

### DIFF
--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -16,7 +16,7 @@ import { sizeOf } from '../routes/aggregators/utils'
 
 // If a client hasn't finished receiving a broadcast in PURGE_CLIENT_TIMEOUT
 // assume the browser has been refreshed or closed
-const PURGE_CLIENT_TIMEOUT = 4 * 60 * 60 * 1000
+const PURGE_CLIENT_TIMEOUT = 30 * 60 * 1000
 
 const instanceID = randomString(8)
 


### PR DESCRIPTION
# 📝 Summary
changed to 30 minutes purge

**Ticket Summary (Title):**  
console-mce-console: SSE client purge timeout of 4 hours causes memory waste from orphaned clients


**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-34280

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->