### PR TITLE
WIP ACM-35158 Improve readiness/liveness probe behaviour [release-2.16]

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { startLoggingMemory } from './lib/memory'
 import { notFound, respondInternalServerError, respondOK } from './lib/respond'
 import { startServer, stopServer } from './lib/server'
 import { ServerSideEvents } from './lib/server-side-events'
+import { setReady } from './routes/readiness'
 import { aggregate, startAggregating, stopAggregating } from './routes/aggregator'
 import { ansibleTower } from './routes/ansibletower'
 import { apiPaths } from './routes/apiPaths'
@@ -116,8 +117,13 @@ export async function requestHandler(req: Http2ServerRequest, res: Http2ServerRe
 export async function start() {
   await loadSettings()
   if (eventsEnabled) {
-    startWatching()
-    startAggregating()
+    const watchingReady: Promise<void> = startWatching()
+    const aggregatingReady: Promise<void> = startAggregating()
+    void Promise.all([watchingReady, aggregatingReady]).then(() => {
+      setReady()
+    })
+  } else {
+    setReady()
   }
   return startServer({ requestHandler })
 }

--- a/backend/src/lib/batch-promise-all.ts
+++ b/backend/src/lib/batch-promise-all.ts
@@ -1,0 +1,22 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+/**
+ * Process an array of items through an async mapper in batches, yielding the
+ * event loop between batches to allow HTTP requests (e.g. liveness probes) to
+ * be served.
+ */
+export async function batchPromiseAll<T, R>(
+  items: T[],
+  mapper: (item: T) => Promise<R>,
+  batchSize = 100
+): Promise<R[]> {
+  const results: R[] = []
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = await Promise.all(items.slice(i, i + batchSize).map(mapper))
+    results.push(...batch)
+    if (i + batchSize < items.length) {
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+  return results
+}

--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:http2'
 import type { Transform } from 'node:stream'
 import { clearInterval } from 'node:timers'
 import type { Zlib } from 'node:zlib'
+import { batchPromiseAll } from './batch-promise-all'
 import { getEncodeStream, inflateEvent } from './compression'
 import { setCookie } from './cookies'
 import { logger } from './logger'
@@ -313,7 +314,7 @@ export class ServerSideEvents {
     // uncompress and split events into packets
     const values = Object.values(this.events)
     const compressed = sizeOf(values)
-    let parts = await Promise.all(values.map((event) => inflateEvent(event)))
+    let parts = await batchPromiseAll(values, (event) => inflateEvent(event))
 
     // mock a large environment
     if (process.env.MOCK_CLUSTERS) {

--- a/backend/src/routes/aggregator.ts
+++ b/backend/src/routes/aggregator.ts
@@ -17,8 +17,10 @@ import { requestAggregatedAppSetData } from './aggregators/appSetData'
 import type { IResource } from '../resources/resource'
 import type { IWatchOptions } from '../resources/watch-options'
 
-export function startAggregating(): void {
-  void startAggregatingApplications()
+export function startAggregating(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    void startAggregatingApplications(resolve)
+  })
 }
 
 export function stopAggregating(): void {

--- a/backend/src/routes/aggregators/applications.ts
+++ b/backend/src/routes/aggregators/applications.ts
@@ -194,9 +194,9 @@ export const promiseTimeout = <T>(promise: Promise<T>, delay: number) => {
 // //////////////////////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////////////////////
-export async function startAggregatingApplications() {
+export async function startAggregatingApplications(onFirstPassComplete?: () => void) {
   await discoverSystemAppNamespacePrefixes()
-  void searchLoop()
+  void searchLoop(onFirstPassComplete)
 }
 
 let stopping = false
@@ -351,7 +351,7 @@ export async function addUIData(items: ITransformedResource[]) {
   return items
 }
 
-export async function searchLoop() {
+export async function searchLoop(onFirstPassComplete?: () => void) {
   let pass = 1
   let searchAPIMissing = false
   while (!stopping) {
@@ -370,6 +370,10 @@ export async function searchLoop() {
         if (!searchAPIMissing) {
           logger.error('search API missing')
           searchAPIMissing = true
+          if (onFirstPassComplete) {
+            onFirstPassComplete()
+            onFirstPassComplete = undefined
+          }
         }
         await new Promise((r) => setTimeout(r, 5 * 60 * 1000))
       }
@@ -390,6 +394,11 @@ export async function searchLoop() {
     }
     pass++
     logApplicationCountChanges(applicationCache, pass)
+
+    if (onFirstPassComplete) {
+      onFirstPassComplete()
+      onFirstPassComplete = undefined
+    }
 
     // process every APP_SEARCH_INTERVAL seconds
     /* istanbul ignore if */

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -6,6 +6,7 @@ import { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import pluralize from 'pluralize'
 import { pipeline } from 'node:stream/promises'
 import { Transform } from 'node:stream'
+import { batchPromiseAll } from '../lib/batch-promise-all'
 import { createDictionary, deflateResource, inflateResource } from '../lib/compression'
 import { jsonPost } from '../lib/json-request'
 import { logger } from '../lib/logger'
@@ -41,10 +42,9 @@ let requests: { cancel: () => void }[] = []
 export async function getKubeResources(kind: string, apiVersion: string) {
   const option = { apiVersion, kind }
   const apiVersionPlural = apiVersionPluralFn(option)
-  return await Promise.all(
-    Object.values(resourceCache[apiVersionPlural] || {}).map((event) => {
-      return event.compressed.then((compressed) => inflateResource(compressed, eventDict))
-    })
+  const entries = Object.values(resourceCache[apiVersionPlural] || {})
+  return batchPromiseAll(entries, (event) =>
+    event.compressed.then((compressed) => inflateResource(compressed, eventDict))
   )
 }
 
@@ -437,7 +437,7 @@ async function listKubernetesObjects(serviceAccountToken: string, options: IWatc
     return { size: itemCount }
   }
 
-  await Promise.all(items.map((item) => cacheResource(item)))
+  await batchPromiseAll(items, (item) => cacheResource(item))
 
   // Remove items that are no longer in kubernetes
   const apiVersionPlural = apiVersionPluralFn(options)
@@ -458,7 +458,7 @@ async function listKubernetesObjects(serviceAccountToken: string, options: IWatc
       removeResources.push(resource)
     }
   }
-  await Promise.all(removeResources.map((resource) => deleteResource(resource)))
+  await batchPromiseAll(removeResources, (resource) => deleteResource(resource))
 
   return { resourceVersion, size: items.length }
 }

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -18,6 +18,14 @@ import type { IWatchOptions } from '../resources/watch-options'
 import { polledAggregation } from './aggregator'
 import { getAppDict, type ICompressedResource, type ITransformedResource } from './aggregators/applications'
 
+function createDeferredSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
 export async function events(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
   const token = await getAuthenticatedToken(req, res)
   if (token) {
@@ -336,26 +344,42 @@ const definitions: IWatchOptions[] = [
   },
 ]
 
-export function startWatching(): void {
+export function startWatching(): Promise<void> {
   ServerSideEvents.eventFilter = eventFilter
   startAccessCacheCleanup()
 
+  const listPromises: Promise<void>[] = []
   for (const definition of definitions) {
-    void listAndWatch(definition)
+    const { promise, resolve } = createDeferredSignal()
+    listPromises.push(promise)
+    void listAndWatch(definition, resolve)
   }
+  return Promise.all(listPromises).then(() => {
+    logger.info('all initial resource lists complete')
+  })
 }
+
 // https://kubernetes.io/docs/reference/using-api/api-concepts/
-export async function listAndWatch(options: IWatchOptions) {
+export async function listAndWatch(options: IWatchOptions, onFirstListComplete?: () => void) {
   const serviceAccountToken = getServiceAccountToken()
+  let firstListDone = false
   while (!stopping) {
     try {
       const { resourceVersion } = await listKubernetesObjects(serviceAccountToken, options)
+      if (!firstListDone) {
+        firstListDone = true
+        onFirstListComplete?.()
+      }
       if (options.isPolled) {
         await pollKubernetesObjects(serviceAccountToken, options)
       } else {
         await watchKubernetesObjects(serviceAccountToken, options, resourceVersion)
       }
     } catch (err: unknown) {
+      if (!firstListDone) {
+        firstListDone = true
+        onFirstListComplete?.()
+      }
       if (err instanceof SyntaxError) {
         // Happens when the response body is not JSON
         // Such as the case when the resource version if too old

--- a/backend/src/routes/readiness.ts
+++ b/backend/src/routes/readiness.ts
@@ -1,8 +1,22 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
-import { liveness } from './liveness'
+import { logger } from '../lib/logger'
+import { respondInternalServerError, respondOK } from '../lib/respond'
+
+let isReady = false
 
 // The kubelet uses readiness probes to know when a container is ready to start accepting traffic
 export function readiness(req: Http2ServerRequest, res: Http2ServerResponse): void {
-  liveness(req, res)
+  if (!isReady) {
+    respondInternalServerError(req, res)
+  } else {
+    respondOK(req, res)
+  }
+}
+
+export function setReady(): void {
+  if (!isReady) {
+    logger.info('readiness set to true - initial loading complete')
+    isReady = true
+  }
 }

--- a/backend/test/lib/batch-promise-all.test.ts
+++ b/backend/test/lib/batch-promise-all.test.ts
@@ -1,0 +1,93 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { batchPromiseAll } from '../../src/lib/batch-promise-all'
+
+describe('batchPromiseAll', () => {
+  it('should process all items and return results in order', async () => {
+    const items = [1, 2, 3, 4, 5]
+    const results = await batchPromiseAll(items, (n) => Promise.resolve(n * 2))
+    expect(results).toEqual([2, 4, 6, 8, 10])
+  })
+
+  it('should handle empty arrays', async () => {
+    const results = await batchPromiseAll([], (n: number) => Promise.resolve(n))
+    expect(results).toEqual([])
+  })
+
+  it('should process items in batches of the specified size', async () => {
+    const batchesProcessed: number[][] = []
+    const items = [1, 2, 3, 4, 5, 6, 7]
+
+    await batchPromiseAll(
+      items,
+      (n) => {
+        if (batchesProcessed.length === 0 || batchesProcessed[batchesProcessed.length - 1].length >= 3) {
+          batchesProcessed.push([])
+        }
+        batchesProcessed[batchesProcessed.length - 1].push(n)
+        return Promise.resolve(n)
+      },
+      3
+    )
+
+    expect(batchesProcessed).toEqual([[1, 2, 3], [4, 5, 6], [7]])
+  })
+
+  it('should yield the event loop between batches', async () => {
+    let yielded = false
+    const items = [1, 2, 3, 4]
+
+    const originalSetImmediate = global.setImmediate
+    global.setImmediate = ((fn: () => void) => {
+      yielded = true
+      return originalSetImmediate(fn)
+    }) as typeof setImmediate
+
+    await batchPromiseAll(items, (n) => Promise.resolve(n), 2)
+
+    global.setImmediate = originalSetImmediate
+    expect(yielded).toBe(true)
+  })
+
+  it('should not yield after the last batch', async () => {
+    let yieldCount = 0
+    const items = [1, 2, 3]
+
+    const originalSetImmediate = global.setImmediate
+    global.setImmediate = ((fn: () => void) => {
+      yieldCount++
+      return originalSetImmediate(fn)
+    }) as typeof setImmediate
+
+    await batchPromiseAll(items, (n) => Promise.resolve(n), 3)
+
+    global.setImmediate = originalSetImmediate
+    expect(yieldCount).toBe(0)
+  })
+
+  it('should use default batch size of 100', async () => {
+    const items = Array.from({ length: 250 }, (_, i) => i)
+    let batchCount = 0
+    let currentBatchSize = 0
+
+    await batchPromiseAll(items, (n) => {
+      currentBatchSize++
+      if (currentBatchSize === 100) {
+        batchCount++
+        currentBatchSize = 0
+      }
+      return Promise.resolve(n)
+    })
+
+    expect(batchCount).toBe(2)
+  })
+
+  it('should propagate errors from the mapper', async () => {
+    const items = [1, 2, 3]
+    await expect(
+      batchPromiseAll(items, (n) => {
+        if (n === 2) return Promise.reject(new Error('test error'))
+        return Promise.resolve(n)
+      })
+    ).rejects.toThrow('test error')
+  })
+})

--- a/backend/test/routes/readiness.test.ts
+++ b/backend/test/routes/readiness.test.ts
@@ -1,17 +1,15 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { request } from '../mock-request'
-import nock from 'nock'
-import { apiServerPing } from '../../src/routes/liveness'
+import { setReady } from '../../src/routes/readiness'
 
 describe(`readiness Route`, function () {
-  it(`GET /readinessProbe should return status code 200`, async function () {
-    const res = await request('GET', '/readinessProbe')
-    expect(res.statusCode).toEqual(200)
-  })
-  it(`GET /readinessProbe should return status code 500 if dead`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
-    await apiServerPing()
+  it(`GET /readinessProbe should return status code 500 if not ready`, async function () {
     const res = await request('GET', '/readinessProbe')
     expect(res.statusCode).toEqual(500)
+  })
+  it(`GET /readinessProbe should return status code 200 after setReady`, async function () {
+    setReady()
+    const res = await request('GET', '/readinessProbe')
+    expect(res.statusCode).toEqual(200)
   })
 })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
console-mce pod CrashLoopBackOff due to probe failure with large resource sets

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-35158

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Customer was observing CrashLoopBackoff on console-mce pods and had over 20,000 Group resources present. Initially processing these resources may have blocked us from responding to the readiness and liveness probes on time, causing Kubernetes to restart the pod.

This PR batches Promise.all calls so that we call setImmediate after each batch of 100 to yield the event queue so that new requests can be handled. This seems to smooth out memory usage of the pods. Before this change, I observed a spike at startup, then a retreat to stable size.

This PR also separates the liveness and readiness probes so that we can delay marking the pod as ready for traffic until after initial loading of the watched resources and aggregated application resources has completed.