### PR TITLE
Add Azure HCP cluster creation UI

### DIFF
--- a/frontend/src/NavigationPath.tsx
+++ b/frontend/src/NavigationPath.tsx
@@ -84,6 +84,8 @@ export enum NavigationPath {
   createDiscoverHost = '/multicloud/infrastructure/clusters/create/discover-host',
   createCluster = '/multicloud/infrastructure/clusters/create',
   createAWSCLI = '/multicloud/infrastructure/clusters/create/aws/cli',
+  createAzureControlPlane = '/multicloud/infrastructure/clusters/create/azure/control-plane',
+  createAzureCLI = '/multicloud/infrastructure/clusters/create/azure/cli',
   createKubeVirt = '/multicloud/infrastructure/clusters/create/kubevirt',
   editCluster = '/multicloud/infrastructure/clusters/edit/:namespace/:name',
   clusterDetails = '/multicloud/infrastructure/clusters/details/:namespace/:name',

--- a/frontend/src/lib/doc-util.tsx
+++ b/frontend/src/lib/doc-util.tsx
@@ -68,6 +68,7 @@ export const DOC_LINKS = {
   HYPERSHIFT_STS_ARN: `${OCP_DOC_BASE_PATH}/hosted_control_planes/hosted-control-planes-overview#hcp-aws-create-role-sts-creds_hcp-deploy-aws`,
   HYPERSHIFT_MANAGE_KUBEVIRT: `${OCP_DOC_BASE_PATH}/hosted_control_planes/hosted-control-planes-overview#deploying-hosted-control-planes-on-openshift-virtualization`,
   HOSTED_ENABLE_FEATURE_AWS: `${OCP_DOC_BASE_PATH}/hosted_control_planes/hosted-control-planes-overview#hcp-enable-manual_hcp-enable-disable`,
+  HYPERSHIFT_DEPLOY_AZURE: `${OCP_DOC_BASE_PATH}/hosted_control_planes/hosted-control-planes-overview#deploying-hosted-control-planes-on-azure`,
   HYPERSHIFT_OIDC: `${OCP_DOC_BASE_PATH}/hosted_control_planes/hosted-control-planes-overview#hcp-aws-prereqs_hcp-deploy-aws`,
   IDENTITY_PROVIDER_CONFIGURATION: `${OCP_DOC_BASE_PATH}/authentication_and_authorization/understanding-identity-provider#understanding-identity-provider`,
   // Virtualization

--- a/frontend/src/routes/Infrastructure/Clusters/Clusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/Clusters.tsx
@@ -9,7 +9,9 @@ import DiscoveryConfigPage from './DiscoveredClusters/DiscoveryConfig/DiscoveryC
 import ClusterDetailsPage from './ManagedClusters/ClusterDetails/ClusterDetails'
 import EditAICluster from './ManagedClusters/components/cim/EditAICluster'
 import { HypershiftAWSCLI } from './ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAWSCLI'
+import { HypershiftAzureCLI } from './ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAzureCLI'
 import { CreateAWSControlPlane } from './ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane'
+import { CreateAzureControlPlane } from './ManagedClusters/CreateClusterCatalog/CreateAzureControlPlane'
 import { CreateControlPlane } from './ManagedClusters/CreateClusterCatalog/CreateControlPlane'
 import { CreateDiscoverHost } from './ManagedClusters/CreateClusterCatalog/CreateDiscoverHost'
 import { CreateKubeVirtControlPlane } from './ManagedClusters/CreateClusterCatalog/CreateKubeVirtControlPlane'
@@ -51,6 +53,8 @@ export default function Clusters() {
         element={<CreateKubeVirtControlPlane />}
       />
       <Route path={clustersChildPath(NavigationPath.createAWSCLI)} element={<HypershiftAWSCLI />} />
+      <Route path={clustersChildPath(NavigationPath.createAzureControlPlane)} element={<CreateAzureControlPlane />} />
+      <Route path={clustersChildPath(NavigationPath.createAzureCLI)} element={<HypershiftAzureCLI />} />
       <Route path={clustersChildPath(NavigationPath.createDiscoverHost)} element={<CreateDiscoverHost />} />
       <Route path={clustersChildPath(NavigationPath.createCluster)} element={<CreateClusterPage />} />
       <Route path={clustersChildPath(NavigationPath.importCluster)} element={<ImportClusterPage />} />

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -156,6 +156,7 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
   const controlPlaneBreadCrumbBM = generateBreadCrumb('Host Inventory', NavigationPath.createBMControlPlane)
   const controlPlaneBreadCrumbNutanix = generateBreadCrumb('Nutanix', NavigationPath.createCluster)
   const controlPlaneBreadCrumbAWS = generateBreadCrumb('AWS', NavigationPath.createAWSControlPlane)
+  const controlPlaneBreadCrumbAzure = generateBreadCrumb('Azure', NavigationPath.createAzureControlPlane)
 
   const hostsBreadCrumb = { text: t('Hosts'), to: NavigationPath.createDiscoverHost }
 
@@ -551,6 +552,7 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
       )
       break
     case Provider.azure:
+      breadcrumbs.push(controlPlaneBreadCrumbAzure)
       controlData = getControlDataAZR(
         t,
         handleModalToggle,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAzureCLI.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAzureCLI.test.tsx
@@ -1,0 +1,41 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { RecoilRoot } from 'recoil'
+import { nockGet, nockIgnoreApiPaths } from '../../../../../../../../lib/nock-util'
+import { mockOpenShiftConsoleConfigMap } from '../../../../../../../../lib/test-metadata'
+import { waitForNocks, waitForTestId, waitForText } from '../../../../../../../../lib/test-util'
+import { NavigationPath } from '../../../../../../../../NavigationPath'
+import { HypershiftAzureCLI } from './HypershiftAzureCLI'
+
+describe('HypershiftAzureCLI', () => {
+  const Component = () => {
+    return (
+      <RecoilRoot>
+        <MemoryRouter initialEntries={[NavigationPath.createAzureCLI]}>
+          <Routes>
+            <Route path={NavigationPath.createAzureCLI} element={<HypershiftAzureCLI />} />
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+  }
+
+  test('should show all the steps', async () => {
+    nockIgnoreApiPaths()
+    const initialNocks = [nockGet(mockOpenShiftConsoleConfigMap)]
+    render(<Component />)
+    await waitForNocks(initialNocks)
+    await waitForText('Prerequisites and Configuration')
+    await waitForText('Prepare environment variables')
+    await waitForText('Create Azure credentials file')
+    await waitForText('Configure OIDC issuer')
+    await waitForText('Create workload identities')
+    await waitForText('Create Azure infrastructure')
+    await waitForText('Create the Hosted Control Plane')
+    // find code blocks
+    await waitForTestId('code-content')
+    await waitForTestId('helper-command')
+    await waitForText('Copy login command')
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAzureCLI.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAzureCLI.tsx
@@ -1,0 +1,225 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { CodeBlock, CodeBlockCode, Content, ContentVariants } from '@patternfly/react-core'
+import { ICatalogBreadcrumb } from '@stolostron/react-data-view'
+import { Fragment } from 'react'
+import { useTranslation } from '../../../../../../../../lib/acm-i18next'
+import { DOC_LINKS, ViewDocumentationLink } from '../../../../../../../../lib/doc-util'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../../../../NavigationPath'
+import { Actions, GetOCLogInCommand } from './common/common'
+import DocPage from './common/DocPage'
+
+export function HypershiftAzureCLI() {
+  const { t } = useTranslation()
+  const { back, cancel } = useBackCancelNavigation()
+  const breadcrumbs: ICatalogBreadcrumb[] = [
+    { label: t('Clusters'), to: NavigationPath.clusters },
+    { label: t('Infrastructure'), to: NavigationPath.createCluster },
+    { label: t('Control plane type - {{hcType}}', { hcType: 'Azure' }), to: NavigationPath.createAzureControlPlane },
+    { label: t('Create cluster') },
+  ]
+
+  const envVarsCode = `# Set environment variables
+export CLUSTER_NAME="my-azure-hcp"
+export CLUSTER_NAMESPACE="clusters"
+export LOCATION="centralus"
+export BASE_DOMAIN="example.azure.devcluster.openshift.com"
+export RESOURCE_GROUP_NAME="my-resource-group"
+export DNS_ZONE_RG_NAME="my-dns-zone-rg"
+export AZURE_CREDS="./azure-creds.json"
+export PULL_SECRET="/path/to/pull-secret.json"
+export INFRA_ID="$(oc get infrastructures cluster -o jsonpath='{.status.infrastructureName}')"
+export WORKLOAD_IDENTITIES_FILE="./workload-identities.json"
+export INFRA_OUTPUT_FILE="./infra-output.json"`
+
+  const azureCredsCode = `# Create azure-creds.json with your Azure service principal credentials
+{
+  "subscriptionId": "your-subscription-id",
+  "tenantId": "your-tenant-id",
+  "clientId": "your-client-id",
+  "clientSecret": "your-client-secret"
+}`
+
+  const oidcCode = `export SUBSCRIPTION_ID="$(jq -r '.subscriptionId' "\${AZURE_CREDS}")"
+export TENANT_ID="$(jq -r '.tenantId' "\${AZURE_CREDS}")"
+export OIDC_STORAGE_ACCOUNT_NAME="youroidcstorageacct"
+
+# Ensure cluster resource group exists
+az group create --name "\${RESOURCE_GROUP_NAME}" --location "\${LOCATION}"
+
+# Create signing key pair
+ccoctl azure create-key-pair
+export SA_TOKEN_ISSUER_PRIVATE_KEY_PATH="./serviceaccount-signer.private"
+export SA_TOKEN_ISSUER_PUBLIC_KEY_PATH="./serviceaccount-signer.public"
+
+# Create OIDC issuer resources
+ccoctl azure create-oidc-issuer \\
+  --oidc-resource-group-name "\${RESOURCE_GROUP_NAME}" \\
+  --tenant-id "\${TENANT_ID}" \\
+  --region "\${LOCATION}" \\
+  --name "\${OIDC_STORAGE_ACCOUNT_NAME}" \\
+  --subscription-id "\${SUBSCRIPTION_ID}" \\
+  --public-key-file "\${SA_TOKEN_ISSUER_PUBLIC_KEY_PATH}"
+
+export OIDC_ISSUER_URL="https://\${OIDC_STORAGE_ACCOUNT_NAME}.blob.core.windows.net/\${OIDC_STORAGE_ACCOUNT_NAME}"`
+
+  const workloadIdentitiesCode = `hcp create iam azure \\
+  --name "\${CLUSTER_NAME}" \\
+  --infra-id "\${INFRA_ID}" \\
+  --azure-creds "\${AZURE_CREDS}" \\
+  --location "\${LOCATION}" \\
+  --resource-group-name "\${RESOURCE_GROUP_NAME}" \\
+  --oidc-issuer-url "\${OIDC_ISSUER_URL}" \\
+  --output-file "\${WORKLOAD_IDENTITIES_FILE}"`
+
+  const infraCode = `hcp create infra azure \\
+  --name "\${CLUSTER_NAME}" \\
+  --infra-id "\${INFRA_ID}" \\
+  --azure-creds "\${AZURE_CREDS}" \\
+  --base-domain "\${BASE_DOMAIN}" \\
+  --location "\${LOCATION}" \\
+  --workload-identities-file "\${WORKLOAD_IDENTITIES_FILE}" \\
+  --output-file "\${INFRA_OUTPUT_FILE}"`
+
+  const createClusterCode = `export DNS_ZONE_NAME="external-dns.\${BASE_DOMAIN}"
+export INFRA_ID_FROM_FILE="$(yq -p yaml -r '.infraID' "\${INFRA_OUTPUT_FILE}")"
+
+hcp create cluster azure \\
+  --name "\${CLUSTER_NAME}" \\
+  --namespace "\${CLUSTER_NAMESPACE}" \\
+  --azure-creds "\${AZURE_CREDS}" \\
+  --location "\${LOCATION}" \\
+  --node-pool-replicas 2 \\
+  --base-domain "\${BASE_DOMAIN}" \\
+  --pull-secret "\${PULL_SECRET}" \\
+  --generate-ssh \\
+  --external-dns-domain "\${DNS_ZONE_NAME}" \\
+  --infra-json "\${INFRA_OUTPUT_FILE}" \\
+  --infra-id "\${INFRA_ID_FROM_FILE}" \\
+  --sa-token-issuer-private-key-path "\${SA_TOKEN_ISSUER_PRIVATE_KEY_PATH}" \\
+  --oidc-issuer-url "\${OIDC_ISSUER_URL}" \\
+  --dns-zone-rg-name "\${DNS_ZONE_RG_NAME}" \\
+  --auto-assign-roles \\
+  --workload-identities-file "\${WORKLOAD_IDENTITIES_FILE}" \\
+  --diagnostics-storage-account-type Managed`
+
+  const helperCommand = `hcp create cluster azure --help`
+
+  const listItems = [
+    {
+      title: t('Prerequisites and Configuration'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.p}>
+            {t(
+              'Install the Hosted Control Plane CLI (hcp), oc, az, and ccoctl. Authenticate with Azure (az login) and OpenShift (oc login).'
+            )}
+          </Content>
+          <Content component={ContentVariants.a} href={DOC_LINKS.HYPERSHIFT_DEPLOY_AZURE} target="_blank">
+            {t('Follow documentation for more information.')}
+          </Content>
+        </Fragment>
+      ),
+    },
+    {
+      title: t('Prepare environment variables'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.p}>
+            {t('Set the required environment variables for the Azure Hosted Control Plane cluster creation.')}
+          </Content>
+          <CodeBlock actions={Actions(envVarsCode, 'env-vars-command')}>
+            <CodeBlockCode id="env-vars-content">{envVarsCode}</CodeBlockCode>
+          </CodeBlock>
+        </Fragment>
+      ),
+    },
+    {
+      title: t('Create Azure credentials file'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.p}>
+            {t('Create an azure-creds.json file with your Azure service principal credentials.')}
+          </Content>
+          <CodeBlock actions={Actions(azureCredsCode, 'azure-creds-command')}>
+            <CodeBlockCode id="azure-creds-content">{azureCredsCode}</CodeBlockCode>
+          </CodeBlock>
+        </Fragment>
+      ),
+    },
+    {
+      title: t('Configure OIDC issuer'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.p}>
+            {t(
+              'Configure the OIDC issuer for workload identity. This creates a storage account and signing key pair for token authentication.'
+            )}
+          </Content>
+          <CodeBlock actions={Actions(oidcCode, 'oidc-command')}>
+            <CodeBlockCode id="oidc-content">{oidcCode}</CodeBlockCode>
+          </CodeBlock>
+        </Fragment>
+      ),
+    },
+    {
+      title: t('Create workload identities'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.p}>
+            {t('Create the Azure workload identities required for the Hosted Control Plane.')}
+          </Content>
+          <CodeBlock actions={Actions(workloadIdentitiesCode, 'workload-identities-command')}>
+            <CodeBlockCode id="workload-identities-content">{workloadIdentitiesCode}</CodeBlockCode>
+          </CodeBlock>
+        </Fragment>
+      ),
+    },
+    {
+      title: t('Create Azure infrastructure'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.p}>
+            {t('Create the Azure infrastructure resources required for the Hosted Control Plane.')}
+          </Content>
+          <CodeBlock actions={Actions(infraCode, 'infra-command')}>
+            <CodeBlockCode id="infra-content">{infraCode}</CodeBlockCode>
+          </CodeBlock>
+        </Fragment>
+      ),
+    },
+    {
+      title: t('Create the Hosted Control Plane'),
+      content: (
+        <Fragment>
+          <Content component={ContentVariants.h4}>{t('Log in to OpenShift Container Platform')}</Content>
+          {GetOCLogInCommand()}
+          <Content component={ContentVariants.h4}>{t('Run command')}</Content>
+          <Content component={ContentVariants.p}>
+            {t('Create the Hosted Control Plane by copying and pasting the following command:')}
+          </Content>
+          <CodeBlock actions={Actions(createClusterCode, 'code-command')}>
+            <CodeBlockCode id="code-content">{createClusterCode}</CodeBlockCode>
+          </CodeBlock>
+          <Content component="p" style={{ marginTop: '1em' }}>
+            {t('Use the following command to get a list of available parameters: ')}
+          </Content>
+          <CodeBlock actions={Actions(helperCommand, 'helper-command')}>
+            <CodeBlockCode id="helper-command">{helperCommand}</CodeBlockCode>
+          </CodeBlock>
+          <ViewDocumentationLink doclink={DOC_LINKS.HYPERSHIFT_DEPLOY_AZURE} />
+        </Fragment>
+      ),
+    },
+  ]
+
+  return (
+    <DocPage
+      listItems={listItems}
+      breadcrumbs={breadcrumbs}
+      onBack={back(NavigationPath.createAzureControlPlane)}
+      onCancel={cancel(NavigationPath.managedClusters)}
+      docLink={DOC_LINKS.HYPERSHIFT_DEPLOY_AZURE}
+    />
+  )
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/common/DocPage.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/common/DocPage.tsx
@@ -16,9 +16,10 @@ type DocPageProps = {
   onCancel?: () => void
   onBack?: () => void
   noMargin?: boolean
+  docLink?: string
 }
 
-const DocPage: React.FC<DocPageProps> = ({ listItems, breadcrumbs, onCancel, onBack, noMargin }) => {
+const DocPage: React.FC<DocPageProps> = ({ listItems, breadcrumbs, onCancel, onBack, noMargin, docLink }) => {
   const { t } = useTranslation()
   return (
     <>
@@ -30,7 +31,7 @@ const DocPage: React.FC<DocPageProps> = ({ listItems, breadcrumbs, onCancel, onB
             <>
               {t('page.header.create-cluster.tooltip')}
               <a
-                href={DOC_LINKS.HYPERSHIFT_DEPLOY_AWS}
+                href={docLink ?? DOC_LINKS.HYPERSHIFT_DEPLOY_AWS}
                 target="_blank"
                 rel="noreferrer"
                 style={{ display: 'block', marginTop: '4px' }}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAzureControlPlane.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAzureControlPlane.test.tsx
@@ -1,0 +1,68 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { RecoilRoot } from 'recoil'
+import { clickByTestId, isCardEnabled, waitForNocks } from '../../../../../lib/test-util'
+import { NavigationPath } from '../../../../../NavigationPath'
+import { CreateAzureControlPlane } from './CreateAzureControlPlane'
+import { nockIgnoreApiPaths } from '../../../../../lib/nock-util'
+import { nockHypershiftStatus } from '../../../../../lib/nock-hypershift-status'
+import { managedClusterAddonsState, multiClusterEnginesState } from '../../../../../atoms'
+import {
+  mockManagedClusterAddOn,
+  mockMultiClusterEngine,
+  mockMultiClusterEngineWithHypershiftDisabled,
+} from './sharedMocks'
+
+describe('CreateAzureControlPlane', () => {
+  beforeEach(() => {
+    nockIgnoreApiPaths()
+  })
+
+  const Component = ({ enableHypershift = true }: { enableHypershift?: boolean }) => {
+    return (
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, mockManagedClusterAddOn)
+          snapshot.set(multiClusterEnginesState, [
+            enableHypershift ? mockMultiClusterEngine : mockMultiClusterEngineWithHypershiftDisabled,
+          ])
+        }}
+      >
+        <MemoryRouter initialEntries={[NavigationPath.createAzureControlPlane]}>
+          <Routes>
+            <Route path={NavigationPath.createAzureControlPlane} element={<CreateAzureControlPlane />} />
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+  }
+
+  test('Hosted should be enabled when hypershift is enabled', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(true)
+
+    const { getByTestId } = render(<Component />)
+    await waitForNocks([hypershiftStatusNock])
+
+    expect(isCardEnabled(getByTestId('hosted'))).toBe(true)
+  })
+
+  test('Hosted should be disabled when hypershift is disabled', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(false)
+
+    const { getByTestId } = render(<Component enableHypershift={false} />)
+    await waitForNocks([hypershiftStatusNock])
+
+    expect(isCardEnabled(getByTestId('hosted'))).toBe(false)
+    await clickByTestId('hosted')
+  })
+
+  test('can click standalone', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(true)
+
+    render(<Component />)
+    await waitForNocks([hypershiftStatusNock])
+
+    await clickByTestId('standalone')
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAzureControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAzureControlPlane.tsx
@@ -1,0 +1,163 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { CheckIcon, ExternalLinkAltIcon } from '@patternfly/react-icons'
+import {
+  CatalogCardItemType,
+  CatalogColor,
+  DataViewStringContext,
+  ICatalogCard,
+  ItemView,
+} from '@stolostron/react-data-view'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from '../../../../../lib/acm-i18next'
+import { useDataViewStrings } from '../../../../../lib/dataViewStrings'
+import { DOC_LINKS } from '../../../../../lib/doc-util'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
+import { AcmPage, AcmPageHeader, Provider } from '../../../../../ui-components'
+import { getTypedCreateClusterPath } from '../ClusterInfrastructureType'
+import { useIsHypershiftEnabled } from '../../../../../hooks/use-hypershift-enabled'
+import { HypershiftDiagramExpand } from './common/HypershiftDiagramExpand'
+import { Icon } from '@patternfly/react-core'
+
+export function CreateAzureControlPlane() {
+  const [t] = useTranslation()
+  const { nextStep, back, cancel } = useBackCancelNavigation()
+  const [isDiagramExpanded, setIsDiagramExpanded] = useState(true)
+  const [isMouseOverControlPlaneLink, setIsMouseOverControlPlaneLink] = useState(false)
+  const [isHypershiftEnabled, loaded] = useIsHypershiftEnabled()
+
+  const onDiagramToggle = (isExpanded: boolean) => {
+    if (!isMouseOverControlPlaneLink) {
+      setIsDiagramExpanded(isExpanded)
+    }
+  }
+  const cards = useMemo(() => {
+    const newCards: ICatalogCard[] = [
+      {
+        id: 'hosted',
+        title: t('Hosted'),
+        items: [
+          {
+            type: CatalogCardItemType.Description,
+            description: t(
+              'Run an OpenShift cluster where the control plane is decoupled from the data plane, and is treated like a multi-tenant workload on a hosting service cluster. The data plane is on a separate network domain that allows segmentation between management and workload traffic.'
+            ),
+          },
+          {
+            type: CatalogCardItemType.List,
+            title: t(''),
+            icon: (
+              <Icon status="success">
+                <CheckIcon />
+              </Icon>
+            ),
+            items: [
+              {
+                text: t('Reduces costs by efficiently reusing an OpenShift cluster to host multiple control planes.'),
+              },
+              { text: t('Quickly provisions clusters.') },
+            ],
+          },
+        ],
+        onClick: isHypershiftEnabled ? nextStep(NavigationPath.createAzureCLI) : undefined,
+        alertTitle: (() => {
+          if (!loaded || isHypershiftEnabled) return undefined
+          return t('Hosted control plane operator must be enabled in order to continue')
+        })(),
+        alertVariant: 'info',
+        alertContent: (() => {
+          if (!loaded || isHypershiftEnabled) return undefined
+          return (
+            <a href={DOC_LINKS.HOSTED_ENABLE_FEATURE_AWS} target="_blank" rel="noopener noreferrer">
+              {t('View documentation')} <ExternalLinkAltIcon />
+            </a>
+          )
+        })(),
+        badgeList: [
+          {
+            badge: t('Technology preview'),
+            badgeColor: CatalogColor.purple,
+          },
+          {
+            badge: t('CLI-based'),
+            badgeColor: CatalogColor.purple,
+          },
+        ],
+      },
+      {
+        id: 'standalone',
+        title: t('Standalone'),
+        items: [
+          {
+            type: CatalogCardItemType.Description,
+            description: t(
+              'Run an OpenShift cluster where the control plane and data plane are coupled. The control plane is hosted by a dedicated group of physical or virtual nodes and the network stack is shared.'
+            ),
+          },
+          {
+            type: CatalogCardItemType.List,
+            title: t(''),
+            icon: (
+              <Icon status="success">
+                <CheckIcon />
+              </Icon>
+            ),
+            items: [
+              {
+                text: t('Increases resiliency with closely interconnected control plane and worker nodes.'),
+              },
+              {
+                text: t('Provide customized control plane cluster configuration.'),
+                subTitles: [t('Standard'), t('Single node OpenShift'), t('Three-node cluster')],
+              },
+            ],
+          },
+        ],
+        onClick: nextStep(getTypedCreateClusterPath(Provider.azure)),
+      },
+    ]
+    return newCards
+  }, [nextStep, t, isHypershiftEnabled, loaded])
+
+  const keyFn = useCallback((card: ICatalogCard) => card.id, [])
+
+  const breadcrumbs = useMemo(() => {
+    const newBreadcrumbs = [
+      { text: t('Clusters'), to: NavigationPath.clusters },
+      { text: t('Infrastructure'), to: NavigationPath.createCluster },
+      { text: t('Control plane type - {{hcType}}', { hcType: 'Azure' }) },
+    ]
+    return newBreadcrumbs
+  }, [t])
+
+  const dataViewStrings = useDataViewStrings()
+
+  return (
+    <AcmPage
+      header={
+        <AcmPageHeader
+          title={t('Control plane type - {{hcType}}', { hcType: 'Azure' })}
+          description={t('Choose a control plane type for your cluster.')}
+          breadcrumb={breadcrumbs}
+        />
+      }
+    >
+      <DataViewStringContext.Provider value={dataViewStrings}>
+        <ItemView
+          items={cards}
+          itemKeyFn={keyFn}
+          itemToCardFn={(card) => card}
+          onBack={back(NavigationPath.createCluster)}
+          onCancel={cancel(NavigationPath.clusters)}
+          customCatalogSection={
+            <HypershiftDiagramExpand
+              isDiagramExpanded={isDiagramExpanded}
+              onDiagramToggle={onDiagramToggle}
+              setIsMouseOverControlPlaneLink={setIsMouseOverControlPlaneLink}
+              t={t}
+            />
+          }
+        />
+      </DataViewStringContext.Provider>
+    </AcmPage>
+  )
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateClusterCatalog.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateClusterCatalog.tsx
@@ -151,6 +151,8 @@ export function CreateClusterCatalog() {
     (provider: CardProvider) => {
       if (provider === Provider.aws) {
         return nextStep(NavigationPath.createAWSControlPlane)
+      } else if (provider === Provider.azure) {
+        return nextStep(NavigationPath.createAzureControlPlane)
       } else if (provider === Provider.kubevirt) {
         return nextStep(NavigationPath.createKubeVirtControlPlane)
       } else if (provider === Provider.hostinventory) {


### PR DESCRIPTION
## ACM-30521: Add Azure HCP cluster creation and selection cards

### Summary

Adds UI support for Azure Hosted Control Plane (HCP) cluster creation, mirroring the existing AWS HCP flow. When users click "Azure" in the cluster creation catalog, they now see a control plane type selection page with "Hosted" and "Standalone" options. The "Hosted" option navigates to a CLI instructions page with a 7-step guide for creating an Azure HCP cluster.

### Acceptance Criteria Checklist

1. **[PASS]** Users can select to create Azure HCP clusters from the cluster catalog
   - Implemented in `CreateClusterCatalog.tsx` (routing) and `CreateAzureControlPlane.tsx` (page)
   - Tested in `CreateAzureControlPlane.test.tsx`

2. **[PASS]** Users have a page with instructions to create an Azure HCP cluster
   - Implemented in `HypershiftAzureCLI.tsx` (7-step CLI guide)
   - Tested in `HypershiftAzureCLI.test.tsx`

3. **[PASS]** Catalog routing updated — Azure navigates to control plane selection
   - Implemented in `CreateClusterCatalog.tsx`
   - Tested in `CreateClusterCatalog.test.tsx` (existing test still passes)

### Changeset Summary

| File | Action | Description |
|------|--------|-------------|
| `NavigationPath.tsx` | Modified | Added `createAzureControlPlane` and `createAzureCLI` routes |
| `doc-util.tsx` | Modified | Added `HYPERSHIFT_DEPLOY_AZURE` doc link |
| `DocPage.tsx` | Modified | Added optional `docLink` prop for provider-specific documentation |
| `CreateAzureControlPlane.tsx` | **New** | Azure control plane type selection page with Hosted/Standalone cards |
| `CreateAzureControlPlane.test.tsx` | **New** | Unit tests: hypershift enabled/disabled, standalone click |
| `HypershiftAzureCLI.tsx` | **New** | Azure HCP CLI instructions page with 7 creation steps |
| `HypershiftAzureCLI.test.tsx` | **New** | Unit test: all 7 steps render correctly |
| `CreateClusterCatalog.tsx` | Modified | Route Azure to control plane selection page |
| `Clusters.tsx` | Modified | Register new Azure routes |
| `CreateCluster.tsx` | Modified | Add Azure breadcrumb for standalone wizard |

### Test Results

```
Test Suites: 10 passed, 10 total
Tests:       38 passed, 38 total
Snapshots:   1 passed, 1 total
New tests added: 4 (across 2 new test files)
TypeScript: Clean (no errors)
ESLint: Clean (no errors)
```

### How to Test (Plugin Mode)

1. Run `npm run plugins`
2. Navigate to **Infrastructure → Clusters → Create cluster**
3. Click **Azure** in the infrastructure catalog
4. Verify the **Control plane type - Azure** page shows:
   - **Hosted** card with "Technology preview" and "CLI-based" badges
   - **Standalone** card with standard options
5. If hypershift is enabled, click **Hosted** → verify the 7-step Azure CLI instructions page renders with all code blocks
6. Click **Back** → verify navigation returns to control plane selection
7. Click **Standalone** → verify the existing Azure cluster creation wizard opens with correct breadcrumbs

### Notes

- Destroy functionality is out of scope (handled by ACM-34514)
- The Hosted card is gated by `useIsHypershiftEnabled()` — disabled with an info alert when hypershift operator is not enabled
- Azure HCP is marked as "Technology preview" via badge on the Hosted card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure managed cluster creation workflows with two path options: hosted and standalone control planes.
  * Added CLI-based Azure cluster creation guided page with step-by-step instructions including environment setup, credentials configuration, and infrastructure provisioning.
  * Added selection interface for choosing between hosted and standalone Azure control plane types.
  * Updated documentation links to include Azure hosted control planes deployment resources.
  * Enhanced navigation breadcrumbs for Azure cluster creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->