### PR TITLE
ACM-35499 avoid blocking incoming requests

### DIFF
--- a/backend/src/lib/batch-promise-all.ts
+++ b/backend/src/lib/batch-promise-all.ts
@@ -1,0 +1,20 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+export const BATCH_SIZE = 100
+
+/**
+ * Process an array of items through an async mapper in batches, yielding the
+ * event loop between batches to allow HTTP requests (e.g. liveness probes) to
+ * be served.
+ */
+export async function batchPromiseAll<T, R>(items: T[], mapper: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = []
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    const batch = await Promise.all(items.slice(i, i + BATCH_SIZE).map(mapper))
+    results.push(...batch)
+    if (i + BATCH_SIZE < items.length) {
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+  return results
+}

--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:http2'
 import type { Transform } from 'node:stream'
 import { clearInterval } from 'node:timers'
 import type { Zlib } from 'node:zlib'
+import { batchPromiseAll } from './batch-promise-all'
 import { getEncodeStream, inflateEvent } from './compression'
 import { setCookie } from './cookies'
 import { logger } from './logger'
@@ -313,7 +314,7 @@ export class ServerSideEvents {
     // uncompress and split events into packets
     const values = Object.values(this.events)
     const compressed = sizeOf(values)
-    let parts = await Promise.all(values.map((event) => inflateEvent(event)))
+    let parts = await batchPromiseAll(values, (event) => inflateEvent(event))
 
     // mock a large environment
     if (process.env.MOCK_CLUSTERS) {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -6,6 +6,7 @@ import { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import pluralize from 'pluralize'
 import { pipeline } from 'node:stream/promises'
 import { Transform } from 'node:stream'
+import { batchPromiseAll } from '../lib/batch-promise-all'
 import { createDictionary, deflateResource, inflateResource } from '../lib/compression'
 import { jsonPost } from '../lib/json-request'
 import { logger } from '../lib/logger'
@@ -41,10 +42,9 @@ let requests: { cancel: () => void }[] = []
 export async function getKubeResources(kind: string, apiVersion: string) {
   const option = { apiVersion, kind }
   const apiVersionPlural = apiVersionPluralFn(option)
-  return await Promise.all(
-    Object.values(resourceCache[apiVersionPlural] || {}).map((event) => {
-      return event.compressed.then((compressed) => inflateResource(compressed, eventDict))
-    })
+  const entries = Object.values(resourceCache[apiVersionPlural] || {})
+  return batchPromiseAll(entries, (event) =>
+    event.compressed.then((compressed) => inflateResource(compressed, eventDict))
   )
 }
 
@@ -439,7 +439,7 @@ async function listKubernetesObjects(serviceAccountToken: string, options: IWatc
   }
 
   const forward = options.forwardEventsToClients !== false
-  await Promise.all(items.map((item) => cacheResource(item, forward)))
+  await batchPromiseAll(items, (item) => cacheResource(item, forward))
 
   // Remove items that are no longer in kubernetes
   const apiVersionPlural = apiVersionPluralFn(options)
@@ -460,7 +460,7 @@ async function listKubernetesObjects(serviceAccountToken: string, options: IWatc
       removeResources.push(resource)
     }
   }
-  await Promise.all(removeResources.map((resource) => deleteResource(resource, forward)))
+  await batchPromiseAll(removeResources, (resource) => deleteResource(resource, forward))
 
   return { resourceVersion, size: items.length }
 }

--- a/backend/test/lib/batch-promise-all.test.ts
+++ b/backend/test/lib/batch-promise-all.test.ts
@@ -1,0 +1,80 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { batchPromiseAll, BATCH_SIZE } from '../../src/lib/batch-promise-all'
+
+describe('batchPromiseAll', () => {
+  it('should process all items and return results in order', async () => {
+    const items = [1, 2, 3, 4, 5]
+    const results = await batchPromiseAll(items, (n) => Promise.resolve(n * 2))
+    expect(results).toEqual([2, 4, 6, 8, 10])
+  })
+
+  it('should handle empty arrays', async () => {
+    const results = await batchPromiseAll([], (n: number) => Promise.resolve(n))
+    expect(results).toEqual([])
+  })
+
+  it('should process items in batches', async () => {
+    const items = Array.from({ length: BATCH_SIZE * 2 + 3 }, (_, i) => i)
+    const batchesProcessed: number[][] = []
+
+    await batchPromiseAll(items, (n) => {
+      const last = batchesProcessed[batchesProcessed.length - 1]
+      if (!last || last.length >= BATCH_SIZE) {
+        batchesProcessed.push([])
+      }
+      batchesProcessed[batchesProcessed.length - 1].push(n)
+      return Promise.resolve(n)
+    })
+
+    expect(batchesProcessed.length).toBe(3)
+    expect(batchesProcessed[0].length).toBe(BATCH_SIZE)
+    expect(batchesProcessed[1].length).toBe(BATCH_SIZE)
+    expect(batchesProcessed[2].length).toBe(3)
+  })
+
+  it('should yield the event loop between batches', async () => {
+    let yielded = false
+    const items = Array.from({ length: BATCH_SIZE + 1 }, (_, i) => i)
+
+    const originalSetImmediate = global.setImmediate
+    global.setImmediate = ((fn: () => void) => {
+      yielded = true
+      return originalSetImmediate(fn)
+    }) as typeof setImmediate
+
+    try {
+      await batchPromiseAll(items, (n) => Promise.resolve(n))
+    } finally {
+      global.setImmediate = originalSetImmediate
+    }
+    expect(yielded).toBe(true)
+  })
+
+  it('should not yield after the last batch', async () => {
+    let yieldCount = 0
+    const items = Array.from({ length: BATCH_SIZE }, (_, i) => i)
+
+    const originalSetImmediate = global.setImmediate
+    global.setImmediate = ((fn: () => void) => {
+      yieldCount++
+      return originalSetImmediate(fn)
+    }) as typeof setImmediate
+
+    try {
+      await batchPromiseAll(items, (n) => Promise.resolve(n))
+    } finally {
+      global.setImmediate = originalSetImmediate
+    }
+    expect(yieldCount).toBe(0)
+  })
+
+  it('should propagate errors from the mapper', async () => {
+    const items = [1, 2, 3]
+    await expect(
+      batchPromiseAll(items, (n) => {
+        if (n === 2) return Promise.reject(new Error('test error'))
+        return Promise.resolve(n)
+      })
+    ).rejects.toThrow('test error')
+  })
+})


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
console-mce pod CrashLoopBackOff due to probe failure with large resource sets

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-35499

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Customer was observing CrashLoopBackoff on console-mce pods and had over 20,000 Group resources present. Initially processing these resources may have blocked us from responding to the readiness and liveness probes on time, causing Kubernetes to restart the pod.

This PR batches Promise.all calls so that we call setImmediate after each batch of 100 to yield the event queue so that new requests can be handled. This seems to smooth out memory usage of the pods. Before this change, I observed a spike at startup, then a retreat to stable size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced backend processing to handle large collections in controlled batches instead of launching all work concurrently.
  * Improved server-side event handling and resource reconciliation by batching decompression/inflation and list reconciliation steps, helping maintain consistent performance and ordered results.
* **Tests**
  * Added coverage for batch processing behavior, including result ordering, empty input handling, batch sizing, event-loop yielding, and error propagation from mappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->