### PR TITLE
ACM-35158 avoid blocking incoming requests [release-2.16]

### DIFF
--- a/backend/src/lib/batch-promise-all.ts
+++ b/backend/src/lib/batch-promise-all.ts
@@ -1,0 +1,20 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+export const BATCH_SIZE = 100
+
+/**
+ * Process an array of items through an async mapper in batches, yielding the
+ * event loop between batches to allow HTTP requests (e.g. liveness probes) to
+ * be served.
+ */
+export async function batchPromiseAll<T, R>(items: T[], mapper: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = []
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    const batch = await Promise.all(items.slice(i, i + BATCH_SIZE).map(mapper))
+    results.push(...batch)
+    if (i + BATCH_SIZE < items.length) {
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+  return results
+}

--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:http2'
 import type { Transform } from 'node:stream'
 import { clearInterval } from 'node:timers'
 import type { Zlib } from 'node:zlib'
+import { batchPromiseAll } from './batch-promise-all'
 import { getEncodeStream, inflateEvent } from './compression'
 import { setCookie } from './cookies'
 import { logger } from './logger'
@@ -313,7 +314,7 @@ export class ServerSideEvents {
     // uncompress and split events into packets
     const values = Object.values(this.events)
     const compressed = sizeOf(values)
-    let parts = await Promise.all(values.map((event) => inflateEvent(event)))
+    let parts = await batchPromiseAll(values, (event) => inflateEvent(event))
 
     // mock a large environment
     if (process.env.MOCK_CLUSTERS) {

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -6,6 +6,7 @@ import { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import pluralize from 'pluralize'
 import { pipeline } from 'node:stream/promises'
 import { Transform } from 'node:stream'
+import { batchPromiseAll } from '../lib/batch-promise-all'
 import { createDictionary, deflateResource, inflateResource } from '../lib/compression'
 import { jsonPost } from '../lib/json-request'
 import { logger } from '../lib/logger'
@@ -41,10 +42,9 @@ let requests: { cancel: () => void }[] = []
 export async function getKubeResources(kind: string, apiVersion: string) {
   const option = { apiVersion, kind }
   const apiVersionPlural = apiVersionPluralFn(option)
-  return await Promise.all(
-    Object.values(resourceCache[apiVersionPlural] || {}).map((event) => {
-      return event.compressed.then((compressed) => inflateResource(compressed, eventDict))
-    })
+  const entries = Object.values(resourceCache[apiVersionPlural] || {})
+  return batchPromiseAll(entries, (event) =>
+    event.compressed.then((compressed) => inflateResource(compressed, eventDict))
   )
 }
 
@@ -369,7 +369,7 @@ async function listKubernetesObjects(serviceAccountToken: string, options: IWatc
     return { size: itemCount }
   }
 
-  await Promise.all(items.map((item) => cacheResource(item)))
+  await batchPromiseAll(items, (item) => cacheResource(item))
 
   // Remove items that are no longer in kubernetes
   const apiVersionPlural = apiVersionPluralFn(options)
@@ -390,7 +390,7 @@ async function listKubernetesObjects(serviceAccountToken: string, options: IWatc
       removeResources.push(resource)
     }
   }
-  await Promise.all(removeResources.map((resource) => deleteResource(resource)))
+  await batchPromiseAll(removeResources, (resource) => deleteResource(resource))
 
   return { resourceVersion, size: items.length }
 }

--- a/backend/test/lib/batch-promise-all.test.ts
+++ b/backend/test/lib/batch-promise-all.test.ts
@@ -1,0 +1,80 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { batchPromiseAll, BATCH_SIZE } from '../../src/lib/batch-promise-all'
+
+describe('batchPromiseAll', () => {
+  it('should process all items and return results in order', async () => {
+    const items = [1, 2, 3, 4, 5]
+    const results = await batchPromiseAll(items, (n) => Promise.resolve(n * 2))
+    expect(results).toEqual([2, 4, 6, 8, 10])
+  })
+
+  it('should handle empty arrays', async () => {
+    const results = await batchPromiseAll([], (n: number) => Promise.resolve(n))
+    expect(results).toEqual([])
+  })
+
+  it('should process items in batches', async () => {
+    const items = Array.from({ length: BATCH_SIZE * 2 + 3 }, (_, i) => i)
+    const batchesProcessed: number[][] = []
+
+    await batchPromiseAll(items, (n) => {
+      const last = batchesProcessed[batchesProcessed.length - 1]
+      if (!last || last.length >= BATCH_SIZE) {
+        batchesProcessed.push([])
+      }
+      batchesProcessed[batchesProcessed.length - 1].push(n)
+      return Promise.resolve(n)
+    })
+
+    expect(batchesProcessed.length).toBe(3)
+    expect(batchesProcessed[0].length).toBe(BATCH_SIZE)
+    expect(batchesProcessed[1].length).toBe(BATCH_SIZE)
+    expect(batchesProcessed[2].length).toBe(3)
+  })
+
+  it('should yield the event loop between batches', async () => {
+    let yielded = false
+    const items = Array.from({ length: BATCH_SIZE + 1 }, (_, i) => i)
+
+    const originalSetImmediate = global.setImmediate
+    global.setImmediate = ((fn: () => void) => {
+      yielded = true
+      return originalSetImmediate(fn)
+    }) as typeof setImmediate
+
+    try {
+      await batchPromiseAll(items, (n) => Promise.resolve(n))
+    } finally {
+      global.setImmediate = originalSetImmediate
+    }
+    expect(yielded).toBe(true)
+  })
+
+  it('should not yield after the last batch', async () => {
+    let yieldCount = 0
+    const items = Array.from({ length: BATCH_SIZE }, (_, i) => i)
+
+    const originalSetImmediate = global.setImmediate
+    global.setImmediate = ((fn: () => void) => {
+      yieldCount++
+      return originalSetImmediate(fn)
+    }) as typeof setImmediate
+
+    try {
+      await batchPromiseAll(items, (n) => Promise.resolve(n))
+    } finally {
+      global.setImmediate = originalSetImmediate
+    }
+    expect(yieldCount).toBe(0)
+  })
+
+  it('should propagate errors from the mapper', async () => {
+    const items = [1, 2, 3]
+    await expect(
+      batchPromiseAll(items, (n) => {
+        if (n === 2) return Promise.reject(new Error('test error'))
+        return Promise.resolve(n)
+      })
+    ).rejects.toThrow('test error')
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "@stolostron/react-data-view": "^3.3.1",
         "@tanstack/react-query": "^4.42.2",
         "ajv": "8.17.1",
-        "axios": "^0.31.1",
+        "axios": "^0.32.0",
         "cidr-tools": "4.3.0",
         "debounce": "1.2.1",
         "deep-diff": "1.0.2",
@@ -7359,13 +7359,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -7401,13 +7402,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared/node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -12559,7 +12561,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -13155,9 +13156,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.31.1.tgz",
-      "integrity": "sha512-Ef8DUZSZQP6igY48mjGaoEjwhely97lserep0IFJifBH4YdKvwH5eMLniy3kig2HQoBNR8EkZpDjowxwTJcmbg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.32.0.tgz",
+      "integrity": "sha512-sGQArzERW2SI8IRkjuJ5y91Sm9QjiRq4Ay4kOLqpbBt5CeKDNq4g6nirJdyD+palK3yEDXnJiVXsesX66AjwyA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",
@@ -22076,7 +22077,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "@stolostron/react-data-view": "^3.3.1",
     "@tanstack/react-query": "^4.42.2",
     "ajv": "8.17.1",
-    "axios": "^0.31.1",
+    "axios": "^0.32.0",
     "cidr-tools": "4.3.0",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
console-mce pod CrashLoopBackOff due to probe failure with large resource sets

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-35158

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Customer was observing CrashLoopBackoff on console-mce pods and had over 20,000 Group resources present. Initially processing these resources may have blocked us from responding to the readiness and liveness probes on time, causing Kubernetes to restart the pod.

This PR batches Promise.all calls so that we call setImmediate after each batch of 100 to yield the event queue so that new requests can be handled. This seems to smooth out memory usage of the pods. Before this change, I observed a spike at startup, then a retreat to stable size.

### Memory Usage

In the following videos, I deleted pods, then observed the memory usage of the replacements. You can see that before the patch, the pods sometimes have a memory spike during startup, and in this case we see one of the pods spike to almost 12 GB, before falling back to a more typical value. After the patch, there is no initial spike.

#### Before
https://github.com/user-attachments/assets/3501ee1e-34a5-49d2-9069-e514ac21c2a7

#### After
https://github.com/user-attachments/assets/2c64390d-1919-4158-9301-04d29d5dc72b

### Liveness Probe Response Time

I also checked the response time, turning on garbage collection tracing and using a simple script to repeatedly check the liveness probe endpoint. I tested against cluster `kevin-probe-test` which has 50,000 Group resources on it.

Here is the process I followed:
1. Run `./check-response-time.sh` or `./check-response-time.sh -t 1.0` in one terminal. (The latter command shows only when response time is greater than 1.0 seconds.)
2. In a second terminal, run `npm run plugins`.
3. Drive load to the backend by loading `https://localhost:9000/multicloud/credentials` in several tabs. Repeatedly refresh the tabs to drive new full loads of the SSE stream.

Using a [baseline test branch](https://github.com/KevinFCormier/console/tree/release-2.16-baseline) vs. a [patched test branch](https://github.com/KevinFCormier/console/tree/ACM-35158-avoid-blocking-incoming-requests-debug), I found:
- Without the patch, I can easily provoke response times of 1-2 seconds. I saw a particularly long pause of 53 s on one occasion.
- With the patch, I used `./check-response-time.sh -t 0.1` and only saw response times up to just under 0.5 s.
