### PR TITLE
[ACM-35524] Prevent SSE dictionary corruption from non-string resourc…

### DIFF
--- a/backend/src/lib/compression.ts
+++ b/backend/src/lib/compression.ts
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import type { IResource } from './../resources/resource'
 import type { Readable, Transform } from 'node:stream'
 import { pipeline } from 'node:stream'
+import { promisify } from 'node:util'
 import type { Zlib } from 'node:zlib'
 import {
   createBrotliCompress,
@@ -10,14 +10,14 @@ import {
   createGunzip,
   createGzip,
   createInflate,
-  inflateRaw,
   deflateRaw,
+  inflateRaw,
 } from 'node:zlib'
+import { getAppDict, type ICompressedResource, type ITransformedResource } from '../routes/aggregators/applications'
+import { getEventDict } from '../routes/events'
+import type { IResource } from './../resources/resource'
 import { logger } from './logger'
 import type { ServerSideEvent, WatchEvent } from './server-side-events'
-import { getEventDict } from '../routes/events'
-import { getAppDict, type ICompressedResource, type ITransformedResource } from '../routes/aggregators/applications'
-import { promisify } from 'node:util'
 
 const MAX_RECENTLY_ADDED = 200
 
@@ -175,8 +175,9 @@ function compressResource(resource: UncompressedResourceType, dictionary: Dictio
             res[dictionary.add(key)] = resource[key]
           } else {
             const inx = dictionary.add(key)
-            if (valueInDictionaryKeys.has(key)) {
-              res[inx] = dictionary.add(resource[key] as string)
+            // Guard against non-string values (e.g. nested CRD OpenAPI schema objects) corrupting the shared dictionary.
+            if (valueInDictionaryKeys.has(key) && typeof resource[key] === 'string') {
+              res[inx] = dictionary.add(resource[key])
             } else {
               res[inx] = compressResource(resource[key] as UncompressedResourceType, dictionary)
             }
@@ -277,6 +278,8 @@ function decompressResource(resource: CompressedResourceType, dictionary: Dictio
       for (const inx in resource) {
         if (Object.prototype.hasOwnProperty.call(resource, inx)) {
           const key = dictionary.get(Number(inx))
+          // Dictionary corruption would produce a non-string key; skip rather than crashing on key.includes().
+          if (typeof key !== 'string') continue
           if (
             valueAsIsKeys.has(key) ||
             (key === 'message' && inx in resource && !Number.isInteger(Number(resource[inx]))) ||


### PR DESCRIPTION
…e values

# 📝 Summary

**Ticket Summary (Title):**  
Policies containing CRD OpenAPI schema objects (or other nested objects) in fields like apiVersion or kind caused compressResource to store a non-string value into the shared SSE dictionary. This corrupted the dictionary and caused decompressResource to throw `TypeError: key.includes is not a function` on every subsequent client connection, aborting SSE stream setup before the end-of-packet signal was sent and leaving the UI in a permanent loading state.
- compressResource: only index a value into the dictionary when it is actually a string, otherwise fall through to recursive compression
- decompressResource: skip entries whose dictionary lookup returns a non-string key to prevent crashing on key.includes()

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-35524

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compression and decompression operations to better handle edge cases with corrupted or malformed data values, improving system stability and preventing potential errors when processing improperly formatted information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->