### PR TITLE
ACM-35599 Fix MCE pod log errors

### DIFF
--- a/backend/src/lib/respond.ts
+++ b/backend/src/lib/respond.ts
@@ -64,6 +64,8 @@ export function respondInternalServerError(_req: Http2ServerRequest, res: Http2S
 export function catchInternalServerError(res: Http2ServerResponse): (err: unknown) => void {
   return (err) => {
     logger.error(err)
-    respondInternalServerError(undefined, res)
+    if (!res.headersSent) {
+      respondInternalServerError(undefined, res)
+    }
   }
 }

--- a/backend/src/routes/serve.ts
+++ b/backend/src/routes/serve.ts
@@ -81,6 +81,7 @@ export async function serve(req: Http2ServerRequest, res: Http2ServerResponse): 
     // Don't send content for cache revalidation
     if (req.headers['if-modified-since'] === modificationTime) {
       res.writeHead(constants.HTTP_STATUS_NOT_MODIFIED).end()
+      return
     }
 
     if (/\bbr\b/.test(acceptEncoding)) {


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ACM Console pods are continuously logging ERR_STREAM_UNABLE_TO_PIPE and ERR_HTTP_HEADERS_SENT errors

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-35599

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Root Cause
```
// Line 82-84 in serve.ts
if (req.headers['if-modified-since'] === modificationTime) {
  res.writeHead(constants.HTTP_STATUS_NOT_MODIFIED).end()
  // ← BUG: no `return` here!
}
```
When a browser sends a conditional request with If-Modified-Since matching the file's modification time, the code correctly sends a 304 Not Modified and ends the response — but then falls through into the compression/streaming code below (lines 86–152).
The Error Chain
Here's exactly what happens:
1. 304 response sent and stream ended (line 83)
2. Code falls through to the brotli/gzip/uncompressed sections
3. A readStream is created and pipeline(readStream, res, ...) is called on the already-ended response stream → ERR_STREAM_UNABLE_TO_PIPE
4. The readStream.on('open') callback fires and calls res.writeHead(200, ...) on a response that already has headers sent → ERR_HTTP_HEADERS_SENT
5. The pipeline error propagates to serveHandler → catchInternalServerError → respondInternalServerError which tries res.writeHead(500) on the same already-finished response → ERR_HTTP_HEADERS_SENT (unhandled rejection)
All three errors in your log trace back to this single missing return.

**Analysis for if this was caused by the Nodejs 24 upgrade**

**Why it was silent before:** In Node.js 20/22, when pipeline() was called with an already-ended response stream, the behavior was more lenient — it would either silently fail or just call the error callback without throwing. The response data was effectively dropped, but no loud errors were produced. The 304 was correctly sent to the client, so functionally everything appeared to work.

**What changed in Node.js 24:** The streams implementation tightened up:
1. pipelineImpl now validates upfront — the check at node:internal/streams/pipeline:264 (visible in your stack trace) verifies the destination stream isn't closed/destroyed before attempting to pipe. This throws ERR_STREAM_UNABLE_TO_PIPE immediately instead of failing silently.
2. HTTP response streams are finalized more aggressively after .end() — the stream is marked as destroyed sooner, so by the time pipeline() runs, it sees a closed stream.
3. Stricter writeHead enforcement — calling writeHead() after headers are sent now consistently throws rather than being silently ignored.
So the bug was always there — the 304 path was always falling through and attempting to pipe/write headers on a finished response — but older Node.js versions silently swallowed it. Node.js 24's stricter stream semantics turned it into the three visible errors you're seeing. The fix is correct regardless of Node.js version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error response handling to prevent errors when headers have already been sent to the client.
  * Improved cache revalidation to skip unnecessary content processing when serving cached responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->