### PR TITLE
ACM-34761 Fix multicluster-SDK due to search api boolean to string changes

### DIFF
--- a/frontend/packages/multicluster-sdk/src/internal/search/convertSearchItemToResource.test.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/search/convertSearchItemToResource.test.ts
@@ -913,6 +913,34 @@ describe('convertSearchItemToResource', () => {
       expect(result.volumeBindingMode).toBe('WaitForFirstConsumer')
     })
 
+    it('should handle StorageClass with string boolean allowVolumeExpansion', () => {
+      const storageClassItem = {
+        ...baseSearchItem,
+        kind: 'StorageClass',
+        apigroup: 'storage.k8s.io',
+        allowVolumeExpansion: 'true',
+        provisioner: 'kubernetes.io/aws-ebs',
+      }
+
+      const result = convert(storageClassItem)
+
+      expect(result.allowVolumeExpansion).toBe(true)
+    })
+
+    it('should handle StorageClass with string boolean allowVolumeExpansion false', () => {
+      const storageClassItem = {
+        ...baseSearchItem,
+        kind: 'StorageClass',
+        apigroup: 'storage.k8s.io',
+        allowVolumeExpansion: 'false',
+        provisioner: 'kubernetes.io/aws-ebs',
+      }
+
+      const result = convert(storageClassItem)
+
+      expect(result.allowVolumeExpansion).toBe(false)
+    })
+
     it('should handle StorageClass with partial fields', () => {
       const storageClassItem = {
         ...baseSearchItem,
@@ -1615,6 +1643,36 @@ describe('convertSearchItemToResource', () => {
       expect(result.spec?.target?.kind).toBe('VirtualMachine')
       expect(result.spec?.target?.name).toBe('restored-vm')
       expect(result.spec?.virtualMachineSnapshotName).toBe('test-snapshot')
+    })
+
+    it('should handle VirtualMachineRestore with string boolean complete true', () => {
+      const restoreItem = {
+        ...baseSearchItem,
+        kind: 'VirtualMachineRestore',
+        apigroup: 'snapshot.kubevirt.io',
+        complete: 'true',
+        targetKind: 'VirtualMachine',
+        targetName: 'restored-vm',
+      }
+
+      const result = convert(restoreItem)
+
+      expect(result.status?.complete).toBe(true)
+    })
+
+    it('should handle VirtualMachineRestore with string boolean complete false', () => {
+      const restoreItem = {
+        ...baseSearchItem,
+        kind: 'VirtualMachineRestore',
+        apigroup: 'snapshot.kubevirt.io',
+        complete: 'false',
+        targetKind: 'VirtualMachine',
+        targetName: 'restoring-vm',
+      }
+
+      const result = convert(restoreItem)
+
+      expect(result.status?.complete).toBe(false)
     })
 
     it('should handle VirtualMachineRestore in progress', () => {

--- a/frontend/packages/multicluster-sdk/src/internal/search/convertSearchItemToResource.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/search/convertSearchItemToResource.ts
@@ -279,7 +279,12 @@ export function convertSearchItemToResource<R extends K8sResourceCommon | K8sRes
     }
 
     case 'StorageClass.storage.k8s.io':
-      setIfDefined(resource, 'allowVolumeExpansion', item.allowVolumeExpansion)
+      setIfDefined(
+        resource,
+        'allowVolumeExpansion',
+        item.allowVolumeExpansion,
+        convertToBoolean(item.allowVolumeExpansion)
+      )
       setIfDefined(resource, 'provisioner', item.provisioner)
       setIfDefined(resource, 'reclaimPolicy', item.reclaimPolicy)
       setIfDefined(resource, 'volumeBindingMode', item.volumeBindingMode)
@@ -428,7 +433,7 @@ export function convertSearchItemToResource<R extends K8sResourceCommon | K8sRes
 
     case 'VirtualMachineRestore.snapshot.kubevirt.io':
       setIfDefined(resource, 'status.restoreTime', item.restoreTime)
-      setIfDefined(resource, 'status.complete', item.complete)
+      setIfDefined(resource, 'status.complete', item.complete, convertToBoolean(item.complete))
       setIfDefined(resource, 'spec.target.apiGroup', item.targetApiGroup)
       setIfDefined(resource, 'spec.target.kind', item.targetKind)
       setIfDefined(resource, 'spec.target.name', item.targetName)


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Search API breaking change in 5.0: boolean fields now stored as strings, console and multicluster-SDK impact assessment needed

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-34761

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of boolean-like values in resource search results so fields such as expansion support and completion status now display as real booleans instead of strings.
  * Added coverage for these conversions to help prevent regressions in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->