### PR TITLE
Add option for including pipelines-console-plugin while running ACM/MCE

### DIFF
--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -82,6 +82,10 @@ function getBridgePlugins {
         plugins="${plugins},gitops-plugin=http://${host}:${GITOPS_PORT}"
     fi
 
+    if [ -n "$PIPELINES_PORT" ]; then
+        plugins="${plugins},pipelines-console-plugin=http://${host}:${PIPELINES_PORT}"
+    fi
+
     echo "mce=http://${host}:${MCE_PORT},acm=http://${host}:${ACM_PORT}${plugins}"
 }
 


### PR DESCRIPTION
This PR updates the startup script to include option for convenient development along side OpenShift Pipelines.

From a clone of the [openshift-pipelines/console-plugin](https://github.com/openshift-pipelines/console-plugin) repo, run:
```
yarn install
yarn start # or yarn dev
```

Then from this repo, run:
```
PIPELINES_PORT=9001 npm run plugins
```

This will allow OpenShift Pipelines developers to experiment with using the [@stolostron/multicluster-sdk](https://www.npmjs.com/package/@stolostron/multicluster-sdk)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The console can now automatically include the Pipelines plugin when a pipelines port is available, making the plugin appear without manual setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->