### PR TITLE
ACM-36399 ACM-36340 npm update fast-uri

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20443,9 +20443,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Address CVE-2026-13676 by updating `fast-uri` to version 3.1.3

https://redhat.atlassian.net/browse/ACM-36399
https://redhat.atlassian.net/browse/ACM-36400