### PR TITLE
ACM-35631: Fix Kyverno VAPB link for v1.17.2+ naming convention

### DIFF
--- a/backend/src/routes/aggregators/applicationsArgo.ts
+++ b/backend/src/routes/aggregators/applicationsArgo.ts
@@ -582,7 +582,7 @@ export function createArgoStatusMap(searchResult: SearchResult, clusters: Cluste
       appKey = `appset/${appName}`
     } else if (app.applicationSet) {
       // don't count the placeholder app on the hub for this pulled appset
-      if (!app.label.includes('apps.open-cluster-management.io/pull-to-ocm-managed-cluster=true')) {
+      if (!app.label?.includes('apps.open-cluster-management.io/pull-to-ocm-managed-cluster=true')) {
         appName = `${app.namespace}/${app.applicationSet}`
         appKey = `appset/${appName}`
         const namePart = app.name.startsWith(app.applicationSet)

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailHooks.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailHooks.tsx
@@ -14,6 +14,7 @@ import { parseStringMap } from '../../../common/util'
 export function useFetchVapb() {
   const urlParams = useParams()
   const name = urlParams.templateName ?? '-'
+  const kind = urlParams.kind ?? ''
   const apiGroup = urlParams.apiGroup ?? ''
   const { clusterName, template, templateLoading } = useTemplateDetailsContext()
   const [getVapb, { loading, error, data }] = useSearchResultItemsLazyQuery({
@@ -31,7 +32,13 @@ export function useFetchVapb() {
       !data &&
       !error
     ) {
-      const vapbName = apiGroup === 'constraints.gatekeeper.sh' ? `gatekeeper-${name}` : name + '-binding'
+      let vapbNames: string[]
+      if (apiGroup === 'constraints.gatekeeper.sh') {
+        vapbNames = [`gatekeeper-${kind.toLowerCase()}-${name}`]
+      } else {
+        const prefix = kind === 'ClusterPolicy' ? 'cpol' : 'pol'
+        vapbNames = [`${prefix}-${name}-binding`, `${name}-binding`]
+      }
 
       getVapb({
         client: process.env.NODE_ENV === 'test' ? undefined : searchClient,
@@ -49,7 +56,7 @@ export function useFetchVapb() {
                 },
                 {
                   property: 'name',
-                  values: [vapbName],
+                  values: vapbNames,
                 },
                 {
                   property: 'cluster',
@@ -62,7 +69,7 @@ export function useFetchVapb() {
         },
       })
     }
-  }, [apiGroup, clusterName, name, template, templateLoading, data, loading, error, getVapb])
+  }, [apiGroup, clusterName, name, kind, template, templateLoading, data, loading, error, getVapb])
 
   return { vapbItems: data?.searchResult?.[0]?.items, loading, err: error?.message }
 }

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetails.tsx
@@ -214,7 +214,7 @@ export function PolicyTemplateDetails() {
 
     addRowsForConstraint(cols, clusterName, apiGroup, kind)
 
-    addRowsForHasVapb(cols, hasVapb, vapb.loading, vapb.vapbItems, apiGroup, clusterName, name)
+    addRowsForHasVapb(cols, hasVapb, vapb.loading, vapb.vapbItems, clusterName)
 
     addRowsForOperatorPolicy(cols, template, kind, t)
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsColumns.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsColumns.tsx
@@ -11,9 +11,7 @@ export const addRowsForHasVapb = (
   hasVapb: boolean,
   loading: boolean,
   vapbItems: any[] | null | undefined,
-  apiGroup: string,
-  clusterName: string,
-  name: string
+  clusterName: string
 ) => {
   if (!hasVapb) {
     return cols
@@ -25,7 +23,7 @@ export const addRowsForHasVapb = (
       value: <Skeleton width="100%" screenreaderText="Fetching ValidatingAdmissionPolicyBinding" />,
     })
   } else if (vapbItems && vapbItems.length > 0 && !loading) {
-    const vapbName = apiGroup === 'constraints.gatekeeper.sh' ? `gatekeeper-${name}` : name + '-binding'
+    const vapbName = vapbItems[0].name
     cols.push({
       key: 'Validating Admission Policy Binding',
       value: (

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
@@ -316,7 +316,7 @@ const oppolStatus: Record<string, unknown> = {
 }
 
 const vapbScope = {
-  name: 'gatekeeper-ns-must-have-gk',
+  name: 'gatekeeper-k8srequiredlabels-ns-must-have-gk',
   resource: 'validatingadmissionpolicybinding.v1.admissionregistration.k8s.io',
 }
 
@@ -339,7 +339,7 @@ const vapbStatus = {
         'policy.open-cluster-management.io/cluster-name': 'local-cluster',
         'policy.open-cluster-management.io/cluster-namespace': 'local-cluster',
       },
-      name: 'gatekeeper-ns-must-have-gk',
+      name: 'gatekeeper-k8srequiredlabels-ns-must-have-gk',
     },
     spec: {
       policyName: 'gatekeeper-k8srequiredlabels',
@@ -372,7 +372,7 @@ describe('Policy Template Details Page', () => {
                   created: '2024-10-28T15:15:59Z',
                   kind: 'ValidatingAdmissionPolicyBinding',
                   kind_plural: 'validatingadmissionpolicybindings',
-                  name: 'gatekeeper-all-must-have-owner',
+                  name: 'gatekeeper-k8srequiredlabels-ns-must-have-gk',
                   policyName: 'gatekeeper-k8srequiredlabels',
                   validationActions: 'deny',
                 },
@@ -816,16 +816,16 @@ describe('Policy Template Details Page', () => {
     )
 
     // Verify the generated ValidatingAdmissionPolicyBinding
-    await waitForText('gatekeeper-ns-must-have-gk')
+    await waitForText('gatekeeper-k8srequiredlabels-ns-must-have-gk')
     await waitForText('Validating Admission Policy Binding')
-    expect(screen.getByRole('link', { name: 'gatekeeper-ns-must-have-gk' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'gatekeeper-k8srequiredlabels-ns-must-have-gk' })).toHaveAttribute(
       'href',
       generatePath(NavigationPath.discoveredPolicyDetails, {
         clusterName: 'test-cluster',
         apiVersion: 'v1',
         apiGroup: 'admissionregistration.k8s.io',
         kind: 'ValidatingAdmissionPolicyBinding',
-        templateName: `gatekeeper-ns-must-have-gk`,
+        templateName: `gatekeeper-k8srequiredlabels-ns-must-have-gk`,
         templateNamespace: null,
       })
     )
@@ -1266,7 +1266,7 @@ describe('Policy Template Details Page', () => {
               apiGroup: 'admissionregistration.k8s.io',
               apiVersion: 'v1',
               kind: 'ValidatingAdmissionPolicyBinding',
-              templateName: 'gatekeeper-ns-must-have-gk',
+              templateName: 'gatekeeper-k8srequiredlabels-ns-must-have-gk',
               templateNamespace: '',
             }),
           ]}
@@ -1287,7 +1287,7 @@ describe('Policy Template Details Page', () => {
     // wait for page load - looking for breadcrumb items
     await waitForText('Discovered policies')
 
-    expect(screen.getByRole('link', { name: 'gatekeeper-ns-must-have-gk' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'gatekeeper-k8srequiredlabels-ns-must-have-gk' })).toBeInTheDocument()
 
     await waitForText('ValidatingAdmissionPolicyBinding details')
 
@@ -1604,6 +1604,334 @@ describe('Policy Template Details Page', () => {
     within(view).getByText('2')
   })
 
+  test('Should render Kyverno policy page with new cpol- VAPB naming convention', async () => {
+    ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: undefined, loading: false, error: undefined },
+    ])
+    ;(useSearchResultItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      {
+        data: {
+          searchResult: [
+            {
+              items: [
+                {
+                  _hubClusterResource: 'true',
+                  _uid: 'local-cluster/new-vapb-uid',
+                  apigroup: 'admissionregistration.k8s.io',
+                  apiversion: 'v1',
+                  cluster: 'local-cluster',
+                  created: '2024-10-28T15:15:59Z',
+                  kind: 'ValidatingAdmissionPolicyBinding',
+                  kind_plural: 'validatingadmissionpolicybindings',
+                  name: 'cpol-require-owner-labels-binding',
+                  policyName: 'cpol-require-owner-labels-binding',
+                  validationActions: 'audit',
+                },
+              ],
+              __typename: 'SearchResult',
+            },
+          ],
+        },
+        loading: false,
+        error: undefined,
+      },
+    ])()
+
+    const kyvernoScope = {
+      name: 'require-owner-labels',
+      resource: 'clusterpolicy.v1.kyverno.io',
+    }
+    const kyvernoStatus = {
+      conditions: [
+        {
+          message: 'Watching resources successfully',
+          reason: 'GetResourceProcessing',
+          status: 'True',
+          type: 'Processing',
+        },
+      ],
+      result: {
+        apiVersion: 'kyverno.io/v1',
+        kind: 'ClusterPolicy',
+        metadata: {
+          name: 'require-owner-labels',
+        },
+        spec: {
+          validationFailureAction: 'Audit',
+          background: true,
+          rules: [
+            {
+              name: 'require-labels',
+              match: {
+                any: [{ resources: { kinds: ['Namespace'] } }],
+              },
+              validate: {
+                message: 'The label `owner` is required',
+                pattern: { metadata: { labels: { owner: '?*' } } },
+              },
+            },
+          ],
+        },
+      },
+    }
+    mockUuidV4.mockReturnValue(MOCKED_UUID_1)
+    const mcvNocks = nockManagedClusterView(MOCKED_UUID_1, 'test-cluster', kyvernoScope, kyvernoStatus)
+
+    nockIgnoreRBAC()
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, {})
+        }}
+      >
+        <MemoryRouter
+          initialEntries={[
+            generatePath(NavigationPath.discoveredPolicyDetails, {
+              clusterName: 'test-cluster',
+              apiGroup: 'kyverno.io',
+              apiVersion: 'v1',
+              kind: 'ClusterPolicy',
+              templateName: 'require-owner-labels',
+              templateNamespace: '',
+            }),
+          ]}
+        >
+          <Routes>
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.discoveredPolicyDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.discoveredPolicyYaml} element={<PolicyTemplateYaml />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForNocks(mcvNocks)
+    await waitForText('Discovered policies')
+    await waitForText('ClusterPolicy details')
+
+    // VAPB link should use the new cpol- naming convention from search results
+    expect(screen.getByRole('link', { name: 'cpol-require-owner-labels-binding' })).toBeInTheDocument()
+  })
+
+  test('Should render Kyverno ClusterPolicy page with dash when no VAPB exists', async () => {
+    ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: undefined, loading: false, error: undefined },
+    ])
+    ;(useSearchResultItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      {
+        data: {
+          searchResult: [
+            {
+              items: [],
+              __typename: 'SearchResult',
+            },
+          ],
+        },
+        loading: false,
+        error: undefined,
+      },
+    ])()
+
+    const kyvernoScope = {
+      name: 'no-vapb-policy',
+      resource: 'clusterpolicy.v1.kyverno.io',
+    }
+    const kyvernoStatus = {
+      conditions: [
+        {
+          message: 'Watching resources successfully',
+          reason: 'GetResourceProcessing',
+          status: 'True',
+          type: 'Processing',
+        },
+      ],
+      result: {
+        apiVersion: 'kyverno.io/v1',
+        kind: 'ClusterPolicy',
+        metadata: {
+          name: 'no-vapb-policy',
+        },
+        spec: {
+          validationFailureAction: 'Audit',
+          background: true,
+          rules: [
+            {
+              name: 'require-labels',
+              match: {
+                any: [{ resources: { kinds: ['Namespace'] } }],
+              },
+              validate: {
+                message: 'The label `owner` is required',
+                pattern: { metadata: { labels: { owner: '?*' } } },
+              },
+            },
+          ],
+        },
+      },
+    }
+    mockUuidV4.mockReturnValue(MOCKED_UUID_1)
+    const mcvNocks = nockManagedClusterView(MOCKED_UUID_1, 'test-cluster', kyvernoScope, kyvernoStatus)
+
+    nockIgnoreRBAC()
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, {})
+        }}
+      >
+        <MemoryRouter
+          initialEntries={[
+            generatePath(NavigationPath.discoveredPolicyDetails, {
+              clusterName: 'test-cluster',
+              apiGroup: 'kyverno.io',
+              apiVersion: 'v1',
+              kind: 'ClusterPolicy',
+              templateName: 'no-vapb-policy',
+              templateNamespace: '',
+            }),
+          ]}
+        >
+          <Routes>
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.discoveredPolicyDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.discoveredPolicyYaml} element={<PolicyTemplateYaml />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForNocks(mcvNocks)
+    await waitForText('Discovered policies')
+    await waitForText('ClusterPolicy details')
+
+    // VAPB row should show dash when no VAPB exists
+    await waitForText('Validating Admission Policy Binding')
+    const vapbRow = screen.getByText('Validating Admission Policy Binding').closest('div')
+    expect(vapbRow?.parentElement).toHaveTextContent('-')
+    // No VAPB link should exist
+    expect(screen.queryByRole('link', { name: /binding/i })).not.toBeInTheDocument()
+  })
+
+  test('Should render Kyverno namespace-scoped Policy page with pol- VAPB naming convention', async () => {
+    ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: undefined, loading: false, error: undefined },
+    ])
+    ;(useSearchResultItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      {
+        data: {
+          searchResult: [
+            {
+              items: [
+                {
+                  _hubClusterResource: 'true',
+                  _uid: 'local-cluster/pol-vapb-uid',
+                  apigroup: 'admissionregistration.k8s.io',
+                  apiversion: 'v1',
+                  cluster: 'local-cluster',
+                  created: '2024-10-28T15:15:59Z',
+                  kind: 'ValidatingAdmissionPolicyBinding',
+                  kind_plural: 'validatingadmissionpolicybindings',
+                  name: 'pol-require-team-label-binding',
+                  policyName: 'pol-require-team-label-binding',
+                  validationActions: 'audit',
+                },
+              ],
+              __typename: 'SearchResult',
+            },
+          ],
+        },
+        loading: false,
+        error: undefined,
+      },
+    ])()
+
+    const kyvernoScope = {
+      name: 'require-team-label',
+      namespace: 'kyverno-test',
+      resource: 'policy.v1.kyverno.io',
+    }
+    const kyvernoStatus = {
+      conditions: [
+        {
+          message: 'Watching resources successfully',
+          reason: 'GetResourceProcessing',
+          status: 'True',
+          type: 'Processing',
+        },
+      ],
+      result: {
+        apiVersion: 'kyverno.io/v1',
+        kind: 'Policy',
+        metadata: {
+          name: 'require-team-label',
+          namespace: 'kyverno-test',
+        },
+        spec: {
+          validationFailureAction: 'Audit',
+          background: true,
+          rules: [
+            {
+              name: 'check-team-label',
+              match: {
+                any: [{ resources: { kinds: ['Pod'] } }],
+              },
+              validate: {
+                message: 'The label `team` is required',
+                pattern: { metadata: { labels: { team: '?*' } } },
+              },
+            },
+          ],
+        },
+      },
+    }
+    mockUuidV4.mockReturnValue(MOCKED_UUID_1)
+    const mcvNocks = nockManagedClusterView(MOCKED_UUID_1, 'test-cluster', kyvernoScope, kyvernoStatus)
+
+    nockIgnoreRBAC()
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, {})
+        }}
+      >
+        <MemoryRouter
+          initialEntries={[
+            generatePath(NavigationPath.discoveredPolicyDetails, {
+              clusterName: 'test-cluster',
+              apiGroup: 'kyverno.io',
+              apiVersion: 'v1',
+              kind: 'Policy',
+              templateName: 'require-team-label',
+              templateNamespace: 'kyverno-test',
+            }),
+          ]}
+        >
+          <Routes>
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.discoveredPolicyDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.discoveredPolicyYaml} element={<PolicyTemplateYaml />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForNocks(mcvNocks)
+    await waitForText('Discovered policies')
+    await waitForText('Policy details')
+
+    // VAPB link should use the pol- naming convention for namespace-scoped Policy
+    expect(screen.getByRole('link', { name: 'pol-require-team-label-binding' })).toBeInTheDocument()
+  })
+
   test('Should render ValidatingAdmissionPolicyBinding with paramRefs successfully', async () => {
     ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
       jest.fn(),
@@ -1813,5 +2141,212 @@ describe('Policy Template Details Page', () => {
     expect(within(parameterTable).queryByText('ValidatingAdmissionPolicy')).not.toBeInTheDocument()
     expect(within(parameterTable).queryByText('Cluster')).not.toBeInTheDocument()
     expect(within(parameterTable).queryByText('ConfigurationPolicy')).not.toBeInTheDocument()
+  })
+})
+
+describe('useFetchVapb hook coverage', () => {
+  beforeEach(() => {
+    mockUuidV4.mockReset()
+    nockIgnoreApiPaths()
+  })
+
+  test('Should compute cpol- VAPB names for Kyverno ClusterPolicy', async () => {
+    const mockGetVapb = jest.fn()
+    ;(useSearchResultItemsLazyQuery as jest.Mock).mockReturnValue([
+      mockGetVapb,
+      { data: undefined, loading: false, error: undefined },
+    ])
+    ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: undefined, loading: false, error: undefined },
+    ])
+
+    const kyvernoScope = {
+      name: 'require-owner-labels',
+      resource: 'clusterpolicy.v1.kyverno.io',
+    }
+    const kyvernoStatus = {
+      conditions: [{ message: 'OK', reason: 'GetResourceProcessing', status: 'True', type: 'Processing' }],
+      result: {
+        apiVersion: 'kyverno.io/v1',
+        kind: 'ClusterPolicy',
+        metadata: { name: 'require-owner-labels' },
+        spec: { rules: [] },
+      },
+    }
+
+    mockUuidV4.mockReturnValue(MOCKED_UUID_1)
+    const mcvNocks = nockManagedClusterView(MOCKED_UUID_1, 'test-cluster', kyvernoScope, kyvernoStatus)
+    nockIgnoreRBAC()
+
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, {})
+        }}
+      >
+        <MemoryRouter
+          initialEntries={[
+            generatePath(NavigationPath.discoveredPolicyDetails, {
+              clusterName: 'test-cluster',
+              apiGroup: 'kyverno.io',
+              apiVersion: 'v1',
+              kind: 'ClusterPolicy',
+              templateName: 'require-owner-labels',
+              templateNamespace: '',
+            }),
+          ]}
+        >
+          <Routes>
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.discoveredPolicyDetails} element={<PolicyTemplateDetails />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForNocks(mcvNocks)
+    await waitForText('ClusterPolicy details')
+
+    await waitFor(() => {
+      expect(mockGetVapb).toHaveBeenCalled()
+    })
+
+    const callArgs = mockGetVapb.mock.calls[0][0]
+    const nameFilter = callArgs.variables.input[0].filters.find((f: any) => f.property === 'name')
+    expect(nameFilter.values).toEqual(['cpol-require-owner-labels-binding', 'require-owner-labels-binding'])
+  })
+
+  test('Should compute pol- VAPB names for Kyverno namespace-scoped Policy', async () => {
+    const mockGetVapb = jest.fn()
+    ;(useSearchResultItemsLazyQuery as jest.Mock).mockReturnValue([
+      mockGetVapb,
+      { data: undefined, loading: false, error: undefined },
+    ])
+    ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: undefined, loading: false, error: undefined },
+    ])
+
+    const kyvernoScope = {
+      name: 'require-team-label',
+      namespace: 'kyverno-test',
+      resource: 'policy.v1.kyverno.io',
+    }
+    const kyvernoStatus = {
+      conditions: [{ message: 'OK', reason: 'GetResourceProcessing', status: 'True', type: 'Processing' }],
+      result: {
+        apiVersion: 'kyverno.io/v1',
+        kind: 'Policy',
+        metadata: { name: 'require-team-label', namespace: 'kyverno-test' },
+        spec: { rules: [] },
+      },
+    }
+
+    mockUuidV4.mockReturnValue(MOCKED_UUID_1)
+    const mcvNocks = nockManagedClusterView(MOCKED_UUID_1, 'test-cluster', kyvernoScope, kyvernoStatus)
+    nockIgnoreRBAC()
+
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, {})
+        }}
+      >
+        <MemoryRouter
+          initialEntries={[
+            generatePath(NavigationPath.discoveredPolicyDetails, {
+              clusterName: 'test-cluster',
+              apiGroup: 'kyverno.io',
+              apiVersion: 'v1',
+              kind: 'Policy',
+              templateName: 'require-team-label',
+              templateNamespace: 'kyverno-test',
+            }),
+          ]}
+        >
+          <Routes>
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.discoveredPolicyDetails} element={<PolicyTemplateDetails />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForNocks(mcvNocks)
+    await waitForText('Policy details')
+
+    await waitFor(() => {
+      expect(mockGetVapb).toHaveBeenCalled()
+    })
+
+    const callArgs = mockGetVapb.mock.calls[0][0]
+    const nameFilter = callArgs.variables.input[0].filters.find((f: any) => f.property === 'name')
+    expect(nameFilter.values).toEqual(['pol-require-team-label-binding', 'require-team-label-binding'])
+  })
+
+  test('Should compute gatekeeper- VAPB names for Gatekeeper constraint', async () => {
+    const mockGetVapb = jest.fn()
+    ;(useSearchResultItemsLazyQuery as jest.Mock).mockReturnValue([
+      mockGetVapb,
+      { data: undefined, loading: false, error: undefined },
+    ])
+    ;(useSearchResultRelatedItemsLazyQuery as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { data: undefined, loading: false, error: undefined },
+    ])
+
+    const gkScope = {
+      name: 'ns-must-have-gk',
+      resource: 'k8srequiredlabels.v1beta1.constraints.gatekeeper.sh',
+    }
+    const gkStatus = {
+      conditions: [{ message: 'OK', reason: 'GetResourceProcessing', status: 'True', type: 'Processing' }],
+      result: {
+        apiVersion: 'constraints.gatekeeper.sh/v1beta1',
+        kind: 'K8sRequiredLabels',
+        metadata: { name: 'ns-must-have-gk' },
+        spec: { enforcementAction: 'warn' },
+        status: { totalViolations: 0 },
+      },
+    }
+
+    const canUserCreateMCVNock = nockCreate(getCanUserCreateMCVReq, getCanUserCreateMCVRes)
+    mockUuidV4.mockReturnValue(MOCKED_UUID_1)
+    const mcvNocks = nockManagedClusterView(MOCKED_UUID_1, 'test-cluster', gkScope, gkStatus)
+
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, {})
+        }}
+      >
+        <MemoryRouter
+          initialEntries={[
+            '/multicloud/governance/policies/details/test/parent-policy/template/test-cluster/' +
+              'constraints.gatekeeper.sh/v1beta1/K8sRequiredLabels/ns-must-have-gk',
+          ]}
+        >
+          <Routes>
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForNocks([canUserCreateMCVNock, ...mcvNocks])
+    await waitForText('K8sRequiredLabels details')
+
+    await waitFor(() => {
+      expect(mockGetVapb).toHaveBeenCalled()
+    })
+
+    const callArgs = mockGetVapb.mock.calls[0][0]
+    const nameFilter = callArgs.variables.input[0].filters.find((f: any) => f.property === 'name')
+    expect(nameFilter.values).toEqual(['gatekeeper-k8srequiredlabels-ns-must-have-gk'])
   })
 })

--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -11,6 +11,7 @@ KUBEVIRT_PORT=${KUBEVIRT_PORT:=""}
 ODF_PORT=${ODF_PORT:=""}
 GITOPS_PORT=${GITOPS_PORT:=""}
 CONSOLE_IMAGE="quay.io/openshift/origin-console:${CONSOLE_VERSION}"
+PIPELINES_PORT=${PIPELINES_PORT:=""}
 
 mkdir -p ocp-console
 oc extract secret/off-cluster-token -n openshift-console --to ocp-console --confirm


### PR DESCRIPTION
Resolves [ACM-35631](https://issues.redhat.com/browse/ACM-35631)

## Summary

- **Fix VAPB link resolution** for Kyverno v1.17.2+ which changed the ValidatingAdmissionPolicyBinding naming from `{name}-binding` to `cpol-{name}-binding` (ClusterPolicy) / `pol-{name}-binding` (Policy)
- **Search for both naming conventions** in `useFetchVapb()` for backward compatibility with older Kyverno versions
- **Use actual VAPB name from search results** in `addRowsForHasVapb()` instead of re-computing it, which is more correct regardless of naming convention

## How to test

> **Note:** Prerequisites for test cases 1, 3, 4, and 5 have been set up on the `weekly` cluster (`cs-aws-50-qnxxc`). Kyverno v1.17.2 and Gatekeeper are installed, and all test policies/constraints are created. Test case 2 (old Kyverno naming) requires a cluster with Kyverno < v1.17 and is covered by unit tests.

### Prerequisites
- Access to an ACM hub cluster with Search enabled
- A managed cluster with Kyverno v1.17.2+ installed
- (Optional) A managed cluster with Gatekeeper for regression testing

### Setup: Install Kyverno and create a test ClusterPolicy

```bash
# On a managed cluster
helm repo add kyverno https://kyverno.github.io/kyverno/ && helm repo update

# Apply CRDs (ACM manages shared CRDs, so --server-side --force-conflicts is required)
helm template kyverno kyverno/kyverno --version 3.7.2 --include-crds | \
  python3 -c "
import sys, yaml
for doc in yaml.safe_load_all(sys.stdin):
    if doc and doc.get('kind') == 'CustomResourceDefinition':
        name = doc.get('metadata', {}).get('name', '')
        if name == 'policyreports.wgpolicyk8s.io':
            continue
        print('---')
        print(yaml.dump(doc))
" | oc apply --server-side --force-conflicts -f -

# Install Kyverno
helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace \
  --set crds.install=false --version 3.7.2
```

Create a ClusterPolicy with CEL/VAP generation:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-owner-labels
spec:
  validationFailureAction: Audit
  background: false
  rules:
    - name: check-owner-label
      match:
        any:
          - resources:
              kinds:
                - Pod
      validate:
        cel:
          generate: true
          expressions:
            - expression: "has(object.metadata.labels) && 'owner' in object.metadata.labels"
              message: "All Pods must have an 'owner' label."
```

Verify the VAPB was generated:
```bash
oc get validatingadmissionpolicybindings | grep require-owner-labels
# Expected: cpol-require-owner-labels-binding
```

### Test cases

| # | Scenario | Resource | Steps | Expected |
|---|----------|----------|-------|----------|
| 1 | **ClusterPolicy VAPB — new Kyverno (cpol- prefix)** | ClusterPolicy `require-owner-labels` | Navigate to Governance > Discovered policies > click the ClusterPolicy | VAPB row shows clickable link `cpol-require-owner-labels-binding` |
| 2 | **ClusterPolicy VAPB — old Kyverno (no prefix)** | ClusterPolicy on Kyverno < v1.17 | Same as above, on a cluster running Kyverno < v1.17 | Link shows `require-owner-labels-binding` (old convention) |
| 3 | **Gatekeeper constraint VAPB (regression)** | K8sRequiredLabels `ns-must-have-gk` | Navigate to Governance > Discovered policies > click the Gatekeeper constraint | VAPB row shows clickable link `gatekeeper-k8srequiredlabels-ns-must-have-gk` |
| 4 | **ClusterPolicy without VAP generation** | ClusterPolicy `require-app-label` | Navigate to Governance > Discovered policies > click the ClusterPolicy | Row shows `-` (dash), no broken link |
| 5 | **Namespace-scoped Policy** | Policy `require-team-label` in `kyverno-test` | Navigate to Governance > Discovered policies > click the Policy | Row shows `-` (Kyverno v1.17.2 doesn't generate VAPBs for namespace-scoped policies) |


_____

Snapshots per test case:
1. http://localhost:9000/multicloud/governance/discovered/kyverno.io/v1/ClusterPolicy/require-owner-labels/weekly/detail
<img width="1176" height="397" alt="Screenshot 2026-07-08 at 7 27 30 PM" src="https://github.com/user-attachments/assets/84e5ab9b-b347-4adb-a558-64d7873976f1" />

2. N/A
3. http://localhost:9000/multicloud/governance/discovered/constraints.gatekeeper.sh/v1beta1/K8sRequiredLabels/ns-must-have-gk/weekly/detail
<img width="1672" height="437" alt="Screenshot 2026-07-08 at 7 38 29 PM" src="https://github.com/user-attachments/assets/879c839e-4a15-4625-8c85-addd09eed45f" />

4. http://localhost:9000/multicloud/governance/discovered/kyverno.io/v1/ClusterPolicy/require-app-label/weekly/detail
<img width="1675" height="382" alt="Screenshot 2026-07-08 at 7 39 19 PM" src="https://github.com/user-attachments/assets/148e7ba0-5e5f-425b-9d80-9f53e613052d" />

5. http://localhost:9000/multicloud/governance/discovered/kyverno.io/v1/Policy/require-team-label/kyverno-test/weekly/detail
<img width="1664" height="416" alt="Screenshot 2026-07-08 at 7 41 15 PM" src="https://github.com/user-attachments/assets/83a86d27-0e6b-46cb-9dfd-d167e3dac82d" />

### Unit tests

```bash
cd frontend
npx jest --config jest.config.ts "PolicyTemplateDetailsPage.test"
```

## Test plan

- [x] Unit tests pass (18/18 in `PolicyTemplateDetailsPage.test.tsx`)
- [x] New test: ClusterPolicy with `cpol-` VAPB naming convention
- [x] New test: ClusterPolicy with no VAPB (dash renders)
- [x] New test: Namespace-scoped Policy with `pol-` VAPB naming convention
- [x] New test: Hook coverage for `useFetchVapb()` useEffect body (3 tests)
- [x] Existing test: Gatekeeper `gatekeeper-` VAPB naming (regression)
- [x] Existing test: Kyverno ClusterPolicy with old `{name}-binding` naming (backward compat)
- [x] Manual testing on two clusters with Kyverno v1.17.2 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Policy Template Details so VAPB/binding links resolve consistently for Gatekeeper and Kyverno, including correct handling when multiple candidates are possible and when switching policy kind.
  * Prevented a potential runtime error when filtering placeholder applications with missing labels.
  * Made pipelines support optional in the console launcher when the pipelines port is not set.
* **Tests**
  * Expanded Policy Template Details and VAPB hook coverage for Gatekeeper/Kyverno naming conventions and missing-binding states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-35631]: https://redhat.atlassian.net/browse/ACM-35631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ