### PR TITLE
ACM-34696-Show-hook-status-on-cluster-details-page-for-HCP-cluster-provision-update-with-automation-templates

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
@@ -31,6 +31,7 @@ import {
   SecretApiVersion,
   SecretKind,
 } from '../../../../../../resources'
+import { ClusterStatus } from '../../../../../../resources/utils'
 import { HypershiftImportCommand } from '../../components/HypershiftImportCommand'
 import {
   mockAWSHostedCluster,
@@ -911,5 +912,94 @@ describe('ClusterOverview automation template', () => {
 
     await waitForText(mockCluster.name)
     expect(screen.queryByText('View template')).not.toBeInTheDocument()
+  })
+})
+
+describe('ClusterOverview hypershift hook status', () => {
+  const hypershiftClusterCurator: ClusterCurator = {
+    apiVersion: ClusterCuratorApiVersion,
+    kind: ClusterCuratorKind,
+    metadata: {
+      name: mockAWSHypershiftCluster.name,
+      namespace: mockAWSHypershiftCluster.namespace,
+    },
+    spec: {
+      desiredCuration: 'install',
+      install: {
+        prehook: [{ name: 'prehook-ansible-job', extra_vars: {} }],
+        posthook: [{ name: 'posthook-ansible-job', extra_vars: {} }],
+        towerAuthSecret: 'ansible-cred',
+      },
+    },
+  }
+
+  const renderHypershiftOverview = (cluster: typeof mockAWSHypershiftCluster, clusterCurator?: ClusterCurator) => {
+    const context: Partial<ClusterDetailsContext> = {
+      cluster,
+      hostedCluster: mockAWSHostedCluster,
+      clusterCurator,
+      canGetSecret: true,
+    }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policyreportState, [])
+          snapshot.set(managedClustersState, [])
+          snapshot.set(clusterDeploymentsState, [])
+          snapshot.set(managedClusterInfosState, [])
+          snapshot.set(certificateSigningRequestsState, [])
+          snapshot.set(managedClusterAddonsState, {})
+          snapshot.set(clusterManagementAddonsState, [])
+          snapshot.set(clusterClaimsState, [])
+          snapshot.set(clusterCuratorsState, clusterCurator ? [clusterCurator] : [])
+          snapshot.set(agentClusterInstallsState, [])
+          snapshot.set(agentsState, [])
+          snapshot.set(infraEnvironmentsState, [])
+          snapshot.set(hostedClustersState, [mockAWSHostedCluster])
+          snapshot.set(nodePoolsState, [])
+        }}
+      >
+        <MemoryRouter>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<ClusterOverviewPageContent />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+  }
+
+  beforeEach(() => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+  })
+
+  it('should display provision hook progress for hypershift clusters', async () => {
+    const clusterWithPrehook = {
+      ...mockAWSHypershiftCluster,
+      status: ClusterStatus.prehookjob,
+      hasAutomationTemplate: true,
+      isCurator: true,
+    }
+    renderHypershiftOverview(clusterWithPrehook, hypershiftClusterCurator)
+
+    await waitForText('Creating cluster')
+    expect(screen.getAllByText('Prehook').length).toBeGreaterThan(0)
+    await waitForText('Control plane status')
+  })
+
+  it('should display automation template for hypershift clusters with automation', async () => {
+    nockAggegateRequest('statuses', statusAggregate.req, statusAggregate.res)
+    const clusterWithAutomation = {
+      ...mockAWSHypershiftCluster,
+      hasAutomationTemplate: true,
+      isCurator: true,
+    }
+    renderHypershiftOverview(clusterWithAutomation, hypershiftClusterCurator)
+
+    await waitForText(mockAWSHypershiftCluster.name)
+    await waitForText('Automation template')
+    await waitForText('View template')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -380,9 +380,8 @@ export function ClusterOverviewPageContent() {
       ? getAIClusterProperties(clusterDeployment, agentClusterInstall)
       : [
           ...clusterClaimedBySetPool,
-          ...(!cluster?.isHypershift &&
-          (cluster?.hasAutomationTemplate ||
-            (cluster && clusterSupportsAction(cluster, ClusterAction.UpdateAutomationTemplate)))
+          ...(cluster?.hasAutomationTemplate ||
+          (cluster && clusterSupportsAction(cluster, ClusterAction.UpdateAutomationTemplate))
             ? [clusterProperties.automationTemplate]
             : []),
         ]),
@@ -404,11 +403,25 @@ export function ClusterOverviewPageContent() {
 
   let details = <ProgressStepBar />
   if (cluster?.isHypershift) {
-    details = <HypershiftClusterDetails handleModalToggle={handleModalToggle} />
+    // ProgressStepBar shows ClusterCurator install pre/post hook status (pending, running, succeeded,
+    // failed) and log links—the same visibility standalone OCP clusters already have. HypershiftClusterDetails
+    // only covers control plane and node pool progress. ProgressStepBar renders null when not in an install
+    // hook flow, so ready clusters are unaffected. Upgrade hook status is shown in DistributionField.
+    details = (
+      <>
+        <ProgressStepBar />
+        <HypershiftClusterDetails handleModalToggle={handleModalToggle} />
+      </>
+    )
   }
   if (cluster?.provider && [Provider.hostinventory, Provider.nutanix].includes(cluster.provider)) {
     if (cluster.isHypershift) {
-      details = <AIHypershiftClusterDetails />
+      details = (
+        <>
+          <ProgressStepBar />
+          <AIHypershiftClusterDetails />
+        </>
+      )
     } else if (clusterDeployment) {
       // Do not display alert or AIClusterDetails for imported Nutanix clusters (will not have a ClusterDeployment)
       if (!agentClusterInstall) {


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hypershift cluster details now show the provisioning progress bar alongside other cluster information.
  * Automation template information is now visible for hypershift clusters when available, with a direct view option.

* **Bug Fixes**
  * Improved hypershift overview behavior so cluster status and automation details display consistently.
  * Expanded test coverage for hypershift cluster status and automation template scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->