### PR TITLE
Fix TypeError when ApplicationSet has no labels

### DIFF
--- a/backend/src/routes/aggregators/applicationsArgo.ts
+++ b/backend/src/routes/aggregators/applicationsArgo.ts
@@ -582,7 +582,7 @@ export function createArgoStatusMap(searchResult: SearchResult, clusters: Cluste
       appKey = `appset/${appName}`
     } else if (app.applicationSet) {
       // don't count the placeholder app on the hub for this pulled appset
-      if (!app.label.includes('apps.open-cluster-management.io/pull-to-ocm-managed-cluster=true')) {
+      if (!app.label?.includes('apps.open-cluster-management.io/pull-to-ocm-managed-cluster=true')) {
         appName = `${app.namespace}/${app.applicationSet}`
         appKey = `appset/${appName}`
         const namePart = app.name.startsWith(app.applicationSet)


### PR DESCRIPTION
When an ArgoCD ApplicationSet without Kubernetes labels is indexed by Search, app.label is undefined causing aggregateRemoteApplications() to crash with TypeError: Cannot read properties of undefined.

Add optional chaining to handle missing labels gracefully.

Type of Change: Bug Fix

Fix: backend/src/routes/aggregators/applicationsArgo.ts line 585
~~~
- if (!app.label.includes('apps.open-cluster-management.io/pull-to-ocm-managed-cluster=true')) {
+ if (!app.label?.includes('apps.open-cluster-management.io/pull-to-ocm-managed-cluster=true')) {
~~~

Notes for Reviewers:
One-character fix - adds optional chaining (?.) to app.label before calling .includes().
When Search API returns an ApplicationSet without labels, app.label is undefined.
Without the null check, the TypeError aborts aggregateRemoteApplications() and all
remote ArgoCD applications disappear from the Applications Overview.

Customer confirmed the fix approach works - adding any label to the ApplicationSet
restores functionality, proving the null label is the trigger.

JIRA: https://redhat.atlassian.net/browse/ACM-36928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status counting so apps without labels are handled safely instead of causing an error.
  * Placeholder apps are now skipped more reliably when their identifying label is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->