### PR TITLE
chore: Instruct renovate to update package.json as well as package-lock.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   ],
   "schedule": ["every weekend"],
   "timezone": "America/New_York",
+  "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": false
   },


### PR DESCRIPTION
Tells Renovate to bump the version in package.json when the new version is within the existing range (e.g., ^5.107.2 → ^5.108.3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to use a version-bump strategy for future upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->