### PR TITLE
Ignore placement debug for this test

### DIFF
--- a/frontend/src/wizards/Governance/Policy/policyWizard.test.tsx
+++ b/frontend/src/wizards/Governance/Policy/policyWizard.test.tsx
@@ -330,6 +330,7 @@ describe('Policy wizard', () => {
   })
 
   test('default tolerations persist after switching to existing and back to new placement', async () => {
+    nockIgnorePlacementDebug()
     render(<TestPolicyWizard yamlEditor={() => <WizardSyncEditor />} />)
 
     const nameTextbox = screen.getByRole('textbox', { name: /name/i })


### PR DESCRIPTION
Seeing this failure frequently on PRs:

```
[frontend] FAIL src/wizards/Governance/Policy/policyWizard.test.tsx (48.527 s)
[frontend]   ● Policy wizard › default tolerations persist after switching to existing and back to new placement
[frontend] 
[frontend] 
[frontend] 
[frontend]     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[frontend]     !!!!!!!!!!!!!!!! MISSING NOCK(S) !!!!!!!!!!!!!!!!!!!!!!!!
[frontend] 
[frontend]      there was no nocks that matched these request(s):
[frontend] 
[frontend] 
[frontend]     //---create ---
[frontend]     const createUnknown1 = { req: {} }
[frontend] 
[frontend] 
[frontend] 
[frontend]         nockCreate(createUnknown1.req, createUnknown1.res)    // create
[frontend] 
[frontend]       229 | async function setupAfterEach(): Promise<void> {
[frontend]       230 |   await new Promise((resolve) => setTimeout(resolve, 100))
[frontend]     > 231 |   expect(missingNocks).hasNoMissingNocks()
[frontend]           |                        ^
[frontend]       232 |   expect(missingNocks).hasNoPendingNocks()
[frontend]       233 | }
[frontend]       234 |
[frontend] 
[frontend]       at Object.setupAfterEach (src/setupTests.ts:231:24)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a wizard test setup to include the same placement-related mock configuration used by nearby tests, improving consistency and stability of the test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->