### PR TITLE
[ACM-37130] Fix Overview page secondary nav tab alignment

### DIFF
--- a/frontend/src/routes/Home/Overview/Overview.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.tsx
@@ -58,11 +58,6 @@ export default function Overview() {
               usePageInsets
               aria-label={t('Overview page navigation tabs')}
               role="region"
-              style={{
-                // match page section padding inset
-                paddingInlineStart:
-                  'calc(var(--pf-v6-c-page__main-section--PaddingInlineStart) - var(--pf-v6-c-page__main-container--BorderWidth))',
-              }}
             >
               {tabItems.map((tab) => (
                 <Tab


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Secondary nav tab items in the Overview Page have incorrect styling. This change removes the overriding style so the navigation tabs match the styling on all other pages.
<img width="712" height="393" alt="Screenshot 2026-07-10 at 4 26 44 PM" src="https://github.com/user-attachments/assets/e8f0a68f-4fd0-4b21-8a7a-7164071c067c" />


**Ticket Link:**  
https://issues.redhat.com/browse/ACM-37130

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab layout consistency by removing an unnecessary padding override.
  * Tabs now rely on the page’s existing inset handling for alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->