### PR TITLE
Group Renovate npm dependency updates by category

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,76 @@
       ],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
+    },
+    {
+      "description": "Group all @types/* packages into a single PR",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/**"],
+      "groupName": "type definitions",
+      "groupSlug": "types"
+    },
+    {
+      "description": "Group ESLint ecosystem packages into a single PR",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "eslint",
+        "@eslint/**",
+        "@typescript-eslint/**",
+        "eslint-*"
+      ],
+      "groupName": "eslint packages",
+      "groupSlug": "eslint"
+    },
+    {
+      "description": "Group webpack and build tooling packages into a single PR",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "webpack",
+        "webpack-*",
+        "*-webpack-plugin",
+        "*-loader",
+        "@svgr/webpack",
+        "@pmmmwh/react-refresh-webpack-plugin",
+        "fork-ts-checker-webpack-plugin",
+        "monaco-editor-webpack-plugin",
+        "mini-css-extract-plugin",
+        "copy-webpack-plugin"
+      ],
+      "groupName": "build tools",
+      "groupSlug": "build-tools"
+    },
+    {
+      "description": "Group Babel packages into a single PR",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@babel/**", "babel-*"],
+      "groupName": "babel packages",
+      "groupSlug": "babel"
+    },
+    {
+      "description": "Group test framework packages into a single PR",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "jest",
+        "jest-*",
+        "@jest/**",
+        "@testing-library/**",
+        "@cypress/**",
+        "cypress",
+        "jest-axe",
+        "nock"
+      ],
+      "groupName": "test frameworks",
+      "groupSlug": "test-frameworks"
+    },
+    {
+      "description": "Group PatternFly packages into a single PR",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@patternfly/**",
+        "@patternfly-labs/**"
+      ],
+      "groupName": "patternfly packages",
+      "groupSlug": "patternfly"
     }
   ]
 }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Group Renovate npm dependency updates by category to reduce PR volume

**Ticket Link:**  
N/A — process improvement

**Type of Change:**  
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [x] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## What this does

Adds `packageRules` grouping to `renovate.json` so that related dependency updates are combined into single PRs instead of individual ones.

### Groups added

| Group | Packages | Effect |
|---|---|---|
| **type definitions** | `@types/*` | All type definition updates in 1 PR |
| **eslint packages** | `eslint`, `@eslint/*`, `@typescript-eslint/*`, `eslint-*` | All linting updates in 1 PR |
| **build tools** | `webpack`, `*-loader`, `*-webpack-plugin`, related plugins | All build tooling in 1 PR |
| **babel packages** | `@babel/*`, `babel-*` | All Babel updates in 1 PR |
| **test frameworks** | `jest`, `jest-*`, `@testing-library/*`, `@cypress/*`, `cypress`, `nock` | All test tooling in 1 PR |
| **patternfly packages** | `@patternfly/*`, `@patternfly-labs/*` | All PatternFly UI updates in 1 PR |

### Impact

Based on this week's batch: **18 individual PRs → ~8 PRs**, eliminating lockfile conflicts between related packages and simplifying review.

Packages not matching any group (e.g., `validator`, `simple-git`, `react-tagsinput`) will continue to get individual PRs.

---

## ✅ Checklist

### General

- [x] PR title follows the convention
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [N/A] All new display strings are externalized for localization

---

### 🗒️ Notes for Reviewers

This only changes Renovate's behavior for future PR creation — no code changes. The grouping rules use Renovate's `matchPackageNames` glob patterns and `groupName`/`groupSlug` to combine related updates. All existing rules (npm-only on main, no majors, SDK patch-only, storybook/monaco ignore) are preserved unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates are now grouped by category, including type definitions, linting, build tools, Babel, testing frameworks, and PatternFly packages.
  * Related updates will be consolidated into fewer, more focused update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->