### PR TITLE
fix(AcmSelectBase): fix dropdown border overlapping chips in typeaheadMulti (ACM-37276)

### DIFF
--- a/frontend/src/components/AcmSelectBase.tsx
+++ b/frontend/src/components/AcmSelectBase.tsx
@@ -110,6 +110,12 @@ const menuToggleClass = css`
   }
 `
 
+const typeaheadMultiToggleClass = css`
+  &::before {
+    border-radius: 6px !important;
+  }
+`
+
 interface ICheckboxChildren {
   hasCheckbox?: boolean
   isSelected?: boolean
@@ -653,7 +659,7 @@ export function AcmSelectBase(props: AcmSelectBaseProps) {
           )
         }
         isExpanded={isOpen}
-        className={menuToggleClass}
+        className={`${menuToggleClass}${variant === SelectVariant.typeaheadMulti ? ` ${typeaheadMultiToggleClass}` : ''}`}
         style={
           {
             width: width ?? '100%',
@@ -698,7 +704,10 @@ export function AcmSelectBase(props: AcmSelectBaseProps) {
         ? initialFilteredOptions.find((option) => option.value === selectedItem)?.children
         : inputValue
     return (
-      <TextInputGroup isPlain>
+      <TextInputGroup
+        isPlain
+        style={variant === SelectVariant.typeaheadMulti && selectedItems.length > 0 ? { padding: '4px' } : undefined}
+      >
         <TextInputGroupMain
           value={value}
           onClick={onInputClick}

--- a/frontend/src/ui-components/AcmMultiSelect/AcmMultiSelect.test.tsx
+++ b/frontend/src/ui-components/AcmMultiSelect/AcmMultiSelect.test.tsx
@@ -198,6 +198,62 @@ describe('AcmMultiSelect', () => {
     expect(getByText('ACM select')).toBeInTheDocument()
   })
 
+  test('applies padding to TextInputGroup when typeaheadMulti has selected items (ACM-37276)', () => {
+    const TypeaheadMultiSelect = () => {
+      const [value, setValue] = useState<string[] | undefined>(['red', 'green'])
+      return (
+        <AcmMultiSelect
+          id="acm-select-padding"
+          label="ACM select padding"
+          value={value}
+          onChange={setValue}
+          variant={SelectVariant.typeaheadMulti}
+        >
+          <SelectOption key="red" value="red">
+            Red
+          </SelectOption>
+          <SelectOption key="green" value="green">
+            Green
+          </SelectOption>
+        </AcmMultiSelect>
+      )
+    }
+
+    const { container } = render(<TypeaheadMultiSelect />)
+
+    const textInputGroup = container.querySelector('.pf-v6-c-text-input-group')
+    expect(textInputGroup).toBeInTheDocument()
+    expect(textInputGroup).toHaveStyle('padding: 4px')
+  })
+
+  test('does not apply padding to TextInputGroup when typeaheadMulti has no selected items (ACM-37276)', () => {
+    const TypeaheadMultiSelect = () => {
+      const [value, setValue] = useState<string[] | undefined>([])
+      return (
+        <AcmMultiSelect
+          id="acm-select-no-padding"
+          label="ACM select no padding"
+          value={value}
+          onChange={setValue}
+          variant={SelectVariant.typeaheadMulti}
+        >
+          <SelectOption key="red" value="red">
+            Red
+          </SelectOption>
+          <SelectOption key="green" value="green">
+            Green
+          </SelectOption>
+        </AcmMultiSelect>
+      )
+    }
+
+    const { container } = render(<TypeaheadMultiSelect />)
+
+    const textInputGroup = container.querySelector('.pf-v6-c-text-input-group')
+    expect(textInputGroup).toBeInTheDocument()
+    expect(textInputGroup).not.toHaveStyle('padding: 4px')
+  })
+
   test('does not apply maxHeight on MenuToggle for typeaheadMulti variant', () => {
     const TypeaheadMultiSelect = () => {
       const [value, setValue] = useState<string[] | undefined>(['red', 'green'])


### PR DESCRIPTION
## Root Cause Analysis

**Bug:** ClusterSet page "Edit namespace bindings" modal dropdown border overlaps with namespace chips and search textbox when many namespaces are selected.

**Root cause:** The PF6 `MenuToggle` component's `::before` pseudo-element uses `border-radius: 999px` (pill shape) with `position: absolute; inset: 0px`. When the typeaheadMulti variant grows vertically with multiple rows of chips, the extreme pill curve clips through corner chips. Additionally, the `TextInputGroup` with `isPlain` has no padding, so content sits flush against the border edges.

**Affected file:** `frontend/src/components/AcmSelectBase.tsx`

## Fix

Two minimal changes in `AcmSelectBase.tsx`:

1. **New `typeaheadMultiToggleClass`** — Overrides the `::before` pseudo-element's `border-radius` from `999px` to `6px` for the typeaheadMulti variant, preventing the extreme pill curve from clipping through chips at corners
2. **Conditional padding on `TextInputGroup`** — Adds `padding: 4px` when the typeaheadMulti variant has selected items, creating breathing room between content and the border

## Regression Tests

Two tests added to `AcmMultiSelect.test.tsx`:
- Verifies padding IS applied when typeaheadMulti has selected items
- Verifies padding is NOT applied when typeaheadMulti has no selected items

## How to Test

1. Go to Infrastructure → Clusters → Cluster sets tab
2. Click the kebab menu on a cluster set row → "Edit namespace bindings"
3. Select 10+ namespaces from the dropdown
4. Click the "N more" button to expand all chips
5. **Expected:** The dropdown border does not overlap with any namespace chips or the search textbox. The border has standard rounded corners (not pill-shaped).

## Validation

- [x] `npm run check:fix` passes
- [x] `npm test` passes (487 suites, 5553 tests, 0 failures)
- [x] Browser verification with Playwriter confirms fix

Fixes: https://issues.redhat.com/browse/ACM-37276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the multi-select typeahead layout when items are selected.
  * Adjusted toggle borders and input spacing for a cleaner, more consistent appearance.

* **Tests**
  * Added coverage verifying spacing behavior with and without selected items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->