### PR TITLE
ACM-37149 Applications Advanced configuration empty state has incorrect background color

### DIFF
--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -1066,11 +1066,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         </PageSection>
       ) : items.length === 0 && !emptyResult ? (
         props.emptyState && (
-          <PageSection
-            hasBodyWrapper={false}
-            variant={props.extraToolbarControls ? 'secondary' : 'default'}
-            padding={{ default: 'noPadding' }}
-          >
+          <PageSection hasBodyWrapper={false} variant="default" padding={{ default: 'noPadding' }}>
             {props.emptyState}
           </PageSection>
         )


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Fix incorrect background color in Applications Advanced configuration empty state

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://redhat.atlassian.net/browse/ACM-37149

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->
Before:
<img width="1232" height="721" alt="Снимок экрана — 2026-07-15 в 10 46 23 AM" src="https://github.com/user-attachments/assets/bc40951c-c1f8-45b4-9928-aa30baebc704" />

After:
<img width="1221" height="714" alt="Снимок экрана — 2026-07-15 в 12 50 32 AM" src="https://github.com/user-attachments/assets/a0a93026-b2d7-4f67-8f71-610ddcc31588" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the table’s empty-state display by ensuring it consistently uses the default section styling when no results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->