### PR TITLE
fix(topology): show matched clusters on appset placement pod (ACM-37230)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ frontend/packages/react-form-wizard/lib/
 .DS_Store
 
 #ai related files
+.cursor/
 .claude
 test-results
 playwright.config.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,10 @@ All source files must start with the copyright header:
 
 The same codebase builds images for ACM (`release-*` branches) and MCE (`backplane-*` branches). The build system automatically fast-forwards commits between paired branches. See the "Active Release Branches" section in `README.md` for the current branch chains. Pull requests should target the first branch in each chain, which is `main` for the current release. Never open a PR directly against a `backplane-*` branch. 
 
+## Best practices
+
+- **Import shorthand** — When adding an import, use ~/ instead of ../../
+
 ## Feature Flags
 
 Features can be enabled/disabled via the `console-config` ConfigMap in the installation namespace. Flags are defined in `frontend/src/utils/flags/consts.ts`.

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.test.ts
@@ -575,6 +575,60 @@ describe('NodeDetailsProvider', () => {
       nodeDetailsProvider(placementNode, mockActiveFilters, t, mockHubClusterName)
       expect(mockGetMatchLabels).toHaveBeenCalled()
     })
+
+    it('should show numberOfSelectedClusters for placement nodes without decisions (ACM-37230)', () => {
+      const placementNode = {
+        type: 'placement',
+        name: 'appset-placement',
+        clusterName: 'hub',
+        layout: { type: 'placement' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: {
+            apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+            kind: 'Placement',
+            metadata: { name: 'appset-placement' },
+            status: { numberOfSelectedClusters: 3 },
+          },
+        },
+        placement: {
+          kind: 'Placement',
+          spec: { clusterSets: ['dev'] },
+        },
+      }
+
+      const result = nodeDetailsProvider(placementNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Matched Clusters', 3)).toBe(true)
+    })
+
+    it('should show decisions length for placementDecision nodes (ACM-37230)', () => {
+      const placementDecisionNode = {
+        type: 'placementDecision',
+        name: 'appset-placement-decision',
+        clusterName: 'hub',
+        layout: { type: 'placementDecision' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: {
+            apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+            kind: 'PlacementDecision',
+            metadata: { name: 'appset-placement-decision' },
+            status: {
+              decisions: [{ clusterName: 'c1' }, { clusterName: 'c2' }],
+            },
+          },
+        },
+        placementDecision: {
+          kind: 'PlacementDecision',
+          spec: { clusterSelector: { matchLabels: { env: 'prod' } } },
+        },
+      }
+
+      const result = nodeDetailsProvider(placementDecisionNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Matched Clusters', 2)).toBe(true)
+    })
   })
 
   describe('kubeNaming', () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.test.ts
@@ -629,6 +629,223 @@ describe('NodeDetailsProvider', () => {
       const result = nodeDetailsProvider(placementDecisionNode, mockActiveFilters, t, mockHubClusterName)
       expect(detail(result, 'Matched Clusters', 2)).toBe(true)
     })
+
+    it('should default labels to empty when node.labels is omitted', () => {
+      const clusterNode = { type: 'cluster' }
+      const result = nodeDetailsProvider(clusterNode, mockActiveFilters, t, mockHubClusterName)
+      expect(result).toHaveLength(3)
+      expect(
+        result.some(
+          (d) =>
+            (d as { type?: string; labelValue?: string }).type === 'label' &&
+            (d as { labelValue: string }).labelValue === 'Labels'
+        )
+      ).toBe(false)
+    })
+
+    it('should use empty package name when metadata.name is missing', () => {
+      const packageNode = {
+        type: 'package',
+        labels: [],
+        specs: { raw: { metadata: {} } },
+      }
+      const result = nodeDetailsProvider(packageNode, mockActiveFilters, t, mockHubClusterName)
+      expect(result).toContainEqual({
+        type: 'label',
+        labelValue: 'resource.name',
+        value: '',
+      })
+    })
+
+    it('should default layout to empty object and fall back Type to node type', () => {
+      const deploymentNode = {
+        type: 'deployment',
+        name: 'd1',
+        namespace: 'ns1',
+        // no layout — exercises layout = {}
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: { metadata: { name: 'd1' } },
+        },
+      }
+      const result = nodeDetailsProvider(deploymentNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Type', 'Deployment')).toBe(true)
+    })
+
+    it('should join multiple namespaces from the kind model', () => {
+      const deploymentNode = {
+        type: 'deployment',
+        name: 'd1',
+        clusterName: 'c1',
+        layout: { type: 'deployment' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: { apiVersion: 'apps/v1', metadata: { name: 'd1' } },
+          deploymentModel: {
+            a: [{ namespace: 'ns-a' }],
+            b: [{ namespace: 'ns-b' }],
+          },
+        },
+      }
+      const result = nodeDetailsProvider(deploymentNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Namespace', 'ns-a,ns-b')).toBe(true)
+    })
+
+    it('should fall back to github-branch and github-path annotation keys', () => {
+      const subscriptionNode = {
+        type: 'subscription',
+        name: 's1',
+        clusterName: 'c1',
+        layout: { type: 'subscription' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: {
+            apiVersion: 'apps.open-cluster-management.io/v1',
+            metadata: {
+              name: 's1',
+              annotations: {
+                'apps.open-cluster-management.io/github-branch': 'legacy-branch',
+                'apps.open-cluster-management.io/github-path': 'legacy-path',
+              },
+            },
+          },
+          subscriptionModel: {},
+        },
+      }
+      const result = nodeDetailsProvider(subscriptionNode, mockActiveFilters, t, mockHubClusterName)
+      expect(
+        result.some(
+          (d) =>
+            (d as { labelValue?: string; value?: unknown }).labelValue === 'Git branch' &&
+            String((d as { value?: unknown }).value).includes('legacy-branch')
+        )
+      ).toBe(true)
+      expect(
+        result.some(
+          (d) =>
+            (d as { labelValue?: string; value?: unknown }).labelValue === 'Git path' &&
+            String((d as { value?: unknown }).value).includes('legacy-path')
+        )
+      ).toBe(true)
+    })
+
+    it('should resolve unknown apiVersion from apiversion alone when apigroup is absent', () => {
+      const deploymentNode = {
+        type: 'deployment',
+        name: 'd1',
+        clusterName: 'c1',
+        layout: { type: 'deployment' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: {
+            apiVersion: 'unknown',
+            kind: 'Deployment',
+            metadata: { name: 'd1' },
+          },
+          deploymentModel: {
+            key: [{ namespace: 'ns1', apiversion: 'v1' }],
+          },
+        },
+      }
+      const result = nodeDetailsProvider(deploymentNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'API Version', 'v1')).toBe(true)
+    })
+
+    it('should omit API Version and Cluster when they are missing', () => {
+      const deploymentNode = {
+        type: 'deployment',
+        name: 'd1',
+        namespace: 'ns1',
+        layout: { type: 'deployment' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: { metadata: { name: 'd1' } },
+        },
+      }
+      const result = nodeDetailsProvider(deploymentNode, mockActiveFilters, t, mockHubClusterName)
+      // addDetails drops rows whose value is undefined
+      expect(result.find((d) => (d as { labelValue?: string }).labelValue === 'API Version')).toBeUndefined()
+      expect(result.find((d) => (d as { labelValue?: string }).labelValue === 'Cluster')).toBeUndefined()
+      expect(detail(result, 'Type', 'Deployment')).toBe(true)
+      expect(detail(result, 'Namespace', 'ns1')).toBe(true)
+    })
+
+    it('should treat empty resource model as No labels when not design', () => {
+      const deploymentNode = {
+        type: 'deployment',
+        name: 'd1',
+        clusterName: 'c1',
+        layout: { type: 'deployment' },
+        labels: [],
+        specs: {
+          isDesign: false,
+          raw: { apiVersion: 'apps/v1', metadata: { name: 'd1' } },
+          deploymentModel: {},
+        },
+      }
+      const result = nodeDetailsProvider(deploymentNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Labels', 'No labels')).toBe(true)
+    })
+
+    it('should fall back to placementDecision.status.decisions for Matched Clusters (ACM-37230)', () => {
+      const placementNode = {
+        type: 'placement',
+        name: 'p1',
+        clusterName: 'hub',
+        layout: { type: 'placement' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: {
+            apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+            kind: 'Placement',
+            metadata: { name: 'p1' },
+            status: {},
+          },
+        },
+        placementDecision: {
+          kind: 'PlacementDecision',
+          status: {
+            decisions: [{ clusterName: 'remote-1' }, { clusterName: 'remote-2' }, { clusterName: 'remote-3' }],
+          },
+          spec: { clusterSelector: { matchLabels: { env: 'prod' } } },
+        },
+      }
+      const result = nodeDetailsProvider(placementNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Matched Clusters', 3)).toBe(true)
+    })
+
+    it('should show Matched Clusters as 0 when no decisions or numberOfSelectedClusters exist (ACM-37230)', () => {
+      const placementNode = {
+        type: 'placement',
+        name: 'p1',
+        clusterName: 'hub',
+        layout: { type: 'placement' },
+        labels: [],
+        specs: {
+          isDesign: true,
+          raw: {
+            apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+            kind: 'Placement',
+            metadata: { name: 'p1' },
+            status: {},
+          },
+        },
+        placementDecision: {
+          kind: 'PlacementDecision',
+          status: {},
+          spec: {},
+        },
+      }
+      const result = nodeDetailsProvider(placementNode, mockActiveFilters, t, mockHubClusterName)
+      expect(detail(result, 'Matched Clusters', 0)).toBe(true)
+      expect(detail(result, 'ClusterSet', 'Not defined')).toBe(true)
+    })
   })
 
   describe('kubeNaming', () => {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts
@@ -391,7 +391,12 @@ function addK8Details(
   )
 
   if (type === 'placement' || type === 'placementDecision') {
-    const specNbOfClustersTarget = node?.specs?.raw?.status?.decisions?.length ?? 0
+    const rawStatus = node?.specs?.raw?.status
+    const specNbOfClustersTarget =
+      rawStatus?.decisions?.length ??
+      rawStatus?.numberOfSelectedClusters ??
+      node?.placementDecision?.status?.decisions?.length ??
+      0
 
     // placementDecision
     const clusterSets = node?.placementDecision?.spec?.clusterSets


### PR DESCRIPTION
## Summary

- Fix ApplicationSet topology placement pod always showing **Matched Clusters: 0**
- Include agentic workflow dev conventions from ACM-35948 (`.cursor/` gitignore, `~/` import guidance in AGENTS.md)

## Root Cause

`NodeDetailsProvider` only read `status.decisions.length` for placement topology nodes. ApplicationSet **Placement** pods store the matched count in `status.numberOfSelectedClusters`, while **PlacementDecision** pods use `status.decisions[]`. Clicking the placement pod always resolved to 0.

**Affected file:** `frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProvider.ts`

## Fix

Fall back through:
1. `status.decisions.length` (PlacementDecision)
2. `status.numberOfSelectedClusters` (Placement)
3. `placementDecision.status.decisions.length` (fallback)

## Regression Tests

Added to `NodeDetailsProvider.test.ts`:
- Placement node with `numberOfSelectedClusters: 3` shows Matched Clusters = 3
- PlacementDecision node with 2 decisions shows Matched Clusters = 2

## How to Test

1. `npm run plugins` (or `npm start`)
2. Create an ApplicationSet with cluster placement
3. Open **Applications** → select the appset → **Topology** tab
4. Click the **placement** topology pod
5. **Expected:** Matched Clusters shows the correct non-zero count

Fixes: https://issues.redhat.com/browse/ACM-37230


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Matched Clusters” calculations for placement and placement decision nodes, including more status shapes and a safe default when data is missing.
* **Tests**
  * Expanded unit coverage to verify “Matched Clusters” and related rendering across multiple node/status combinations, including fallback and “0 / Not defined” behavior.
* **Documentation**
  * Added contributor guidance on using `~/` import shorthand.
* **Chores**
  * Updated repository ignore rules to exclude the `.cursor/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->