### PR TITLE
Update nodejs-24-minimal base image [release-2.11]

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:acm
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:mce
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm  --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Dockerfile.mce.prow
+++ b/Dockerfile.mce.prow
@@ -1,23 +1,23 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 as dynamic-plugin
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 as dynamic-plugin
 WORKDIR /app/frontend
 COPY ./frontend .
 RUN npm ci --legacy-peer-deps
 RUN npm run build:plugin:mce
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 as backend
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 as backend
 WORKDIR /app/backend
 COPY ./backend .
 RUN npm ci --omit=optional --ignore-scripts
 RUN npm run build
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 as production
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 as production
 WORKDIR /app/backend
 COPY ./backend/package-lock.json ./backend/package.json ./
 RUN npm ci --omit=optional --only=production --ignore-scripts 
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353
 WORKDIR /app
 ENV NODE_ENV production
 COPY --from=production /app/backend/node_modules ./node_modules

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 as frontend-packages
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 as frontend-packages
 WORKDIR /app/frontend
 # Copy only package.json and package-lock.json so that the docker cache hash only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
@@ -11,7 +11,7 @@ COPY ./frontend .
 FROM frontend-packages as dynamic-plugin
 RUN npm run build:plugin:acm
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 as backend
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 as backend
 WORKDIR /app/backend
 # Copy only package.json and package-lock.json so that the docker layer cache only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
@@ -20,12 +20,12 @@ RUN npm ci --omit=optional --ignore-scripts
 COPY ./backend .
 RUN npm run build
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39 as production
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353 as production
 WORKDIR /app/backend
 COPY ./backend/package-lock.json ./backend/package.json ./
 RUN npm ci --omit=optional --only=production  --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:f42698c74c3caa32e9729342152fb5710e21b5a8ed58cd286290155d48785a39
+FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:caf0229871f6d011f7f90274979963b53bd145909c2878a59cd6758cbbb71353
 WORKDIR /app
 ENV NODE_ENV production
 COPY --from=production /app/backend/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- Update `registry.redhat.io/ubi9/nodejs-24-minimal` base image digest in `Containerfile.acm.konflux`, `Containerfile.mce.konflux`, `Dockerfile.prow`, and `Dockerfile.mce.prow`