### PR TITLE
FCN-251: oidc configs api call

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,7 +38,7 @@ import { watchTLSSecurityProfile } from './lib/tlsProfileWatch'
 import { watchPlacementDebugCA } from './lib/placementDebugCAWatch'
 import { invalidatePlacementDebugAgent } from './lib/agent'
 import { multiClusterEngineComponents } from './routes/multiClusterEngineComponents'
-import { getAwsAccountIds, getAwsBillingAccountIds } from './routes/rosaWizardApi'
+import { getAwsAccountIds, getAwsBillingAccountIds, getWizardOIDCConfigs } from './routes/rosaWizardApi'
 
 const isProduction = process.env.NODE_ENV === 'production'
 const isDevelopment = process.env.NODE_ENV === 'development'
@@ -95,6 +95,7 @@ router.all('/managedclusterproxy/*', managedClusterProxy)
 // rosa wizard routes
 router.post('/aws-account-ids', getAwsAccountIds)
 router.post('/aws-billing-accounts', getAwsBillingAccountIds)
+router.post('/oidc-configs', getWizardOIDCConfigs)
 router.get('/*', serveHandler)
 
 export async function requestHandler(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -26,8 +26,8 @@ type Payload = {
   service_account_secret: string
 }
 
-type OIDCConfigReq = Payload & {
-  aws_account_id: number
+type WithAwsAccount = Payload & {
+  aws_account_id: string
 }
 
 export async function getAwsAccountIds(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
@@ -114,7 +114,7 @@ export async function getWizardOIDCConfigs(req: Http2ServerRequest, res: Http2Se
       req.on('end', async () => {
         try {
           data = chucks.join()
-          const body = JSON.parse(data) as OIDCConfigReq
+          const body = JSON.parse(data) as WithAwsAccount
 
           const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
 

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -26,6 +26,10 @@ type Payload = {
   service_account_secret: string
 }
 
+type OIDCConfigReq = Payload & {
+  aws_account_id: number
+}
+
 export async function getAwsAccountIds(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
   const token = await getAuthenticatedToken(req, res)
   if (token) {
@@ -89,6 +93,43 @@ export async function getAwsBillingAccountIds(req: Http2ServerRequest, res: Http
 
         res.setHeader('Content-Type', 'application/json')
         res.end(JSON.stringify(accReq))
+      })
+    } catch (err) {
+      logger.error(err)
+      respondInternalServerError(req, res)
+    }
+  }
+}
+
+export async function getWizardOIDCConfigs(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
+  const token = await getAuthenticatedToken(req, res)
+  if (token) {
+    try {
+      let data: string = undefined
+      const chucks: string[] = []
+      req.on('data', (chuck: string) => {
+        chucks.push(chuck)
+      })
+
+      req.on('end', async () => {
+        try {
+          data = chucks.join()
+          const body = JSON.parse(data) as OIDCConfigReq
+
+          const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
+
+          const accountPath = `${API_URL}/api/clusters_mgmt/v1/oidc_configs?search=aws.account_id=${body.aws_account_id} or aws.account_id=''`
+          const request = await jsonRequest(accountPath, accessTokenSSO).catch((err: Error) => {
+            logger.error({ msg: 'Failed to fetch account', error: err.message })
+            return { error: err.message }
+          })
+
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify(request))
+        } catch (err) {
+          logger.error(err)
+          respondInternalServerError(req, res)
+        }
       })
     } catch (err) {
       logger.error(err)

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -113,7 +113,7 @@ export async function getWizardOIDCConfigs(req: Http2ServerRequest, res: Http2Se
 
       req.on('end', async () => {
         try {
-          data = chucks.join()
+          data = chucks.join('')
           const body = JSON.parse(data) as WithAwsAccount
 
           const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)

--- a/backend/test/routes/rosaWizardApi.test.ts
+++ b/backend/test/routes/rosaWizardApi.test.ts
@@ -108,4 +108,58 @@ describe('rosaWizardApi routes', () => {
       expect(res.statusCode).toEqual(401)
     })
   })
+
+  describe('POST /oidc-configs', () => {
+    const oidcPayload = {
+      ...mockPayload,
+      aws_account_id: 123456789012,
+    }
+
+    test('should return OIDC configs for given AWS account', async () => {
+      const oidcResponse = {
+        items: [
+          {
+            id: 'oidc-config-1',
+            href: '/api/clusters_mgmt/v1/oidc_configs/oidc-config-1',
+            managed: false,
+            installer_role_arn: 'arn:aws:iam::123456789012:role/Installer',
+          },
+        ],
+      }
+
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST)
+        .get("/api/clusters_mgmt/v1/oidc_configs?search=aws.account_id=123456789012 or aws.account_id=''")
+        .reply(200, oidcResponse)
+
+      const res = await request('POST', '/oidc-configs', oidcPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody(res)
+      expect(body).toEqual(oidcResponse)
+    })
+
+    test('should return error object when OIDC API call fails', async () => {
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST)
+        .get("/api/clusters_mgmt/v1/oidc_configs?search=aws.account_id=123456789012 or aws.account_id=''")
+        .replyWithError('connection refused')
+
+      const res = await request('POST', '/oidc-configs', oidcPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody<{ error: string }>(res)
+      expect(body).toEqual({ error: expect.stringContaining('connection refused') as string })
+    })
+
+    test('should return 500 when SSO token request fails', async () => {
+      nockAuth()
+      nock(SSO_HOST).post(SSO_PATH).replyWithError('SSO unavailable')
+
+      const res = await request('POST', '/oidc-configs', oidcPayload)
+      expect(res.statusCode).toEqual(500)
+    })
+  })
 })

--- a/backend/test/routes/rosaWizardApi.test.ts
+++ b/backend/test/routes/rosaWizardApi.test.ts
@@ -112,7 +112,7 @@ describe('rosaWizardApi routes', () => {
   describe('POST /oidc-configs', () => {
     const oidcPayload = {
       ...mockPayload,
-      aws_account_id: 123456789012,
+      aws_account_id: '123456789012',
     }
 
     test('should return OIDC configs for given AWS account', async () => {
@@ -130,7 +130,8 @@ describe('rosaWizardApi routes', () => {
       nockAuth()
       nockSsoToken()
       nock(API_HOST)
-        .get("/api/clusters_mgmt/v1/oidc_configs?search=aws.account_id=123456789012 or aws.account_id=''")
+        .get('/api/clusters_mgmt/v1/oidc_configs')
+        .query({ search: "aws.account_id=123456789012 or aws.account_id=''" })
         .reply(200, oidcResponse)
 
       const res = await request('POST', '/oidc-configs', oidcPayload)
@@ -144,7 +145,8 @@ describe('rosaWizardApi routes', () => {
       nockAuth()
       nockSsoToken()
       nock(API_HOST)
-        .get("/api/clusters_mgmt/v1/oidc_configs?search=aws.account_id=123456789012 or aws.account_id=''")
+        .get('/api/clusters_mgmt/v1/oidc_configs')
+        .query({ search: "aws.account_id=123456789012 or aws.account_id=''" })
         .replyWithError('connection refused')
 
       const res = await request('POST', '/oidc-configs', oidcPayload)

--- a/frontend/src/lib/rosa-hcp-api.test.ts
+++ b/frontend/src/lib/rosa-hcp-api.test.ts
@@ -1,6 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { getWizardData, getWizardAWSAccountIds, getWizardAwsBillingAccounts } from './rosa-hcp-api'
+import {
+  getWizardData,
+  getWizardAWSAccountIds,
+  getWizardAwsBillingAccounts,
+  getWizardOIDCConfigs,
+} from './rosa-hcp-api'
 
 const mockFetchRetry = jest.fn()
 jest.mock('~/resources/utils', () => ({
@@ -108,6 +113,74 @@ describe('rosa-hcp-api', () => {
           url: 'https://localhost:4000/aws-billing-accounts',
         })
       )
+    })
+  })
+
+  describe('getWizardOIDCConfigs', () => {
+    test('should call getWizardData with /oidc-configs path', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+
+      await getWizardOIDCConfigs('client-id', 'client-secret')
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://localhost:4000/oidc-configs',
+        })
+      )
+    })
+
+    test('should pass additionalData to the request body', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+
+      await getWizardOIDCConfigs('client-id', 'client-secret', undefined, { aws_account_id: 123456789012 })
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            service_account_id: 'client-id',
+            service_account_secret: 'client-secret',
+            aws_account_id: 123456789012,
+          },
+        })
+      )
+    })
+
+    test('should pass abort signal to the request', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+      const controller = new AbortController()
+
+      await getWizardOIDCConfigs('client-id', 'client-secret', controller.signal)
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: controller.signal,
+        })
+      )
+    })
+
+    test('should return OIDC config items on success', async () => {
+      const oidcResponse = {
+        items: [
+          {
+            id: 'oidc-config-1',
+            managed: false,
+            installer_role_arn: 'arn:aws:iam::123456789012:role/Installer',
+          },
+        ],
+      }
+      mockFetchRetry.mockResolvedValue({ data: oidcResponse })
+
+      const result = await getWizardOIDCConfigs('client-id', 'client-secret')
+
+      expect(result).toEqual(oidcResponse)
+    })
+
+    test('should throw error when response contains Error kind', async () => {
+      mockFetchRetry.mockResolvedValue({
+        data: { kind: 'Error', reason: 'Service account not authorized' },
+      })
+
+      await expect(getWizardOIDCConfigs('client-id', 'client-secret')).rejects.toThrow('Service account not authorized')
     })
   })
 })

--- a/frontend/src/lib/rosa-hcp-api.test.ts
+++ b/frontend/src/lib/rosa-hcp-api.test.ts
@@ -132,14 +132,14 @@ describe('rosa-hcp-api', () => {
     test('should pass additionalData to the request body', async () => {
       mockFetchRetry.mockResolvedValue({ data: { items: [] } })
 
-      await getWizardOIDCConfigs('client-id', 'client-secret', undefined, { aws_account_id: 123456789012 })
+      await getWizardOIDCConfigs('client-id', 'client-secret', undefined, { aws_account_id: '123456789012' })
 
       expect(mockFetchRetry).toHaveBeenCalledWith(
         expect.objectContaining({
           data: {
             service_account_id: 'client-id',
             service_account_secret: 'client-secret',
-            aws_account_id: 123456789012,
+            aws_account_id: '123456789012',
           },
         })
       )

--- a/frontend/src/lib/rosa-hcp-api.ts
+++ b/frontend/src/lib/rosa-hcp-api.ts
@@ -2,6 +2,7 @@
 
 import {
   AwsAccountIdsResponse,
+  AwsAccountPayload,
   OIDCConfigResponse,
   OrganizationQuotaResponse,
   WizardBasePayload,
@@ -74,9 +75,9 @@ export const getWizardOIDCConfigs = (
   client_id: string,
   client_secret: string,
   signal?: AbortSignal,
-  additionalData?: Record<string, unknown>
+  additionalData?: AwsAccountPayload
 ): Promise<OIDCConfigResponse> =>
-  getWizardData<OIDCConfigResponse, Record<string, unknown>>(
+  getWizardData<OIDCConfigResponse, AwsAccountPayload>(
     client_id,
     client_secret,
     '/oidc-configs',

--- a/frontend/src/lib/rosa-hcp-api.ts
+++ b/frontend/src/lib/rosa-hcp-api.ts
@@ -1,6 +1,12 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { AwsAccountIdsResponse, OrganizationQuotaResponse, WizardBasePayload, WizardErrorResponse } from '~/resources'
+import {
+  AwsAccountIdsResponse,
+  OIDCConfigResponse,
+  OrganizationQuotaResponse,
+  WizardBasePayload,
+  WizardErrorResponse,
+} from '~/resources'
 import { fetchRetry, getBackendUrl } from '~/resources/utils'
 
 function isWizardError(data: unknown): data is WizardErrorResponse {
@@ -60,6 +66,20 @@ export const getWizardAwsBillingAccounts = (
     client_id,
     client_secret,
     '/aws-billing-accounts',
+    signal,
+    additionalData
+  )
+
+export const getWizardOIDCConfigs = (
+  client_id: string,
+  client_secret: string,
+  signal?: AbortSignal,
+  additionalData?: Record<string, unknown>
+): Promise<OIDCConfigResponse> =>
+  getWizardData<OIDCConfigResponse, Record<string, unknown>>(
+    client_id,
+    client_secret,
+    '/oidc-configs',
     signal,
     additionalData
   )

--- a/frontend/src/resources/rosa-hcp-wizard.ts
+++ b/frontend/src/resources/rosa-hcp-wizard.ts
@@ -51,3 +51,7 @@ export interface OIDCConfigResponse {
   total: number
   items: OIDCConfig[]
 }
+
+export type AwsAccountPayload = {
+  aws_account_id: string
+}

--- a/frontend/src/resources/rosa-hcp-wizard.ts
+++ b/frontend/src/resources/rosa-hcp-wizard.ts
@@ -37,3 +37,17 @@ export interface WizardErrorResponse {
   reason?: string
   body?: { kind?: string; reason?: string }
 }
+
+interface OIDCConfig {
+  id: string
+  organization_id: string
+  issuer_url: string
+  managed: boolean
+  reusable: boolean
+}
+export interface OIDCConfigResponse {
+  page: number
+  size: number
+  total: number
+  items: OIDCConfig[]
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.test.ts
@@ -27,6 +27,11 @@ describe('queryKeyFactory', () => {
     expect(key1).not.toEqual(key2)
   })
 
+  test('rosaWizardKeys.oidcConfigs should extend the base key with client id and aws account id', () => {
+    const key = rosaWizardKeys.oidcConfigs('test-client-id', '123456789012')
+    expect(key).toEqual([ROSA_HCP_WIZARD_QUERY_KEY, 'test-client-id', '123456789012', 'oidc-configs'])
+  })
+
   test('each key factory call should return a new array instance', () => {
     const key1 = rosaWizardKeys.awsInfrastructureAccounts('test-client-id')
     const key2 = rosaWizardKeys.awsInfrastructureAccounts('test-client-id')

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
@@ -5,4 +5,5 @@ export const rosaWizardKeys = {
   all: [ROSA_HCP_WIZARD_QUERY_KEY],
   awsInfrastructureAccounts: (id: string) => [...rosaWizardKeys.all, id, 'aws-account-ids'],
   awsBillingAccounts: (id: string) => [...rosaWizardKeys.all, id, 'aws-billing-ids'],
+  oidcConfigs: (id: string, aws_account_id: string) => [...rosaWizardKeys.all, id, aws_account_id, 'oidc-configs'],
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
@@ -5,5 +5,5 @@ export const rosaWizardKeys = {
   all: [ROSA_HCP_WIZARD_QUERY_KEY],
   awsInfrastructureAccounts: (id: string) => [...rosaWizardKeys.all, id, 'aws-account-ids'],
   awsBillingAccounts: (id: string) => [...rosaWizardKeys.all, id, 'aws-billing-ids'],
-  oidcConfigs: (id: string, aws_account_id: string) => [...rosaWizardKeys.all, id, aws_account_id, 'oidc-configs'],
+  oidcConfigs: (id: string, aws_account_id?: string) => [...rosaWizardKeys.all, id, aws_account_id, 'oidc-configs'],
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.test.tsx
@@ -1,0 +1,134 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useFetchOIDCConfigs } from './useFetchOIDCConfigs'
+import { SelectedSecret } from '../constants/types'
+const mockUseQuery = jest.fn()
+jest.mock('~/hooks/shared-react-query', () => ({
+  useSharedReactQuery: () => ({
+    useQuery: mockUseQuery,
+  }),
+}))
+jest.mock('~/lib/rosa-hcp-api', () => ({
+  getWizardOIDCConfigs: jest.fn(),
+}))
+const mockSecret: SelectedSecret = {
+  client_id: 'test-client-id',
+  client_secret: 'test-client-secret',
+}
+describe('useFetchOIDCConfigs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  test('should return OIDC configs mapped to value/label/issuer_url pairs', () => {
+    mockUseQuery.mockReturnValue({
+      data: [
+        { value: 'oidc-config-1', label: 'oidc-config-1', issuer_url: 'https://issuer-1.example.com' },
+        { value: 'oidc-config-2', label: 'oidc-config-2', issuer_url: 'https://issuer-2.example.com' },
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+    })
+    const { result } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(result.current.data).toEqual([
+      { value: 'oidc-config-1', label: 'oidc-config-1', issuer_url: 'https://issuer-1.example.com' },
+      { value: 'oidc-config-2', label: 'oidc-config-2', issuer_url: 'https://issuer-2.example.com' },
+    ])
+  })
+  test('should return empty array when data is undefined', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    })
+    const { result } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(result.current.data).toEqual([])
+  })
+  test('should be disabled when awsAccountId has not been set via fetch', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    })
+    renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['rosa-hcp-wizard-query-key', 'test-client-id', '', 'oidc-configs'],
+        enabled: false,
+      })
+    )
+  })
+  test('should enable the query after fetch is called with an awsAccountId', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    })
+    const { result, rerender } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    act(() => {
+      result.current.fetch('123456789012')
+    })
+    rerender()
+    expect(mockUseQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryKey: ['rosa-hcp-wizard-query-key', 'test-client-id', '123456789012', 'oidc-configs'],
+        enabled: true,
+      })
+    )
+  })
+  test('should forward loading state as isFetching', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    })
+    const { result } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(result.current.isFetching).toBe(true)
+  })
+  test('should return error message string when query errors with an Error instance', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Network failure'),
+    })
+    const { result } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(result.current.error).toBe('Network failure')
+  })
+  test('should return "Unknown error" when query errors with a non-Error value', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: 'something went wrong',
+    })
+    const { result } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(result.current.error).toBe('Unknown error')
+  })
+  test('should return null error when query is not in error state', () => {
+    mockUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+    })
+    const { result } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    expect(result.current.error).toBeNull()
+  })
+  test('should expose a stable fetch function reference', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    })
+    const { result, rerender } = renderHook(() => useFetchOIDCConfigs(mockSecret))
+    const firstFetch = result.current.fetch
+    rerender()
+    expect(result.current.fetch).toBe(firstFetch)
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.test.tsx
@@ -55,7 +55,7 @@ describe('useFetchOIDCConfigs', () => {
     renderHook(() => useFetchOIDCConfigs(mockSecret))
     expect(mockUseQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ['rosa-hcp-wizard-query-key', 'test-client-id', '', 'oidc-configs'],
+        queryKey: ['rosa-hcp-wizard-query-key', 'test-client-id', undefined, 'oidc-configs'],
         enabled: false,
       })
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.ts
@@ -12,7 +12,7 @@ export const useFetchOIDCConfigs = (selectedSecret: SelectedSecret) => {
     queryKey: rosaWizardKeys.oidcConfigs(selectedSecret.client_id, awsAccountId),
     queryFn: async ({ signal }) => {
       const response = await getWizardOIDCConfigs(selectedSecret.client_id, selectedSecret.client_secret, signal, {
-        aws_account_id: awsAccountId,
+        aws_account_id: awsAccountId as string,
       })
       return (
         response.items?.map((item) => ({

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.ts
@@ -9,7 +9,7 @@ export const useFetchOIDCConfigs = (selectedSecret: SelectedSecret) => {
   const { useQuery } = useSharedReactQuery()
   const [awsAccountId, setAwsAccountId] = useState<string | undefined>()
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: rosaWizardKeys.oidcConfigs(selectedSecret.client_id, awsAccountId ?? ''),
+    queryKey: rosaWizardKeys.oidcConfigs(selectedSecret.client_id, awsAccountId),
     queryFn: async ({ signal }) => {
       const response = await getWizardOIDCConfigs(selectedSecret.client_id, selectedSecret.client_secret, signal, {
         aws_account_id: awsAccountId,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOIDCConfigs.ts
@@ -1,0 +1,38 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { useCallback, useState } from 'react'
+import { getWizardOIDCConfigs } from '~/lib/rosa-hcp-api'
+import { SelectedSecret } from '../constants/types'
+import { useSharedReactQuery } from '~/hooks/shared-react-query'
+import { rosaWizardKeys } from './queryKeyFactory'
+
+export const useFetchOIDCConfigs = (selectedSecret: SelectedSecret) => {
+  const { useQuery } = useSharedReactQuery()
+  const [awsAccountId, setAwsAccountId] = useState<string | undefined>()
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: rosaWizardKeys.oidcConfigs(selectedSecret.client_id, awsAccountId ?? ''),
+    queryFn: async ({ signal }) => {
+      const response = await getWizardOIDCConfigs(selectedSecret.client_id, selectedSecret.client_secret, signal, {
+        aws_account_id: awsAccountId,
+      })
+      return (
+        response.items?.map((item) => ({
+          value: item.id,
+          label: item.id,
+          issuer_url: item.issuer_url,
+        })) ?? []
+      )
+    },
+    retry: false,
+    enabled: !!selectedSecret && !!awsAccountId,
+  })
+  const fetch = useCallback(async (accountId: string): Promise<void> => {
+    setAwsAccountId(accountId)
+  }, [])
+
+  return {
+    data: data ?? [],
+    isFetching: isLoading,
+    error: isError ? (error instanceof Error ? error.message : 'Unknown error') : null,
+    fetch,
+  }
+}

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -188,7 +188,8 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
         '/multicloud/vmResourceUsage',
         '/multicloud/managedclusterproxy',
         '/multicloud/aws-account-ids',
-        '/multicloud/aws-billing-accounts'
+        '/multicloud/aws-billing-accounts',
+        '/multicloud/oidc-configs'
       ].map((backendPath) => ({
         path: backendPath,
         target: `https://localhost:${process.env.BACKEND_PORT}`,


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Api call for OIDC configs for ROSA HCP Wizard

**Ticket Link:**  
[<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->](https://redhat.atlassian.net/browse/FCN-251)

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [X] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [X] All acceptance criteria met
- [X] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ROSA HCP wizard API to retrieve OIDC configurations via `POST /oidc-configs`.
  * Added frontend support to fetch and present OIDC configuration options based on the selected secret and AWS account, including a new React hook and query key helper.
* **Bug Fixes**
  * Improved dev/proxy routing for OIDC configuration requests (`/multicloud/oidc-configs`).
* **Tests**
  * Added backend and frontend coverage for success paths, authentication and token failures, downstream errors, query enabling/disable behavior, option mapping, and loading/error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->