### PR TITLE
Display Cluster Description with Markdown Rendering

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -254,6 +254,7 @@ export type Cluster = {
   microshiftDistribution?: MicroshiftDistributionInfo
   addons?: Addons
   labels?: Record<string, string>
+  annotations?: Record<string, string>
   nodes?: Nodes
   kubeApiServer?: string
   consoleURL?: string
@@ -582,6 +583,7 @@ export function getCluster({
     acmConsoleURL: getACMConsoleURL(acmDistribution.version, consoleURL),
     addons: getAddons(managedClusterAddOns, clusterManagementAddOns),
     labels: managedCluster?.metadata.labels ?? managedClusterInfo?.metadata.labels,
+    annotations: managedCluster?.metadata.annotations ?? managedClusterInfo?.metadata.annotations,
     nodes: getNodes(managedClusterInfo),
     kubeApiServer: getKubeApiServer(clusterDeployment, managedClusterInfo, agentClusterInstall),
     consoleURL: consoleURL,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -341,15 +341,12 @@ export function ClusterOverviewPageContent() {
     },
     description: {
       key: t('Description'),
-      value: (
+      value: cluster?.annotations?.[clusterDescriptionAnnotation] ? (
         <Content>
-          <Markdown
-            template={
-              cluster?.annotations?.[clusterDescriptionAnnotation] ??
-              '**Production Cluster**\n\nThis is a test cluster for development purposes.\n\n- High availability setup\n- [Documentation](https://example.com)\n- Auto-scaling enabled'
-            }
-          />
+          <Markdown template={cluster.annotations[clusterDescriptionAnnotation]} />
         </Content>
+      ) : (
+        '-'
       ),
     },
   }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -5,9 +5,10 @@ import {
   ClusterDeploymentK8sResource,
   getClusterProperties,
 } from '@openshift-assisted/ui-lib/cim'
-import { AlertVariant, ButtonVariant, PageSection, Popover } from '@patternfly/react-core'
+import { AlertVariant, ButtonVariant, Content, PageSection, Popover } from '@patternfly/react-core'
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated'
 import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon, PencilAltIcon } from '@patternfly/react-icons'
+import { Markdown } from '@redhat-cloud-services/rule-components/Markdown'
 import { Fragment, useMemo, useState } from 'react'
 import { generatePath, Link } from 'react-router'
 import { getControlPlaneString } from '../../../../../../components/Clusters'
@@ -82,6 +83,7 @@ export function ClusterOverviewPageContent() {
     useClusterDetailsContext()
   const { t } = useTranslation()
   const localHubName = useLocalHubName()
+  const clusterDescriptionAnnotation = 'console.open-cluster-management.io/description'
   const [showEditLabels, setShowEditLabels] = useState<boolean>(false)
   const [showChannelSelectModal, setShowChannelSelectModal] = useState<boolean>(false)
   const [curatorSummaryModalIsOpen, setCuratorSummaryModalIsOpen] = useState<boolean>(false)
@@ -337,6 +339,19 @@ export function ClusterOverviewPageContent() {
       key: t('Placements'),
       value: <PlacementLinkList placementsForCluster={placementsForCluster} />,
     },
+    description: {
+      key: t('Description'),
+      value: (
+        <Content>
+          <Markdown
+            template={
+              cluster?.annotations?.[clusterDescriptionAnnotation] ??
+              '**Production Cluster**\n\nThis is a test cluster for development purposes.\n\n- High availability setup\n- [Documentation](https://example.com)\n- Auto-scaling enabled'
+            }
+          />
+        </Content>
+      ),
+    },
   }
 
   const fromClusterPool =
@@ -386,6 +401,7 @@ export function ClusterOverviewPageContent() {
             : []),
         ]),
     clusterProperties.placements,
+    clusterProperties.description,
   ]
 
   const [isModalOpen, setIsModalOpen] = useState(false)


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
ACM-37998 Display Cluster Description with Markdown Rendering

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://redhat.atlassian.net/browse/ACM-37998

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [x] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [x] UI/UX reviewed (if applicable)
- [x] All acceptance criteria met
- [x] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->
### Testing Instructions
**Add annotation:**
```
oc annotate managedcluster <cluster-name> \
  'console.open-cluster-management.io/description=**Production** cluster with [docs](https://example.com)'
```

**Verify:**  Check Description field in right column shows markdown rendered text.

**Remove annotation:**
`oc annotate managedcluster <cluster-name> 'console.open-cluster-management.io/description-'`

**Verify:** Description field shows "-"

Empty State:
<img width="1226" height="689" alt="Снимок экрана — 2026-07-20 в 2 26 09 PM" src="https://github.com/user-attachments/assets/421502ba-26e1-4658-bf24-61d6504c3f78" />

Non Empty State:
<img width="1224" height="679" alt="Снимок экрана — 2026-07-20 в 2 24 49 PM" src="https://github.com/user-attachments/assets/42ceb921-33d3-404b-8c6e-66317c2ce190" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster overview pages now display a Description field.
  * Descriptions support Markdown formatting and use a default template when no custom description is available.
  * Cluster details now include available annotations for displaying additional metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->