### PR TITLE
ACM-38011: Fix ResizeObserver loop in topology YAML tab

### DIFF
--- a/frontend/__mocks__/@monaco-editor/react.tsx
+++ b/frontend/__mocks__/@monaco-editor/react.tsx
@@ -46,6 +46,10 @@ export const lastDiffNavigator = {
   current: null as { dispose: () => void; previous: jest.Mock; next: jest.Mock } | null,
 }
 
+export const lastEditorLayout = {
+  current: null as jest.Mock | null,
+}
+
 const createMockDiffNavigator = () => {
   const navigator = {
     dispose: () => {},
@@ -189,8 +193,10 @@ const MonacoEditor = (props: {
         return find === 'that' ? [{ range: new Range(0, 0, 0, 1) }, { range: new Range(0, 1, 0, 2) }] : []
       },
     }
+    const layoutMock = jest.fn()
+    lastEditorLayout.current = layoutMock
     editorMockRef.current.mockEditor = {
-      layout: () => {},
+      layout: layoutMock,
       focus: () => {},
       trigger: (_source, action) => {
         switch (action) {
@@ -410,8 +416,10 @@ const buildMockEditor = (props: { onChange?: (value: string, e: any) => void; in
     onDidChangeContent: () => {},
     findMatches: () => [],
   }
+  const layoutMockFn = jest.fn()
+  lastEditorLayout.current = layoutMockFn
   const mockEditor = {
-    layout: () => {},
+    layout: layoutMockFn,
     focus: () => {},
     trigger: () => {},
     onKeyDown: (handler: (e: unknown) => void) => {

--- a/frontend/src/components/SyncEditor/SyncEditor.test.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.test.tsx
@@ -10,6 +10,11 @@ const lastDiffNavigator = (
     lastDiffNavigator: { current: { previous: jest.Mock; next: jest.Mock } | null }
   }
 ).lastDiffNavigator
+const lastEditorLayout = (
+  MonacoEditorReact as typeof MonacoEditorReact & {
+    lastEditorLayout: { current: jest.Mock | null }
+  }
+).lastEditorLayout
 import userEvent from '@testing-library/user-event'
 import get from 'lodash/get'
 import set from 'lodash/set'
@@ -475,13 +480,22 @@ describe('SyncEditor component', () => {
   describe('layoutEditor resize handling', () => {
     const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
     const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+    let resizeCallback: (() => void) | null = null
 
     beforeEach(() => {
       Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 800 })
       Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 600 })
+      resizeCallback = null
+      lastEditorLayout.current = null
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('@react-hook/resize-observer')
+      jest.spyOn(mod, 'default').mockImplementation((_ref: any, cb: any) => {
+        resizeCallback = cb
+      })
     })
 
     afterEach(() => {
+      jest.restoreAllMocks()
       if (originalClientWidth) {
         Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth)
       }
@@ -495,19 +509,20 @@ describe('SyncEditor component', () => {
       render(<SyncEditor {...clone} />)
       const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
       await waitFor(() => expect(input).not.toHaveValue(''))
-      const container = document.querySelector('.sync-editor__container')
-      expect(container).toBeTruthy()
+      expect(lastEditorLayout.current).toHaveBeenCalledWith({ width: 800, height: 564 })
     })
 
-    it('skips layout when dimensions have not changed', async () => {
+    it('skips layout when resize fires but dimensions have not changed', async () => {
       const clone = cloneDeep(propsNewResource)
       render(<SyncEditor {...clone} />)
       const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
       await waitFor(() => expect(input).not.toHaveValue(''))
+      lastEditorLayout.current!.mockClear()
       await act(async () => {
-        window.dispatchEvent(new Event('resize'))
-        await new Promise((resolve) => setTimeout(resolve, 100))
+        resizeCallback?.()
+        await new Promise((resolve) => requestAnimationFrame(resolve))
       })
+      expect(lastEditorLayout.current).not.toHaveBeenCalled()
     })
 
     it('re-layouts when activeEditor changes to diff editor', async () => {
@@ -517,10 +532,13 @@ describe('SyncEditor component', () => {
       render(<SyncEditor {...clone} />)
       const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
       await waitFor(() => expect(input).not.toHaveValue(''))
+      const originalLayoutMock = lastEditorLayout.current!
+      expect(originalLayoutMock).toHaveBeenCalledWith({ width: 800, height: 564 })
       await act(async () => {
         userEvent.click(screen.getByRole('checkbox', { name: /show changes/i }))
       })
       await waitFor(() => expect(screen.getByRole('textbox', { name: /monaco-diff/i })).toBeInTheDocument())
+      expect(lastEditorLayout.current).not.toBe(originalLayoutMock)
     })
 
     it('skips layout when container has zero width', async () => {

--- a/frontend/src/components/SyncEditor/SyncEditor.test.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.test.tsx
@@ -549,9 +549,7 @@ describe('SyncEditor component', () => {
       const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
       await waitFor(() => expect(input).not.toHaveValue(''))
       const calls = lastEditorLayout.current!.mock.calls
-      const hasPositiveDimensions = calls.some(
-        (args: any[]) => args[0] && args[0].width > 0 && args[0].height > 0
-      )
+      const hasPositiveDimensions = calls.some((args: any[]) => args[0] && args[0].width > 0 && args[0].height > 0)
       expect(hasPositiveDimensions).toBe(false)
     })
 

--- a/frontend/src/components/SyncEditor/SyncEditor.test.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.test.tsx
@@ -541,12 +541,18 @@ describe('SyncEditor component', () => {
       expect(lastEditorLayout.current).not.toBe(originalLayoutMock)
     })
 
-    it('skips layout when container has zero width', async () => {
+    it('skips layout when container has zero dimensions', async () => {
       Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 })
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 0 })
       const clone = cloneDeep(propsNewResource)
       render(<SyncEditor {...clone} />)
       const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
       await waitFor(() => expect(input).not.toHaveValue(''))
+      const calls = lastEditorLayout.current!.mock.calls
+      const hasPositiveDimensions = calls.some(
+        (args: any[]) => args[0] && args[0].width > 0 && args[0].height > 0
+      )
+      expect(hasPositiveDimensions).toBe(false)
     })
 
     it('sets condensed mode when width is below 500', async () => {

--- a/frontend/src/components/SyncEditor/SyncEditor.test.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.test.tsx
@@ -471,6 +471,75 @@ describe('SyncEditor component', () => {
       expect(input.value).toContain('-----BEGIN CERTIFICATE-----')
     })
   })
+
+  describe('layoutEditor resize handling', () => {
+    const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+    const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+
+    beforeEach(() => {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 800 })
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 600 })
+    })
+
+    afterEach(() => {
+      if (originalClientWidth) {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth)
+      }
+      if (originalClientHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight)
+      }
+    })
+
+    it('calls editor.layout with container dimensions on mount', async () => {
+      const clone = cloneDeep(propsNewResource)
+      render(<SyncEditor {...clone} />)
+      const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
+      await waitFor(() => expect(input).not.toHaveValue(''))
+      const container = document.querySelector('.sync-editor__container')
+      expect(container).toBeTruthy()
+    })
+
+    it('skips layout when dimensions have not changed', async () => {
+      const clone = cloneDeep(propsNewResource)
+      render(<SyncEditor {...clone} />)
+      const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
+      await waitFor(() => expect(input).not.toHaveValue(''))
+      await act(async () => {
+        window.dispatchEvent(new Event('resize'))
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      })
+    })
+
+    it('re-layouts when activeEditor changes to diff editor', async () => {
+      const clone = cloneDeep(propsNewResource)
+      clone.defaultResources = cloneDeep(clone.resources)
+      set(clone, 'resources.0.spec.disabled', false)
+      render(<SyncEditor {...clone} />)
+      const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
+      await waitFor(() => expect(input).not.toHaveValue(''))
+      await act(async () => {
+        userEvent.click(screen.getByRole('checkbox', { name: /show changes/i }))
+      })
+      await waitFor(() => expect(screen.getByRole('textbox', { name: /monaco-diff/i })).toBeInTheDocument())
+    })
+
+    it('skips layout when container has zero width', async () => {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 })
+      const clone = cloneDeep(propsNewResource)
+      render(<SyncEditor {...clone} />)
+      const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
+      await waitFor(() => expect(input).not.toHaveValue(''))
+    })
+
+    it('sets condensed mode when width is below 500', async () => {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 400 })
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 300 })
+      const clone = cloneDeep(propsNewResource)
+      render(<SyncEditor {...clone} />)
+      const input = screen.getByRole('textbox', { name: /monaco/i }) as HTMLTextAreaElement
+      await waitFor(() => expect(input).not.toHaveValue(''))
+    })
+  })
 })
 
 const propsNewResource: SyncEditorProps = {

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -849,7 +849,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
           height -= 75
         }
 
-        if (height <= 0) return
+        if (width <= 0 || height <= 0) return
 
         const prev = lastLayoutSize.current
         const sameEditor = lastLayoutEditor.current === editor

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -833,6 +833,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
   ])
 
   const lastLayoutSize = useRef<{ width: number; height: number }>({ width: 0, height: 0 })
+  const lastLayoutEditor = useRef<unknown>(null)
   const rafId = useRef<number>(0)
 
   const layoutEditor = useCallback(
@@ -851,15 +852,24 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
         if (height <= 0) return
 
         const prev = lastLayoutSize.current
-        if (prev.width === width && prev.height === height) return
+        const sameEditor = lastLayoutEditor.current === editor
+        if (sameEditor && prev.width === width && prev.height === height) return
 
         lastLayoutSize.current = { width, height }
+        lastLayoutEditor.current = editor
         editor.layout({ width, height })
         setShowCondensed(width < 500)
       }
     },
     [editorHasErrors, variant]
   )
+
+  useEffect(() => {
+    cancelAnimationFrame(rafId.current)
+    if (activeEditor) {
+      layoutEditor(activeEditor)
+    }
+  }, [activeEditor, layoutEditor])
 
   useResizeObserver(pageRef, () => {
     cancelAnimationFrame(rafId.current)

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -157,8 +157,10 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
   }
   // ensure cleanup when component unmounts
   useEffect(() => {
-    // hide SyncEditor version of monaco-colors
-    return () => dismountTheme('se')
+    return () => {
+      dismountTheme('se')
+      cancelAnimationFrame(rafId.current)
+    }
   }, [])
 
   function onEditorDidMount(editor: editorTypes.IStandaloneCodeEditor, monaco: Monaco) {
@@ -830,20 +832,14 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
     t,
   ])
 
-  useResizeObserver(pageRef, () => {
-    layoutEditor(activeEditor)
-  })
+  const lastLayoutSize = useRef<{ width: number; height: number }>({ width: 0, height: 0 })
+  const rafId = useRef<number>(0)
 
   const layoutEditor = useCallback(
     (editor: any) => {
       if (pageRef.current && editor) {
-        const rect = pageRef.current.getBoundingClientRect()
-        const { width } = rect
-        let { height } = rect
-
-        if (pageRef.current) {
-          height = window.innerHeight - pageRef.current?.getBoundingClientRect().top
-        }
+        const width = pageRef.current.clientWidth
+        let height = pageRef.current.clientHeight
 
         if (variant === 'toolbar') {
           height -= 36
@@ -851,12 +847,26 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
         if (editorHasErrors) {
           height -= 75
         }
+
+        if (height <= 0) return
+
+        const prev = lastLayoutSize.current
+        if (prev.width === width && prev.height === height) return
+
+        lastLayoutSize.current = { width, height }
         editor.layout({ width, height })
         setShowCondensed(width < 500)
       }
     },
     [editorHasErrors, variant]
   )
+
+  useResizeObserver(pageRef, () => {
+    cancelAnimationFrame(rafId.current)
+    rafId.current = requestAnimationFrame(() => {
+      layoutEditor(activeEditor)
+    })
+  })
 
   // if showChanges is true, set activeEditor,activeMonaco to DiffEditor
   // else set the actives to the regular editor/monanco

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/DetailsView.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/DetailsView.tsx
@@ -1,26 +1,27 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import React, { Component, Fragment, KeyboardEvent, MouseEvent } from 'react'
-import classNames from 'classnames'
-import { Button, Spinner, Tabs, Tab, TabTitleText } from '@patternfly/react-core'
-import { createResourceSearchLink, createResourceURL, getFilteredNode } from '../helpers/diagram-helpers'
-import ClusterDetailsContainer from './ClusterDetailsContainer'
-import ArgoAppDetailsContainer from './ArgoAppDetailsContainer'
-import DetailsTable from './DetailsTable'
-import { LogsContainer } from './LogsContainer'
-import { YAMLContainer } from './YAMLContainer'
+import { Button, Spinner, Tab, TabTitleText, Tabs } from '@patternfly/react-core'
 import {
+  DetailItemExtended,
+  DetailsViewDecoratorProps,
   DetailsViewProps,
   DetailsViewState,
-  DetailsViewDecoratorProps,
-  DetailItemExtended,
   LinkValue,
-  TopologyNodeWithStatus,
-  StatusType,
   ResourceAction,
+  StatusType,
+  TopologyNodeWithStatus,
 } from '../types'
-import { typeToShapeMap } from '../model/NodeDetailsProvider'
+import React, { Component, Fragment, KeyboardEvent, MouseEvent } from 'react'
+import { createResourceSearchLink, createResourceURL, getFilteredNode } from '../helpers/diagram-helpers'
+
+import ArgoAppDetailsContainer from './ArgoAppDetailsContainer'
+import ClusterDetailsContainer from './ClusterDetailsContainer'
+import DetailsTable from './DetailsTable'
+import { LogsContainer } from './LogsContainer'
 import type { TFunction } from 'i18next'
+import { YAMLContainer } from './YAMLContainer'
+import classNames from 'classnames'
+import { typeToShapeMap } from '../model/NodeDetailsProvider'
 
 /**
  * Decorator component that renders an icon for the details view header
@@ -199,7 +200,14 @@ class DetailsView extends Component<DetailsViewProps, DetailsViewState> {
     const searchLink = createResourceSearchLink(currentNode, t)
 
     return (
-      <div className="topologyDetails" style={{ overflow: activeTabKey !== 2 ? 'auto' : 'hidden' }}>
+      <div
+        className="topologyDetails"
+        style={{
+          overflow: activeTabKey !== 2 ? 'auto' : 'hidden',
+          display: activeTabKey === 2 ? 'flex' : undefined,
+          flexDirection: activeTabKey === 2 ? 'column' : undefined,
+        }}
+      >
         <div className="detailsHeader">
           {/* Back button when viewing filtered node details */}
           {filteredNode && (
@@ -233,7 +241,9 @@ class DetailsView extends Component<DetailsViewProps, DetailsViewState> {
         </div>
 
         {/* Content area - either table or tabbed content */}
-        <section style={{ height: activeTabKey !== 2 ? undefined : '100%' }}>
+        <section
+          style={{ flex: activeTabKey === 2 ? '1 1 0' : undefined, minHeight: activeTabKey === 2 ? 0 : undefined }}
+        >
           {isTableView ? this.renderTableContents(currentUpdatedNode!) : this.renderTabContents(currentUpdatedNode!)}
         </section>
       </div>

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/css/Drawer.css
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/topology/css/Drawer.css
@@ -8,6 +8,7 @@
 .topologyDetails .detailsHeader {
   position: sticky;
   top: 0px;
+  flex-shrink: 0;
   box-shadow: var(--pf-v5-c-page--section--m-sticky-top--BoxShadow);
   z-index: var(--pf-v5-c-page--section--m-sticky-top--ZIndex);
   background-color: var(--pf-v5-global--BackgroundColor--100);


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Application topology YAML tab causes ResizeObserver loop and scrollbar jittering

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-38011

**Type of Change:**  
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

**Root cause:** `SyncEditor`'s `layoutEditor` computed editor height using `window.innerHeight - getBoundingClientRect().top` (a viewport-relative value), but the container's actual height is constrained by CSS. The mismatch caused Monaco's `editor.layout()` to toggle scrollbars, which shifted the container position, triggering the ResizeObserver again in an infinite loop.

**Fix (3 files):**

1. **`DetailsView.tsx`** — Convert the topology details container to a flex column layout for the YAML tab, giving the content section `flex: 1 1 0; min-height: 0` so it properly fills remaining space after the header.
2. **`Drawer.css`** — Add `flex-shrink: 0` to `.detailsHeader` to prevent it from collapsing in the flex layout.
3. **`SyncEditor.tsx`** — Replace the viewport-relative height calculation with `clientWidth`/`clientHeight` (the container's own CSS-constrained dimensions). Add a dimension guard to skip redundant `editor.layout()` calls, and wrap the resize callback in `requestAnimationFrame` to break any remaining synchronous loop.

**Testing:**
1. Run `npm run plugins` (or `npm start`)
2. Navigate to Applications > select an app > Topology
3. Click on a node to open the details drawer
4. Select the **YAML** tab
5. Verify no scrollbar jittering occurs and no ResizeObserver errors appear in the console

**Impact:** Other consumers of `SyncEditor` (wizards, governance, search) should be unaffected since their containers already have proper height constraints. The flex layout change only applies when the YAML tab is active in the topology drawer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor responsiveness by throttling resize-driven layout updates and skipping redundant re-layouts when dimensions haven’t changed.
  * Improved cleanup on editor close/unmount by canceling any pending layout animation work.
  * Fixed YAML tab layout sizing using flex-based sizing for more consistent height/space handling.
  * Prevented the topology details header from shrinking unexpectedly during panel changes.
* **Tests**
  * Added coverage for editor resize/layout behavior, including active editor switching and condensed mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->