### PR TITLE
fix(backend): use empty separator when joining HTTP body chunks (ACM-38039)

### DIFF
--- a/backend/src/lib/pagination.ts
+++ b/backend/src/lib/pagination.ts
@@ -64,7 +64,7 @@ export function paginate(
     chucks.push(chuck)
   })
   req.on('end', async () => {
-    const body = chucks.join()
+    const body = chucks.join('')
 
     const request = JSON.parse(body) as IRequestListView
     const { search, sortBy, filters } = request

--- a/backend/src/routes/aggregators/appSetData.ts
+++ b/backend/src/routes/aggregators/appSetData.ts
@@ -33,7 +33,7 @@ export function requestAggregatedAppSetData(req: Http2ServerRequest, res: Http2S
   req.on('end', async () => {
     const token = getToken(req)
     if (!token) return unauthorized(req, res)
-    const body = chunks.join()
+    const body = chunks.join('')
     let appset: IApplicationSet
     let isAppSetPullModel = false
     try {

--- a/backend/src/routes/aggregators/statuses.ts
+++ b/backend/src/routes/aggregators/statuses.ts
@@ -33,7 +33,7 @@ export function requestAggregatedStatuses(
     chucks.push(chuck)
   })
   req.on('end', async () => {
-    const body = chucks.join()
+    const body = chucks.join('')
     const { clusters = [] } = JSON.parse(body) as IRequestStatuses
     let items = await getItems()
 

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -36,7 +36,7 @@ export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse):
         chucks.push(chuck)
       })
       req.on('end', () => {
-        const body = chucks.join()
+        const body = chucks.join('')
         ansibleCredential = JSON.parse(body) as AnsibleCredential
         let towerUrl = null
         try {

--- a/backend/src/routes/operatorCheck.ts
+++ b/backend/src/routes/operatorCheck.ts
@@ -41,7 +41,7 @@ export function operatorCheck(req: Http2ServerRequest, res: Http2ServerResponse)
       })
       req.on('end', () => {
         let operatorCheckRequest: unknown
-        const data = chunks.join()
+        const data = chunks.join('')
         try {
           operatorCheckRequest = JSON.parse(data) as unknown
         } catch (err) {

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -37,7 +37,7 @@ export async function getAwsAccountIds(req: Http2ServerRequest, res: Http2Server
       })
 
       req.on('end', async () => {
-        data = chucks.join()
+        data = chucks.join('')
         const body: Payload = JSON.parse(data) as Payload
 
         const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
@@ -73,7 +73,7 @@ export async function getAwsBillingAccountIds(req: Http2ServerRequest, res: Http
       })
 
       req.on('end', async () => {
-        data = chucks.join()
+        data = chucks.join('')
         const body = JSON.parse(data) as Payload
 
         const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)

--- a/backend/src/routes/upgrade-risks-prediction.ts
+++ b/backend/src/routes/upgrade-risks-prediction.ts
@@ -46,7 +46,7 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
         chucks.push(chuck)
       })
       req.on('end', async () => {
-        data = chucks.join()
+        data = chucks.join('')
         const body = JSON.parse(data) as UpgradeRiskBody
 
         // acm-operator version in User-Agent header doesn't matter - CCX only uses the 'acm-operator' string to identify the product initiating the req

--- a/backend/src/routes/userpreference.ts
+++ b/backend/src/routes/userpreference.ts
@@ -80,7 +80,7 @@ export async function userpreference<T = unknown>(req: Http2ServerRequest, res: 
               chucks.push(chuck)
             })
             req.on('end', async () => {
-              data = chucks.join()
+              data = chucks.join('')
 
               const body =
                 req.method === 'POST'

--- a/backend/test/mock-request.ts
+++ b/backend/test/mock-request.ts
@@ -59,7 +59,7 @@ export function mockResponse(resolve: (value: Http2ServerResponse) => void): Htt
 beforeAll(nock.disableNetConnect)
 afterAll(stop)
 
-function createReadWriteStream() {
+export function createReadWriteStream() {
   const chunks: unknown[] = []
   let destroy = false
   let write = false
@@ -93,6 +93,36 @@ function createReadWriteStream() {
     },
   })
   return stream
+}
+
+export async function requestMultiChunk(
+  method: 'GET' | 'PUT' | 'POST' | 'DELETE',
+  path: string,
+  body: Record<string, unknown>,
+  extraHeaders?: IncomingHttpHeaders
+): Promise<Http2ServerResponse> {
+  const stream = createReadWriteStream()
+  const headers: IncomingHttpHeaders = {
+    ...extraHeaders,
+    [constants.HTTP2_HEADER_METHOD]: method,
+    [constants.HTTP2_HEADER_PATH]: path,
+    [constants.HTTP2_HEADER_AUTHORIZATION]: 'Bearer <token>',
+  }
+  headers[constants.HTTP2_HEADER_CONTENT_TYPE] = 'application/json'
+
+  const result = new Promise<Http2ServerResponse>((resolve) => {
+    const req = new Http2ServerRequest(stream as ServerHttp2Stream, headers, {}, [])
+    const res = mockResponse(resolve)
+    void requestHandler(req, res)
+  })
+
+  const bodyBuffer = Buffer.from(JSON.stringify(body))
+  const mid = Math.floor(bodyBuffer.length / 2)
+  stream.write(bodyBuffer.subarray(0, mid))
+  stream.write(bodyBuffer.subarray(mid))
+  stream.end()
+
+  return result
 }
 
 export async function waitUntil(callback: () => Promise<boolean> | boolean): Promise<void> {

--- a/backend/test/routes/operatorCheck.test.ts
+++ b/backend/test/routes/operatorCheck.test.ts
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { request } from '../mock-request'
+import { request, requestMultiChunk } from '../mock-request'
 import { parseResponseJsonBody } from '../../src/lib/body-parser'
 import nock from 'nock'
 
@@ -60,5 +60,21 @@ describe(`operatorCheck Route`, function () {
       .reply(200, subscriptionOperators)
     const res = await request('POST', '/operatorCheck', { operator: 'multicluster-engine' })
     expect(res.statusCode).toEqual(400)
+  })
+
+  it('correctly parses request body received in multiple chunks', async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+      status: 200,
+    })
+    nock(process.env.CLUSTER_API_URL)
+      .get('/apis/operators.coreos.com/v1alpha1/subscriptions')
+      .reply(200, subscriptionOperators)
+    const res = await requestMultiChunk('POST', '/operatorCheck', { operator: 'openshift-gitops-operator' })
+    expect(res.statusCode).toEqual(200)
+    expect(await parseResponseJsonBody(res)).toEqual({
+      operator: 'openshift-gitops-operator',
+      installed: true,
+      version: 'openshift-gitops-operator.v1.8.2',
+    })
   })
 })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Backend: HTTP request body chunks joined without empty separator can corrupt JSON payloads

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-38039

**Type of Change:**  
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## Root Cause

Several backend route handlers collect HTTP request body data using `req.on('data')` listeners that push chunks into an array, then join them before `JSON.parse()`. However, `Array.join()` was called **without an explicit empty-string separator**, which means JavaScript's default comma (`,`) separator would be used. If a request body arrives in multiple TCP chunks, the commas inserted at chunk boundaries corrupt the JSON before parsing.

One location (`virtualMachineProxy.ts`) already used the correct `.join('')` form — this PR aligns all other locations.

## Changes

Changed `.join()` to `.join('')` in 9 locations across 8 backend files:

| File | Function |
|------|----------|
| `backend/src/routes/rosaWizardApi.ts` | `getAwsAccountIds`, `getAwsBillingAccountIds` |
| `backend/src/routes/userpreference.ts` | `userpreference` |
| `backend/src/routes/operatorCheck.ts` | `operatorCheck` |
| `backend/src/routes/aggregators/statuses.ts` | `requestAggregatedStatuses` |
| `backend/src/routes/aggregators/appSetData.ts` | `requestAggregatedAppSetData` |
| `backend/src/routes/ansibletower.ts` | `ansibleTower` |
| `backend/src/lib/pagination.ts` | `requestListView` |
| `backend/src/routes/upgrade-risks-prediction.ts` | `upgradeRisksPrediction` |

Added a `requestMultiChunk()` test helper and a regression test that sends a request body split across two chunks to verify correct reassembly.

## Context

Discovered during review of [PR #6490](https://github.com/stolostron/console/pull/6490). See [this comment thread](https://github.com/stolostron/console/pull/6490#discussion_r3615578710).

---

## ✅ Checklist

### General

- [x] PR title follows the convention
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only) — N/A, no new strings

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

- The fix is mechanical: `.join()` → `.join('')` across all HTTP body chunk reassembly sites.
- Locations in `utils.ts` and `applicationsOCP.ts` that use `.join()` for cache key construction are **intentionally** comma-separated and were not changed.
- In practice this bug was likely never hit because request bodies for these endpoints are small enough to arrive in a single chunk, but it is a latent correctness issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request handling for JSON payloads received in multiple network chunks.
  * Prevented malformed JSON parsing across pagination, aggregation, operator checks, user preferences, account lookup, and upgrade risk prediction endpoints.
  * Improved reliability for requests whose bodies are split during transmission.

* **Tests**
  * Added coverage verifying successful processing of multi-chunk requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->