### PR TITLE
fix(backend): replace full CRD list fetch with targeted GET in /hub route (ACM-38058)

### DIFF
--- a/backend/src/routes/hub.ts
+++ b/backend/src/routes/hub.ts
@@ -7,7 +7,6 @@ import { respondInternalServerError } from '../lib/respond'
 import { getServiceAccountToken } from '../lib/serviceAccountToken'
 import { getAuthenticatedToken } from '../lib/token'
 import type { IResource } from '../resources/resource'
-import type { ResourceList } from '../resources/resource-list'
 import { getHubClusterName, getIsHubSelfManaged, getIsObservabilityInstalled, getKubeResources } from './events'
 
 interface AuthenticationResource {
@@ -51,15 +50,11 @@ export async function hub(req: Http2ServerRequest, res: Http2ServerResponse): Pr
     const serviceAccountToken = getServiceAccountToken()
 
     try {
-      const path = process.env.CLUSTER_API_URL + '/apis/apiextensions.k8s.io/v1/customresourcedefinitions'
+      const crdName = 'multiclusterglobalhubs.operator.open-cluster-management.io'
+      const path = process.env.CLUSTER_API_URL + `/apis/apiextensions.k8s.io/v1/customresourcedefinitions/${crdName}`
       const [crdResponse, authentications] = await Promise.all([
-        jsonRequest(path, serviceAccountToken)
-          .then((response: ResourceList<IResource>) => {
-            const mcgh = response.items.find(
-              (crd) => crd.metadata.name === 'multiclusterglobalhubs.operator.open-cluster-management.io'
-            )
-            return { isGlobalHub: mcgh !== undefined }
-          })
+        jsonRequest<IResource>(path, serviceAccountToken)
+          .then((response) => ({ isGlobalHub: response.kind === 'CustomResourceDefinition' }))
           .catch((err: Error) => {
             logger.error({ msg: 'Error getting Multicluster Global Hubs', error: err.message })
             return { isGlobalHub: false }

--- a/backend/test/routes/hub.test.ts
+++ b/backend/test/routes/hub.test.ts
@@ -5,21 +5,35 @@ import type { IResource } from '../../src/resources/resource'
 import { cacheResource, resetResourceCache } from '../../src/routes/events'
 import { request } from '../mock-request'
 
+const MCGH_CRD_PATH =
+  '/apis/apiextensions.k8s.io/v1/customresourcedefinitions/multiclusterglobalhubs.operator.open-cluster-management.io'
+
 function mockCrdNock(url: string) {
   const apisScope = nock(url).get('/apis').reply(200, { status: 200 })
   const crdScope = nock(url)
-    .get('/apis/apiextensions.k8s.io/v1/customresourcedefinitions')
+    .get(MCGH_CRD_PATH)
     .reply(200, {
-      items: [
-        {
-          kind: 'CustomResourceDefinition',
-          apiVersion: 'apiextensions.k8s.io/v1',
-          metadata: {
-            name: 'multiclusterglobalhubs.operator.open-cluster-management.io',
-          },
-        },
-      ],
+      kind: 'CustomResourceDefinition',
+      apiVersion: 'apiextensions.k8s.io/v1',
+      metadata: {
+        name: 'multiclusterglobalhubs.operator.open-cluster-management.io',
+      },
     })
+  return { apisScope, crdScope }
+}
+
+function mockCrdNock404(url: string) {
+  const apisScope = nock(url).get('/apis').reply(200, { status: 200 })
+  const crdScope = nock(url).get(MCGH_CRD_PATH).reply(404, {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Failure',
+    message:
+      'customresourcedefinitions.apiextensions.k8s.io "multiclusterglobalhubs.operator.open-cluster-management.io" not found',
+    reason: 'NotFound',
+    code: 404,
+  })
   return { apisScope, crdScope }
 }
 
@@ -80,6 +94,24 @@ describe('global hub', function () {
           username: { claim: 'email', prefix: { prefixString: 'oidc:' }, prefixPolicy: 'Prefix' },
           groups: { claim: 'groups', prefix: 'oidc:' },
         },
+      },
+    })
+    apisScope.done()
+    crdScope.done()
+  })
+
+  it('should return isGlobalHub false when the multiclusterglobalhub CRD does not exist (404)', async function () {
+    const { apisScope, crdScope } = mockCrdNock404(process.env.CLUSTER_API_URL)
+    const res = await request('GET', '/hub')
+    expect(res.statusCode).toEqual(200)
+    const parsed = await parsePipedJsonBody(res)
+    expect(parsed).toEqual({
+      localHubName: 'local-cluster',
+      isGlobalHub: false,
+      isHubSelfManaged: false,
+      isObservabilityInstalled: false,
+      authentication: {
+        isDirectAuthenticationEnabled: false,
       },
     })
     apisScope.done()


### PR DESCRIPTION
## Root Cause Analysis

The `/hub` route handler in `backend/src/routes/hub.ts` fetched the **entire CRD list** (~51MB) from the API server every 30 seconds per connected browser tab, just to check if a single CRD (`multiclusterglobalhubs.operator.open-cluster-management.io`) exists:

```
GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions
```

This caused repeated massive memory allocations/deallocations in the `console-chart-console-v2` pod, leading to memory spikes.

## Fix

Replace the full CRD list fetch with a **targeted GET** for the specific CRD by name:

```
GET /apis/apiextensions.k8s.io/v1/customresourcedefinitions/multiclusterglobalhubs.operator.open-cluster-management.io
```

This reduces the response from **~51MB to ~10KB** per call. The targeted GET returns:
- **200** with `kind: CustomResourceDefinition` when the CRD exists → `isGlobalHub: true`
- **404** with `kind: Status` when it does not → `isGlobalHub: false`

Also removed the now-unused `ResourceList` type import.

## Regression Test

Added a test case that mocks a 404 response for the targeted CRD GET and verifies the handler correctly returns `isGlobalHub: false`. Updated existing test mocks to match the new targeted endpoint.

## How to Test

1. Run backend tests: `npm run test:backend` — all 338 tests pass (including 3 hub tests)
2. Run checks: `npm run check:backend` — prettier, lint, and tsc all pass
3. Start in plugin mode (`npm run plugins`) and verify the clusters page loads correctly
4. Inspect the `/hub` network response — should contain `isGlobalHub` with correct value
If the Multiclusterglobalhub operator is installed `isGlobalHub: true` otherwise `isGlobalHub: false`

## Linked Issue

Resolves [ACM-38058](https://redhat.atlassian.net/browse/ACM-38058)

[ACM-38058]: https://redhat.atlassian.net/browse/ACM-38058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of global hub availability for more reliable hub status reporting.
  * Hub status now correctly reports a non-global hub when the required resource is unavailable.

* **Tests**
  * Added coverage for scenarios where the global hub resource does not exist.
  * Updated endpoint validation for direct resource checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->