### PR TITLE
[ACM-38103] Insights request should trust service CA for on prem reqs

### DIFF
--- a/backend/src/lib/agent.ts
+++ b/backend/src/lib/agent.ts
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import type { AgentOptions } from 'node:https'
 import { Agent } from 'node:https'
+import { getCACertificates } from 'node:tls'
 import { getCACertificate, getServiceCACertificate } from './serviceAccountToken'
 import { getPlacementDebugCA } from './placementDebugCAWatch'
 import { HttpsProxyAgent } from 'https-proxy-agent'
@@ -57,4 +58,26 @@ export function getProxyAgent() {
     proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY, COMMON_AGENT_OPTIONS)
   }
   return proxyAgent
+}
+
+// Insights upgrade-risk-prediction requests may target either the public console.redhat.com
+// (default) or an on-cluster gateway like the Insights Operator proxy service (service-ca signed)
+// or an externally hosted on-prem instance (trusted via NODE_EXTRA_CA_CERTS), so this agent trusts
+// all three rather than just the public roots used by getDefaultAgent().
+let insightsAgent: Agent
+export function getInsightsAgent() {
+  if (!insightsAgent) {
+    insightsAgent = new Agent({
+      ca: [
+        ...getCACertificates('default'),
+        ...([] as string[]).concat(
+          getServiceCACertificate(() => {
+            insightsAgent = undefined
+          })
+        ),
+      ],
+      ...COMMON_AGENT_OPTIONS,
+    })
+  }
+  return insightsAgent
 }

--- a/backend/src/routes/upgrade-risks-prediction.ts
+++ b/backend/src/routes/upgrade-risks-prediction.ts
@@ -1,5 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
+import { getInsightsAgent, getProxyAgent } from '../lib/agent'
 import { jsonPost, jsonRequest } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { respondInternalServerError } from '../lib/respond'
@@ -7,7 +8,6 @@ import { getServiceAccountToken } from '../lib/serviceAccountToken'
 import { getAuthenticatedToken } from '../lib/token'
 import type { ResourceList } from '../resources/resource-list'
 import type { Secret } from '../resources/secret'
-import { getProxyAgent } from '../lib/agent'
 interface Credential {
   auths: {
     'cloud.openshift.com': {
@@ -68,12 +68,16 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
 
         // Create req for each 100 id chunk
         const reqs = clusterIds.map((idChunk: string[]) => {
-          return jsonPost(insightsPath, { clusters: idChunk }, crcToken, userAgent, getProxyAgent()).catch(
-            (err: Error) => {
-              logger.error({ msg: 'Error getting cluster upgrade risk predictions', error: err.message })
-              return { error: err.message }
-            }
-          )
+          return jsonPost(
+            insightsPath,
+            { clusters: idChunk },
+            crcToken,
+            userAgent,
+            getProxyAgent() ?? getInsightsAgent()
+          ).catch((err: Error) => {
+            logger.error({ msg: 'Error getting cluster upgrade risk predictions', error: err.message })
+            return { error: err.message }
+          })
         })
 
         await Promise.all(reqs).then((results) => {

--- a/backend/test/lib/agent.test.ts
+++ b/backend/test/lib/agent.test.ts
@@ -1,0 +1,133 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { execFileSync } from 'node:child_process'
+import { createServer, type Server } from 'node:https'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import fetch from 'node-fetch'
+import nock from 'nock'
+import { getDefaultAgent, getInsightsAgent } from '../../src/lib/agent'
+
+// Simulates an in-cluster service (e.g. the Insights Operator proxy) whose TLS certificate is
+// signed by a private CA (standing in for OpenShift's service-ca), to verify that getInsightsAgent()
+// trusts it while the unrelated getDefaultAgent() correctly does not.
+describe('agent', () => {
+  let dir: string
+  let server: Server
+  let port: number
+  let caCertPem: string
+
+  beforeAll(() => {
+    // Other test files leave nock's real-network block in place for the rest of the worker
+    // process, so explicitly allow it here since these tests hit a real local HTTPS server.
+    nock.enableNetConnect('127.0.0.1')
+
+    dir = mkdtempSync(join(tmpdir(), 'agent-test-'))
+    const caKey = join(dir, 'ca.key')
+    const caCrt = join(dir, 'ca.crt')
+    const otherCaKey = join(dir, 'other-ca.key')
+    const otherCaCrt = join(dir, 'other-ca.crt')
+    const leafKey = join(dir, 'leaf.key')
+    const leafCsr = join(dir, 'leaf.csr')
+    const leafCrt = join(dir, 'leaf.crt')
+    const extFile = join(dir, 'leaf.ext')
+
+    execFileSync('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      caKey,
+      '-out',
+      caCrt,
+      '-days',
+      '1',
+      '-nodes',
+      '-subj',
+      '/CN=Test Service CA',
+    ])
+    // Unrelated CA used to stand in for the kube-apiserver ca.crt that getDefaultAgent() trusts,
+    // to show that it doesn't happen to trust the service-ca above.
+    execFileSync('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      otherCaKey,
+      '-out',
+      otherCaCrt,
+      '-days',
+      '1',
+      '-nodes',
+      '-subj',
+      '/CN=Test Kube API CA',
+    ])
+    execFileSync('openssl', [
+      'req',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      leafKey,
+      '-out',
+      leafCsr,
+      '-nodes',
+      '-subj',
+      '/CN=127.0.0.1',
+    ])
+    writeFileSync(extFile, 'subjectAltName=IP:127.0.0.1\n')
+    execFileSync('openssl', [
+      'x509',
+      '-req',
+      '-in',
+      leafCsr,
+      '-CA',
+      caCrt,
+      '-CAkey',
+      caKey,
+      '-CAcreateserial',
+      '-out',
+      leafCrt,
+      '-days',
+      '1',
+      '-extfile',
+      extFile,
+    ])
+
+    caCertPem = readFileSync(caCrt, 'utf-8')
+    process.env.SERVICE_CA_CERT = Buffer.from(caCertPem).toString('base64')
+    process.env.CA_CERT = Buffer.from(readFileSync(otherCaCrt, 'utf-8')).toString('base64')
+
+    server = createServer({ cert: readFileSync(leafCrt), key: readFileSync(leafKey) }, (_req, res) => {
+      res.writeHead(200)
+      res.end('ok')
+    })
+
+    return new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as { port: number }).port
+        resolve()
+      })
+    })
+  })
+
+  afterAll(() => {
+    delete process.env.SERVICE_CA_CERT
+    delete process.env.CA_CERT
+    nock.disableNetConnect()
+    rmSync(dir, { recursive: true, force: true })
+    return new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+
+  it('getInsightsAgent trusts a certificate signed by the cluster service-ca', async () => {
+    const res = await fetch(`https://127.0.0.1:${port}/`, { agent: getInsightsAgent() })
+    expect(res.status).toEqual(200)
+  })
+
+  it('getDefaultAgent does not trust a certificate signed by the cluster service-ca', async () => {
+    await expect(fetch(`https://127.0.0.1:${port}/`, { agent: getDefaultAgent() })).rejects.toThrow(
+      /unable to verify the first certificate/i
+    )
+  })
+})

--- a/backend/test/lib/agent.test.ts
+++ b/backend/test/lib/agent.test.ts
@@ -1,27 +1,27 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { execFileSync } from 'node:child_process'
 import { createServer, type Server } from 'node:https'
+import { connect, type PeerCertificate, type TLSSocket } from 'node:tls'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import fetch from 'node-fetch'
-import nock from 'nock'
+import type { Agent } from 'node:https'
 import { getDefaultAgent, getInsightsAgent } from '../../src/lib/agent'
 
 // Simulates an in-cluster service (e.g. the Insights Operator proxy) whose TLS certificate is
 // signed by a private CA (standing in for OpenShift's service-ca), to verify that getInsightsAgent()
 // trusts it while the unrelated getDefaultAgent() correctly does not.
+//
+// This connects with `tls.connect` directly (rather than `fetch`/`https.request`) because other
+// test files' use of `nock` monkey-patches the shared, process-wide `http`/`https` modules for the
+// lifetime of the Jest worker; going through that layer here would make the outcome depend on
+// which test file happened to run first in this worker. `tls.connect` isn't touched by `nock`.
 describe('agent', () => {
   let dir: string
   let server: Server
   let port: number
-  let caCertPem: string
 
   beforeAll(() => {
-    // Other test files leave nock's real-network block in place for the rest of the worker
-    // process, so explicitly allow it here since these tests hit a real local HTTPS server.
-    nock.enableNetConnect('127.0.0.1')
-
     dir = mkdtempSync(join(tmpdir(), 'agent-test-'))
     const caKey = join(dir, 'ca.key')
     const caCrt = join(dir, 'ca.crt')
@@ -95,8 +95,7 @@ describe('agent', () => {
       extFile,
     ])
 
-    caCertPem = readFileSync(caCrt, 'utf-8')
-    process.env.SERVICE_CA_CERT = Buffer.from(caCertPem).toString('base64')
+    process.env.SERVICE_CA_CERT = Buffer.from(readFileSync(caCrt, 'utf-8')).toString('base64')
     process.env.CA_CERT = Buffer.from(readFileSync(otherCaCrt, 'utf-8')).toString('base64')
 
     server = createServer({ cert: readFileSync(leafCrt), key: readFileSync(leafKey) }, (_req, res) => {
@@ -115,19 +114,45 @@ describe('agent', () => {
   afterAll(() => {
     delete process.env.SERVICE_CA_CERT
     delete process.env.CA_CERT
-    nock.disableNetConnect()
     rmSync(dir, { recursive: true, force: true })
     return new Promise<void>((resolve) => server.close(() => resolve()))
   })
 
+  // rejectUnauthorized is set to false so the handshake always completes and we can inspect the
+  // verification outcome via `authorized`/`authorizationError`, instead of racing an 'error' event
+  // (which is what would fire on an untrusted cert with the default rejectUnauthorized: true).
+  function handshake(agent: Agent): Promise<{ authorized: boolean; authorizationError: Error; cert: PeerCertificate }> {
+    return new Promise((resolve, reject) => {
+      const socket: TLSSocket = connect(
+        {
+          host: '127.0.0.1',
+          port,
+          ca: agent.options.ca,
+          rejectUnauthorized: false,
+        },
+        () => {
+          resolve({
+            authorized: socket.authorized,
+            authorizationError: socket.authorizationError,
+            cert: socket.getPeerCertificate(),
+          })
+          socket.end()
+        }
+      )
+      socket.on('error', reject)
+    })
+  }
+
   it('getInsightsAgent trusts a certificate signed by the cluster service-ca', async () => {
-    const res = await fetch(`https://127.0.0.1:${port}/`, { agent: getInsightsAgent() })
-    expect(res.status).toEqual(200)
+    const { authorized, authorizationError, cert } = await handshake(getInsightsAgent())
+    expect(authorizationError).toBeNull()
+    expect(authorized).toBe(true)
+    expect(cert?.subject.CN).toEqual('127.0.0.1')
   })
 
   it('getDefaultAgent does not trust a certificate signed by the cluster service-ca', async () => {
-    await expect(fetch(`https://127.0.0.1:${port}/`, { agent: getDefaultAgent() })).rejects.toThrow(
-      /unable to verify the first certificate/i
-    )
+    const { authorized, authorizationError } = await handshake(getDefaultAgent())
+    expect(authorized).toBe(false)
+    expect(authorizationError).toBeTruthy()
   })
 })

--- a/backend/test/lib/agent.test.ts
+++ b/backend/test/lib/agent.test.ts
@@ -7,6 +7,22 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Agent } from 'node:https'
 import { getDefaultAgent, getInsightsAgent } from '../../src/lib/agent'
+import * as serviceAccountTokenModule from '../../src/lib/serviceAccountToken'
+
+// getCACertificate()/getServiceCACertificate() read real files from disk (e.g. the SA-mounted
+// ca.crt / service-ca.crt) before ever consulting the CA_CERT/SERVICE_CA_CERT env var fallbacks, and
+// some CI environments (e.g. tests running inside a real Kubernetes pod) genuinely have those files
+// present, which would otherwise silently override whatever this test tries to configure via env
+// vars. Mocking the module directly keeps this test's CA trust deterministic regardless of the
+// environment's filesystem.
+jest.mock('../../src/lib/serviceAccountToken')
+
+const mockedGetCACertificate = serviceAccountTokenModule.getCACertificate as jest.MockedFunction<
+  typeof serviceAccountTokenModule.getCACertificate
+>
+const mockedGetServiceCACertificate = serviceAccountTokenModule.getServiceCACertificate as jest.MockedFunction<
+  typeof serviceAccountTokenModule.getServiceCACertificate
+>
 
 // Simulates an in-cluster service (e.g. the Insights Operator proxy) whose TLS certificate is
 // signed by a private CA (standing in for OpenShift's service-ca), to verify that getInsightsAgent()
@@ -95,8 +111,8 @@ describe('agent', () => {
       extFile,
     ])
 
-    process.env.SERVICE_CA_CERT = Buffer.from(readFileSync(caCrt, 'utf-8')).toString('base64')
-    process.env.CA_CERT = Buffer.from(readFileSync(otherCaCrt, 'utf-8')).toString('base64')
+    mockedGetServiceCACertificate.mockReturnValue([readFileSync(caCrt, 'utf-8')])
+    mockedGetCACertificate.mockReturnValue([readFileSync(otherCaCrt, 'utf-8')])
 
     server = createServer({ cert: readFileSync(leafCrt), key: readFileSync(leafKey) }, (_req, res) => {
       res.writeHead(200)
@@ -112,8 +128,6 @@ describe('agent', () => {
   })
 
   afterAll(() => {
-    delete process.env.SERVICE_CA_CERT
-    delete process.env.CA_CERT
     rmSync(dir, { recursive: true, force: true })
     return new Promise<void>((resolve) => server.close(() => resolve()))
   })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  

- Insights upgrade-risk-prediction requests to on-cluster gateways (e.g. the Insights Operator proxy, used for "Insights on Prem" setups) were failing with self-signed certificate in certificate chain, since the backend never trusted OpenShift's service-ca for this route — it only fell back to the kube-apiserver CA + public roots.
- Added getInsightsAgent(), which trusts public root CAs (default console.redhat.com target) and the cluster's service-ca.crt (in-cluster gateway target), and use it as the fallback in upgrade-risks-prediction.ts instead of the old kube-apiserver-only default agent.
- Added a regression test (backend/test/lib/agent.test.ts) that spins up a local HTTPS server with a service-ca-style cert and verifies getInsightsAgent() trusts it while the existing getDefaultAgent() correctly doesn't.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-38103

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [x] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgrade-risk prediction requests can now use an enhanced trusted-certificate setup for secure outbound connections.
- **Bug Fixes**
  - If the standard proxy configuration isn’t available, requests now automatically fall back to a dedicated secure agent with an expanded trust store.
- **Tests**
  - Added Jest coverage that starts a local TLS server and verifies that trusted certificates are accepted while untrusted certificates are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->