### PR TITLE
FCN-249: openshift versions api call

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -47,6 +47,7 @@ import {
   getOCMRoleARN,
   getRoleARNs,
   getUserRole,
+  getWizardVersions,
 } from './routes/rosaWizardApi'
 
 const isProduction = process.env.NODE_ENV === 'production'
@@ -110,6 +111,7 @@ router.post('/cluster-name-check', getClusterNameCheck)
 router.post('/sts-role-arns', getRoleARNs)
 router.post('/sts-ocm-role', getOCMRoleARN)
 router.post('/sts-user-role', getUserRole)
+router.post('/openshift-versions', getWizardVersions)
 router.get('/*', serveHandler)
 
 export async function requestHandler(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -365,3 +365,34 @@ export async function getUserRole(req: Http2ServerRequest, res: Http2ServerRespo
     }
   }
 }
+
+export async function getWizardVersions(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
+  const token = await getAuthenticatedToken(req, res)
+  if (token) {
+    try {
+      let data: string = undefined
+      const chucks: string[] = []
+      req.on('data', (chuck: string) => {
+        chucks.push(chuck)
+      })
+
+      req.on('end', async () => {
+        data = chucks.join('')
+        const body = JSON.parse(data) as Payload
+        const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
+
+        const versionsPath = `${API_URL}/api/clusters_mgmt/v1/versions/?order=end_of_life_timestamp desc&product=hcp&search=enabled='t' AND (channel_group='stable' OR channel_group='eus' OR channel_group='candidate' OR channel_group='fast' OR channel_group='nightly') AND rosa_enabled='t'&size=-1`
+        const request = await jsonRequest(versionsPath, accessTokenSSO).catch((err: Error) => {
+          logger.error({ msg: 'Failed to fetch versions', error: err.message })
+          return { error: err.message }
+        })
+
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(request))
+      })
+    } catch (err) {
+      logger.error(err)
+      respondInternalServerError(req, res)
+    }
+  }
+}

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -377,18 +377,23 @@ export async function getWizardVersions(req: Http2ServerRequest, res: Http2Serve
       })
 
       req.on('end', async () => {
-        data = chucks.join('')
-        const body = JSON.parse(data) as Payload
-        const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
+        try {
+          data = chucks.join('')
+          const body = JSON.parse(data) as Payload
+          const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
 
-        const versionsPath = `${API_URL}/api/clusters_mgmt/v1/versions/?order=end_of_life_timestamp desc&product=hcp&search=enabled='t' AND (channel_group='stable' OR channel_group='eus' OR channel_group='candidate' OR channel_group='fast' OR channel_group='nightly') AND rosa_enabled='t'&size=-1`
-        const request = await jsonRequest(versionsPath, accessTokenSSO).catch((err: Error) => {
-          logger.error({ msg: 'Failed to fetch versions', error: err.message })
-          return { error: err.message }
-        })
+          const versionsPath = `${API_URL}/api/clusters_mgmt/v1/versions/?order=end_of_life_timestamp desc&product=hcp&search=enabled='t' AND (channel_group='stable' OR channel_group='eus' OR channel_group='candidate' OR channel_group='fast' OR channel_group='nightly') AND rosa_enabled='t'&size=-1`
+          const request = await jsonRequest(versionsPath, accessTokenSSO).catch((err: Error) => {
+            logger.error({ msg: 'Failed to fetch versions', error: err.message })
+            return { error: err.message }
+          })
 
-        res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify(request))
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify(request))
+        } catch (err) {
+          logger.error(err)
+          respondInternalServerError(req, res)
+        }
       })
     } catch (err) {
       logger.error(err)

--- a/backend/test/routes/rosaWizardApi.test.ts
+++ b/backend/test/routes/rosaWizardApi.test.ts
@@ -440,4 +440,76 @@ describe('rosaWizardApi routes', () => {
       expect(res.statusCode).toEqual(401)
     })
   })
+
+  describe('POST /openshift-versions', () => {
+    const versionsPath =
+      "/api/clusters_mgmt/v1/versions/?order=end_of_life_timestamp desc&product=hcp&search=enabled='t' AND (channel_group='stable' OR channel_group='eus' OR channel_group='candidate' OR channel_group='fast' OR channel_group='nightly') AND rosa_enabled='t'&size=-1"
+
+    test('should return OpenShift versions list', async () => {
+      const versionsResponse = {
+        kind: 'VersionList',
+        page: 1,
+        size: 3,
+        total: 3,
+        items: [
+          {
+            id: 'openshift-v4.14.10',
+            kind: 'Version',
+            raw_id: '4.14.10',
+            channel_group: 'stable',
+            rosa_enabled: true,
+            hosted_control_plane_enabled: true,
+            end_of_life_timestamp: '2025-10-31T00:00:00Z',
+          },
+          {
+            id: 'openshift-v4.14.9',
+            kind: 'Version',
+            raw_id: '4.14.9',
+            channel_group: 'stable',
+            rosa_enabled: true,
+            hosted_control_plane_enabled: true,
+            end_of_life_timestamp: '2025-10-31T00:00:00Z',
+          },
+          {
+            id: 'openshift-v4.13.25',
+            kind: 'Version',
+            raw_id: '4.13.25',
+            channel_group: 'eus',
+            rosa_enabled: true,
+            hosted_control_plane_enabled: true,
+            end_of_life_timestamp: '2025-04-17T00:00:00Z',
+          },
+        ],
+      }
+
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST).get(versionsPath).reply(200, versionsResponse)
+
+      const res = await request('POST', '/openshift-versions', mockPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody(res)
+      expect(body).toEqual(versionsResponse)
+    })
+
+    test('should return error object when versions API call fails', async () => {
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST).get(versionsPath).replyWithError('connection timeout')
+
+      const res = await request('POST', '/openshift-versions', mockPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody<{ error: string }>(res)
+      expect(body).toEqual({ error: expect.stringContaining('connection timeout') as string })
+    })
+
+    test('should return 401 when not authenticated', async () => {
+      nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
+
+      const res = await request('POST', '/openshift-versions', mockPayload)
+      expect(res.statusCode).toEqual(401)
+    })
+  })
 })

--- a/frontend/src/lib/rosa-hcp-api.test.ts
+++ b/frontend/src/lib/rosa-hcp-api.test.ts
@@ -10,6 +10,7 @@ import {
   getWizardRegions,
   getWizardClusterNameUniqueness,
   getWizardOIDCConfigs,
+  getWizardVersions,
 } from './rosa-hcp-api'
 
 const mockFetchRetry = jest.fn()
@@ -328,6 +329,68 @@ describe('rosa-hcp-api', () => {
           url: 'https://localhost:4000/regions',
         })
       )
+    })
+  })
+
+  describe('getWizardVersions', () => {
+    test('should call getWizardData with /openshift-versions path', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+
+      await getWizardVersions('client-id', 'client-secret')
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://localhost:4000/openshift-versions',
+        })
+      )
+    })
+
+    test('should pass abort signal to the request', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+      const controller = new AbortController()
+
+      await getWizardVersions('client-id', 'client-secret', controller.signal)
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: controller.signal,
+        })
+      )
+    })
+
+    test('should return versions list on success', async () => {
+      const versionsResponse = {
+        kind: 'VersionList',
+        items: [
+          {
+            id: 'openshift-v4.14.10',
+            raw_id: '4.14.10',
+            channel_group: 'stable',
+            rosa_enabled: true,
+            hosted_control_plane_enabled: true,
+          },
+          {
+            id: 'openshift-v4.13.25',
+            raw_id: '4.13.25',
+            channel_group: 'eus',
+            rosa_enabled: true,
+            hosted_control_plane_enabled: true,
+          },
+        ],
+      }
+      mockFetchRetry.mockResolvedValue({ data: versionsResponse })
+
+      const result = await getWizardVersions('client-id', 'client-secret')
+
+      expect(result).toEqual(versionsResponse)
+    })
+
+    test('should throw error when response contains Error kind', async () => {
+      mockFetchRetry.mockResolvedValue({
+        data: { kind: 'Error', reason: 'Service account not authorized' },
+      })
+
+      await expect(getWizardVersions('client-id', 'client-secret')).rejects.toThrow('Service account not authorized')
     })
   })
 })

--- a/frontend/src/lib/rosa-hcp-api.ts
+++ b/frontend/src/lib/rosa-hcp-api.ts
@@ -128,5 +128,9 @@ export const getWizardUserRoleARN = (
   signal?: AbortSignal
 ): Promise<UserRoleResponse> => getWizardData<UserRoleResponse>(client_id, client_secret, '/sts-user-role', signal)
 
-export const getWizardVersions = (client_id: string, client_secret: string, signal?: AbortSignal): Promise<OpenshiftVersionResponse> =>
+export const getWizardVersions = (
+  client_id: string,
+  client_secret: string,
+  signal?: AbortSignal
+): Promise<OpenshiftVersionResponse> =>
   getWizardData<OpenshiftVersionResponse>(client_id, client_secret, '/openshift-versions', signal)

--- a/frontend/src/lib/rosa-hcp-api.ts
+++ b/frontend/src/lib/rosa-hcp-api.ts
@@ -13,6 +13,7 @@ import {
   UserRoleResponse,
   WizardBasePayload,
   WizardErrorResponse,
+  OpenshiftVersionResponse,
 } from '~/resources'
 import { fetchRetry, getBackendUrl } from '~/resources/utils'
 
@@ -126,3 +127,6 @@ export const getWizardUserRoleARN = (
   client_secret: string,
   signal?: AbortSignal
 ): Promise<UserRoleResponse> => getWizardData<UserRoleResponse>(client_id, client_secret, '/sts-user-role', signal)
+
+export const getWizardVersions = (client_id: string, client_secret: string, signal?: AbortSignal): Promise<OpenshiftVersionResponse> =>
+  getWizardData<OpenshiftVersionResponse>(client_id, client_secret, '/openshift-versions', signal)

--- a/frontend/src/resources/rosa-hcp-wizard.ts
+++ b/frontend/src/resources/rosa-hcp-wizard.ts
@@ -1,5 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
+import { OpenshiftVersion } from "~/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types"
+
 export interface CloudRegion {
   kind?: string
   id?: string
@@ -143,6 +145,14 @@ export interface UserRoleResponse {
   key: string
   kind: string
   value: string
+}
+
+export interface OpenshiftVersionResponse {
+  kind: string;
+  page: number;
+  size: number;
+  total: number;
+  items: OpenshiftVersion[]
 }
 
 export type AwsAccountPayload = {

--- a/frontend/src/resources/rosa-hcp-wizard.ts
+++ b/frontend/src/resources/rosa-hcp-wizard.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { OpenshiftVersion } from "~/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types"
+import { OpenshiftVersion } from '~/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types'
 
 export interface CloudRegion {
   kind?: string
@@ -148,10 +148,10 @@ export interface UserRoleResponse {
 }
 
 export interface OpenshiftVersionResponse {
-  kind: string;
-  page: number;
-  size: number;
-  total: number;
+  kind: string
+  page: number
+  size: number
+  total: number
   items: OpenshiftVersion[]
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types.ts
@@ -32,3 +32,24 @@ export interface NormalizedAccountRole {
   managedPolicies?: boolean
   roleArns: Partial<Record<RoleType, string>>
 }
+
+export interface OpenShiftVersionsData {
+  default?: DropdownType
+  latest?: DropdownType
+  releases: DropdownType[]
+}
+
+export interface OpenshiftVersion {
+  available_channels: string[]
+  available_upgrades: string[]
+  channel_group: string
+  default: boolean
+  enabled: boolean
+  hosted_control_plane_default: boolean
+  hosted_control_plane_enabled: boolean
+  id: string
+  raw_id: string
+  rosa_enabled: boolean
+  wif_enabled: boolean
+  end_of_life_timestamp: string
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.test.ts
@@ -49,6 +49,11 @@ describe('queryKeyFactory', () => {
     expect(key).toEqual([ROSA_HCP_WIZARD_QUERY_KEY, 'test-client-id', 'user-role-arn'])
   })
 
+  test('rosaWizardKeys.openshiftVersions should extend the base key with client id', () => {
+    const key = rosaWizardKeys.openshiftVersions('test-client-id')
+    expect(key).toEqual([ROSA_HCP_WIZARD_QUERY_KEY, 'test-client-id', 'openshift-versions'])
+  })
+
   test('each key factory call should return a new array instance', () => {
     const key1 = rosaWizardKeys.awsInfrastructureAccounts('test-client-id')
     const key2 = rosaWizardKeys.awsInfrastructureAccounts('test-client-id')

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
@@ -25,4 +25,5 @@ export const rosaWizardKeys = {
     'ocm-role-arn',
   ],
   userRoleArn: (client_id: string) => [...rosaWizardKeys.all, client_id, 'user-role-arn'],
+  openshiftVersions: (client_id: string) => [...rosaWizardKeys.all, client_id, 'openshift-versions'],
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.test.ts
@@ -1,0 +1,391 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { renderHook } from '@testing-library/react-hooks'
+import { versionRegEx, versionComparator, useFetchHCPVersions } from './useFetchOpenshiftVersions'
+import type { SelectedSecret, OpenshiftVersion } from '../constants/types'
+
+const mockRefetch = jest.fn()
+const mockUseQuery = jest.fn()
+
+jest.mock('~/hooks/shared-react-query', () => ({
+  useSharedReactQuery: () => ({
+    useQuery: mockUseQuery,
+  }),
+}))
+
+jest.mock('~/lib/rosa-hcp-api', () => ({
+  getWizardVersions: jest.fn(),
+}))
+
+const mockSecret: SelectedSecret = {
+  client_id: 'test-client-id',
+  client_secret: 'test-client-secret',
+}
+
+const createVersion = (overrides: Partial<OpenshiftVersion> = {}): OpenshiftVersion => ({
+  available_channels: [],
+  available_upgrades: [],
+  channel_group: 'stable',
+  default: false,
+  enabled: true,
+  hosted_control_plane_default: false,
+  hosted_control_plane_enabled: true,
+  id: 'openshift-v4.14.10',
+  raw_id: '4.14.10',
+  rosa_enabled: true,
+  wif_enabled: false,
+  end_of_life_timestamp: '2026-12-31T00:00:00Z',
+  ...overrides,
+})
+
+describe('versionRegEx', () => {
+  test('should match standard version strings', () => {
+    const match = versionRegEx.exec('4.14.10')
+    expect(match?.groups).toEqual({
+      major: '4',
+      minor: '14',
+      revision: '10',
+      patch: undefined,
+    })
+  })
+
+  test('should match release candidate versions', () => {
+    const match = versionRegEx.exec('4.15.0-rc.2')
+    expect(match?.groups).toEqual({
+      major: '4',
+      minor: '15',
+      revision: '0',
+      patch: '2',
+    })
+  })
+
+  test('should match feature candidate versions', () => {
+    const match = versionRegEx.exec('4.15.0-fc.1')
+    expect(match?.groups).toEqual({
+      major: '4',
+      minor: '15',
+      revision: '0',
+      patch: '1',
+    })
+  })
+
+  test('should not match invalid version strings', () => {
+    const match = versionRegEx.exec('invalid')
+    expect(match).toBeNull()
+  })
+})
+
+describe('versionComparator', () => {
+  test('should return 1 when first version has higher major', () => {
+    expect(versionComparator('5.0.0', '4.0.0')).toBe(1)
+  })
+
+  test('should return -1 when first version has lower major', () => {
+    expect(versionComparator('3.0.0', '4.0.0')).toBe(-1)
+  })
+
+  test('should return 1 when first version has higher minor', () => {
+    expect(versionComparator('4.15.0', '4.14.0')).toBe(1)
+  })
+
+  test('should return -1 when first version has lower minor', () => {
+    expect(versionComparator('4.13.0', '4.14.0')).toBe(-1)
+  })
+
+  test('should return 1 when first version has higher revision', () => {
+    expect(versionComparator('4.14.10', '4.14.9')).toBe(1)
+  })
+
+  test('should return -1 when first version has lower revision', () => {
+    expect(versionComparator('4.14.8', '4.14.9')).toBe(-1)
+  })
+
+  test('should return 0 when versions are equal', () => {
+    expect(versionComparator('4.14.10', '4.14.10')).toBe(0)
+  })
+
+  test('should return 1 when first version is release and second is rc', () => {
+    expect(versionComparator('4.15.0', '4.15.0-rc.4')).toBe(1)
+  })
+
+  test('should return -1 when first version is rc and second is release', () => {
+    expect(versionComparator('4.15.0-rc.4', '4.15.0')).toBe(-1)
+  })
+
+  test('should compare patch versions for release candidates', () => {
+    expect(versionComparator('4.15.0-rc.5', '4.15.0-rc.3')).toBe(1)
+    expect(versionComparator('4.15.0-rc.1', '4.15.0-rc.3')).toBe(-1)
+  })
+
+  test('should return 0 when both versions are invalid', () => {
+    expect(versionComparator('invalid', 'also-invalid')).toBe(0)
+  })
+})
+
+describe('useFetchHCPVersions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should call useQuery with correct query key', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['rosa-hcp-wizard-query-key', 'test-client-id', 'openshift-versions'],
+      })
+    )
+  })
+
+  test('should return loading state when fetching', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchHCPVersions(mockSecret))
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.error).toBeNull()
+  })
+
+  test('should return error state when fetch fails', () => {
+    const error = new Error('Network error')
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchHCPVersions(mockSecret))
+
+    expect(result.current.error).toBe(error)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  test('should return refetch function', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchHCPVersions(mockSecret))
+
+    expect(result.current.refetch).toBe(mockRefetch)
+  })
+
+  test('should provide a select function that transforms versions data', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.14.10', hosted_control_plane_default: true }),
+      createVersion({ raw_id: '4.14.9' }),
+      createVersion({ raw_id: '4.13.25' }),
+    ]
+
+    const result = selectFn(versions)
+
+    expect(result.default).toEqual({ label: '4.14.10', value: '4.14.10' })
+    expect(result.latest).toEqual({ label: '4.14.10', value: '4.14.10' })
+    expect(result.releases).toEqual(
+      expect.arrayContaining([
+        { label: '4.14.10', value: '4.14.10' },
+        { label: '4.14.9', value: '4.14.9' },
+        { label: '4.13.25', value: '4.13.25' },
+      ])
+    )
+  })
+
+  test('select function should filter out non-stable channel groups', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.14.10', channel_group: 'stable' }),
+      createVersion({ raw_id: '4.14.9', channel_group: 'candidate' }),
+      createVersion({ raw_id: '4.14.8', channel_group: 'nightly' }),
+    ]
+
+    const result = selectFn(versions)
+
+    expect(result.releases).toEqual([{ label: '4.14.10', value: '4.14.10' }])
+  })
+
+  test('select function should filter out versions past end of life', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.14.10', end_of_life_timestamp: '2099-12-31T00:00:00Z' }),
+      createVersion({ raw_id: '4.14.9', end_of_life_timestamp: '2020-01-01T00:00:00Z' }),
+    ]
+
+    const result = selectFn(versions)
+
+    expect(result.releases).toEqual([{ label: '4.14.10', value: '4.14.10' }])
+  })
+
+  test('select function should filter out versions where hosted_control_plane_enabled is false', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.14.10', hosted_control_plane_enabled: true }),
+      createVersion({ raw_id: '4.14.9', hosted_control_plane_enabled: false }),
+    ]
+
+    const result = selectFn(versions)
+
+    expect(result.releases).toEqual([{ label: '4.14.10', value: '4.14.10' }])
+  })
+
+  test('select function should filter out versions where rosa_enabled is false', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.14.10', rosa_enabled: true }),
+      createVersion({ raw_id: '4.14.9', rosa_enabled: false }),
+    ]
+
+    const result = selectFn(versions)
+
+    expect(result.releases).toEqual([{ label: '4.14.10', value: '4.14.10' }])
+  })
+
+  test('select function should limit to 3 minor version branches', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.16.1' }),
+      createVersion({ raw_id: '4.15.5' }),
+      createVersion({ raw_id: '4.14.10' }),
+      createVersion({ raw_id: '4.13.25' }),
+    ]
+
+    const result = selectFn(versions)
+
+    const versionValues = result.releases.map((r: { value: string }) => r.value)
+    expect(versionValues).toContain('4.16.1')
+    expect(versionValues).toContain('4.15.5')
+    expect(versionValues).toContain('4.14.10')
+    expect(versionValues).not.toContain('4.13.25')
+  })
+
+  test('select function should sort versions in descending order', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const versions: OpenshiftVersion[] = [
+      createVersion({ raw_id: '4.14.8' }),
+      createVersion({ raw_id: '4.14.10' }),
+      createVersion({ raw_id: '4.14.9' }),
+    ]
+
+    const result = selectFn(versions)
+
+    expect(result.releases).toEqual([
+      { label: '4.14.10', value: '4.14.10' },
+      { label: '4.14.9', value: '4.14.9' },
+      { label: '4.14.8', value: '4.14.8' },
+    ])
+  })
+
+  test('select function should handle empty versions array', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    renderHook(() => useFetchHCPVersions(mockSecret))
+
+    const queryConfig = mockUseQuery.mock.calls[0][0]
+    const selectFn = queryConfig.select
+
+    const result = selectFn([])
+
+    expect(result.default).toBeUndefined()
+    expect(result.latest).toBeUndefined()
+    expect(result.releases).toEqual([])
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -1,3 +1,5 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
 import { useSharedReactQuery } from '~/hooks/shared-react-query'
 import { getWizardVersions } from '~/lib/rosa-hcp-api'
 import { rosaWizardKeys } from './queryKeyFactory'

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -1,0 +1,107 @@
+import { useSharedReactQuery } from '~/hooks/shared-react-query'
+import { getWizardVersions } from '~/lib/rosa-hcp-api'
+import { rosaWizardKeys } from './queryKeyFactory'
+import { DropdownType, OpenshiftVersion, SelectedSecret } from '../constants/types'
+
+export const versionRegEx = /(?<major>\d+).(?<minor>\d+).(?<revision>\d+)(?:-(rc|fc).(?<patch>\d+))?/
+
+export const versionComparator = (v1: string, v2: string): number => {
+  const g1 = versionRegEx.exec(v1)?.groups
+  const g2 = versionRegEx.exec(v2)?.groups
+  if (g1 && g2) {
+    if (g1.major !== g2.major) {
+      return parseInt(g1.major, 10) > parseInt(g2.major, 10) ? 1 : -1
+    }
+    if (g1.minor !== g2.minor) {
+      return parseInt(g1.minor, 10) > parseInt(g2.minor, 10) ? 1 : -1
+    }
+    if (g1.revision !== g2.revision) {
+      return parseInt(g1.revision, 10) > parseInt(g2.revision, 10) ? 1 : -1
+    }
+    if (g1.patch !== g2.patch) {
+      // e.g. 4.6.0 is later than 4.6.0-rc.4
+      if (g1.patch === undefined) {
+        return 1
+      }
+      if (g2.patch === undefined) {
+        return -1
+      }
+      return parseInt(g1.patch, 10) > parseInt(g2.patch, 10) ? 1 : -1
+    }
+  }
+  return 0
+}
+
+const filterAndSortHCPVersions = (versions: OpenshiftVersion[]): any[] => {
+  const now = Date.now()
+
+  return versions
+    .filter((version) => version)
+    .filter((version) => !version.end_of_life_timestamp || new Date(version.end_of_life_timestamp).getTime() > now)
+    .filter((version) => version.hosted_control_plane_enabled)
+    .filter((version) => version.rosa_enabled)
+    .filter((version) => version.channel_group === 'stable')
+    .sort((a, b) => versionComparator(b.raw_id!, a.raw_id!))
+}
+
+const getVersionBranch = (versionStr: string): string | null => {
+  const groups = versionRegEx.exec(versionStr)?.groups
+  return groups ? `${groups.major}.${groups.minor}` : null
+}
+
+const transformToVersionsData = (versions: OpenshiftVersion[]): any => {
+  const sorted = filterAndSortHCPVersions(versions)
+
+  const defaultVersion = sorted.find((version) => version.hosted_control_plane_default || version.default)
+
+  const latestVersion = sorted[0]
+
+  // Only 3 4.Y versions are needed. Latest and two before with all corresponding z versions
+  const allowedBranches = new Set<string>()
+  for (const version of sorted) {
+    const val = version.raw_id ?? version.id ?? ''
+    const branch = getVersionBranch(val)
+
+    if (branch) {
+      allowedBranches.add(branch)
+      if (allowedBranches.size === 3) break
+    }
+  }
+
+  const releases: DropdownType[] = sorted
+    .filter((version) => {
+      const val = version.raw_id ?? version.id ?? ''
+      const branch = getVersionBranch(val)
+      return branch ? allowedBranches.has(branch) : false
+    })
+    .map((version) => {
+      const val = version.raw_id ?? version.id ?? ''
+      return { label: val, value: val }
+    })
+
+  return {
+    default: defaultVersion ? { label: defaultVersion.raw_id ?? '', value: defaultVersion.raw_id ?? '' } : undefined,
+    latest: latestVersion ? { label: latestVersion.raw_id ?? '', value: latestVersion.raw_id ?? '' } : undefined,
+    releases,
+  }
+}
+
+export const useFetchHCPVersions = (secrets: SelectedSecret) => {
+  const { client_id, client_secret } = secrets
+  const { useQuery } = useSharedReactQuery()
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: rosaWizardKeys.openshiftVersions(client_id),
+    queryFn: async () => {
+      const response = await getWizardVersions(client_id, client_secret)
+      return response.items ?? []
+    },
+    select: transformToVersionsData,
+  })
+
+  return {
+    data,
+    error,
+    isLoading,
+    refetch,
+  }
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -93,7 +93,7 @@ export const useFetchHCPVersions = (secrets: SelectedSecret) => {
   const { useQuery } = useSharedReactQuery()
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: rosaWizardKeys.openshiftVersions(client_id),
-    queryFn: async ({signal}) => {
+    queryFn: async ({ signal }) => {
       const response = await getWizardVersions(client_id, client_secret, signal)
       return response.items ?? []
     },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -7,38 +7,29 @@ import { DropdownType, OpenshiftVersion, SelectedSecret } from '../constants/typ
 
 export const versionRegEx = /(?<major>\d+).(?<minor>\d+).(?<revision>\d+)(?:-(rc|fc).(?<patch>\d+))?/
 
+const compareSegment = (a: string | undefined, b: string | undefined): number => {
+  if (a === b) return 0
+  if (a === undefined) return 1
+  if (b === undefined) return -1
+  return Number.parseInt(a, 10) > Number.parseInt(b, 10) ? 1 : -1
+}
 export const versionComparator = (v1: string, v2: string): number => {
   const g1 = versionRegEx.exec(v1)?.groups
   const g2 = versionRegEx.exec(v2)?.groups
-  if (g1 && g2) {
-    if (g1.major !== g2.major) {
-      return parseInt(g1.major, 10) > parseInt(g2.major, 10) ? 1 : -1
-    }
-    if (g1.minor !== g2.minor) {
-      return parseInt(g1.minor, 10) > parseInt(g2.minor, 10) ? 1 : -1
-    }
-    if (g1.revision !== g2.revision) {
-      return parseInt(g1.revision, 10) > parseInt(g2.revision, 10) ? 1 : -1
-    }
-    if (g1.patch !== g2.patch) {
-      // e.g. 4.6.0 is later than 4.6.0-rc.4
-      if (g1.patch === undefined) {
-        return 1
-      }
-      if (g2.patch === undefined) {
-        return -1
-      }
-      return parseInt(g1.patch, 10) > parseInt(g2.patch, 10) ? 1 : -1
-    }
+  if (!g1 || !g2) return 0
+  const segments: Array<'major' | 'minor' | 'revision'> = ['major', 'minor', 'revision']
+  for (const segment of segments) {
+    const result = compareSegment(g1[segment], g2[segment])
+    if (result !== 0) return result
   }
-  return 0
+  return compareSegment(g1.patch, g2.patch)
 }
 
-const filterAndSortHCPVersions = (versions: OpenshiftVersion[]): any[] => {
+const filterAndSortHCPVersions = (versions: OpenshiftVersion[]) => {
   const now = Date.now()
 
   return versions
-    .filter((version) => version)
+    .filter(Boolean)
     .filter((version) => !version.end_of_life_timestamp || new Date(version.end_of_life_timestamp).getTime() > now)
     .filter((version) => version.hosted_control_plane_enabled)
     .filter((version) => version.rosa_enabled)
@@ -51,7 +42,7 @@ const getVersionBranch = (versionStr: string): string | null => {
   return groups ? `${groups.major}.${groups.minor}` : null
 }
 
-const transformToVersionsData = (versions: OpenshiftVersion[]): any => {
+const transformToVersionsData = (versions: OpenshiftVersion[]) => {
   const sorted = filterAndSortHCPVersions(versions)
 
   const defaultVersion = sorted.find((version) => version.hosted_control_plane_default || version.default)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -73,8 +73,15 @@ const transformToVersionsData = (versions: OpenshiftVersion[]) => {
     })
 
   return {
-    default: defaultVersion ? { label: defaultVersion.raw_id ?? defaultVersion.id ?? '', value: defaultVersion.raw_id ?? defaultVersion.id ?? '' } : undefined,
-    latest: latestVersion ? { label: latestVersion.raw_id ?? latestVersion.id ?? '', value: latestVersion.raw_id ?? latestVersion.id ?? '' } : undefined,
+    default: defaultVersion
+      ? {
+          label: defaultVersion.raw_id ?? defaultVersion.id ?? '',
+          value: defaultVersion.raw_id ?? defaultVersion.id ?? '',
+        }
+      : undefined,
+    latest: latestVersion
+      ? { label: latestVersion.raw_id ?? latestVersion.id ?? '', value: latestVersion.raw_id ?? latestVersion.id ?? '' }
+      : undefined,
     releases,
   }
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -91,8 +91,8 @@ export const useFetchHCPVersions = (secrets: SelectedSecret) => {
   const { useQuery } = useSharedReactQuery()
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: rosaWizardKeys.openshiftVersions(client_id),
-    queryFn: async () => {
-      const response = await getWizardVersions(client_id, client_secret)
+    queryFn: async ({signal}) => {
+      const response = await getWizardVersions(client_id, client_secret, signal)
       return response.items ?? []
     },
     select: transformToVersionsData,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchOpenshiftVersions.ts
@@ -3,7 +3,7 @@
 import { useSharedReactQuery } from '~/hooks/shared-react-query'
 import { getWizardVersions } from '~/lib/rosa-hcp-api'
 import { rosaWizardKeys } from './queryKeyFactory'
-import { DropdownType, OpenshiftVersion, SelectedSecret } from '../constants/types'
+import type { DropdownType, OpenshiftVersion, SelectedSecret } from '../constants/types'
 
 export const versionRegEx = /(?<major>\d+).(?<minor>\d+).(?<revision>\d+)(?:-(rc|fc).(?<patch>\d+))?/
 
@@ -73,8 +73,8 @@ const transformToVersionsData = (versions: OpenshiftVersion[]) => {
     })
 
   return {
-    default: defaultVersion ? { label: defaultVersion.raw_id ?? '', value: defaultVersion.raw_id ?? '' } : undefined,
-    latest: latestVersion ? { label: latestVersion.raw_id ?? '', value: latestVersion.raw_id ?? '' } : undefined,
+    default: defaultVersion ? { label: defaultVersion.raw_id ?? defaultVersion.id ?? '', value: defaultVersion.raw_id ?? defaultVersion.id ?? '' } : undefined,
+    latest: latestVersion ? { label: latestVersion.raw_id ?? latestVersion.id ?? '', value: latestVersion.raw_id ?? latestVersion.id ?? '' } : undefined,
     releases,
   }
 }

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -196,6 +196,7 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
         '/multicloud/sts-ocm-role',
         '/multicloud/sts-role-arns',
         '/multicloud/sts-user-role',
+        '/multicloud/openshift-versions'
       ].map((backendPath) => ({
         path: backendPath,
         target: `https://localhost:${process.env.BACKEND_PORT}`,


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
PR adds backend proxy endpoint to fetch Openshift versions, filter and transform them into ROSA HCP wizard accepted format.

**Ticket Link:**  
[<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->](https://redhat.atlassian.net/browse/FCN-249)

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [X] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [X] All acceptance criteria met
- [X] Unit test coverage added or updated
- [X] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift version retrieval for the ROSA HCP wizard.
  * Added filtering and sorting to show eligible, stable, non-expired versions.
  * Added version data for default, latest, and available release selections.
  * Added development proxy support for the new version endpoint.

* **Tests**
  * Added coverage for version retrieval, authentication errors, filtering, sorting, and query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->