### PR TITLE
ACM-30173 support PQC groups

### DIFF
--- a/backend/src/lib/server.ts
+++ b/backend/src/lib/server.ts
@@ -1,24 +1,14 @@
 /* Copyright Contributors to the Open Cluster Management project */
 /* istanbul ignore file */
-import { getFips } from 'node:crypto'
-import { readFileSync } from 'node:fs'
 import type { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import { constants, createSecureServer, createServer } from 'node:http2'
+
 import type { Socket } from 'node:net'
 import type { TLSSocket } from 'node:tls'
-import { managedClusterProxy } from '../routes/managedClusterProxy'
-import { searchWebSocket } from '../routes/search'
 import { logger } from './logger'
-
-// Explicitly set ECDH curves to enable PQC (X25519MLKEM768).
-// The default image crypto policy (/etc/crypto-policies/config) does not include them.
-// In FIPS mode, X25519MLKEM768 and X25519 are not approved and must be excluded.
-const ALL_ECDH_CURVES = ['X25519MLKEM768', 'X25519', 'P-256', 'P-384']
-const FIPS_ECDH_CURVES = ['SecP256r1MLKEM768', 'SecP384r1MLKEM1024', 'P-256', 'P-384']
-
-function getEcdhCurves(fipsEnabled: boolean): string {
-  return (fipsEnabled ? FIPS_ECDH_CURVES : ALL_ECDH_CURVES).join(':')
-}
+import { managedClusterProxy } from '../routes/managedClusterProxy'
+import { readFileSync } from 'node:fs'
+import { searchWebSocket } from '../routes/search'
 
 let server: Http2Server | undefined
 
@@ -50,9 +40,8 @@ export function startServer(options: ServerOptions): Promise<Http2Server | undef
 
   try {
     if (cert && key) {
-      const ecdhCurve = getEcdhCurves(getFips() !== 0)
       logger.info({ msg: `server start`, secure: true, options })
-      server = createSecureServer({ cert, key, allowHTTP1: true, ecdhCurve, ...options }, options.requestHandler)
+      server = createSecureServer({ cert, key, allowHTTP1: true, ...options }, options.requestHandler)
     } else {
       logger.info({ msg: `server start`, secure: false })
       server = createServer(options.requestHandler)

--- a/backend/src/lib/tlsProfileWatch.ts
+++ b/backend/src/lib/tlsProfileWatch.ts
@@ -6,6 +6,7 @@ import { pipeline } from 'node:stream/promises'
 import { Transform } from 'node:stream'
 import { logger } from './logger'
 import { getCACertificate, getServiceAccountToken } from './serviceAccountToken'
+import { getFips } from 'node:crypto'
 
 type TLSProfileType = 'Old' | 'Intermediate' | 'Modern' | 'Custom'
 type TLSVersionValue = 'VersionTLS10' | 'VersionTLS11' | 'VersionTLS12' | 'VersionTLS13'
@@ -20,6 +21,7 @@ const TLS_VERSION_MAP: Record<TLSVersionValue, SecureVersion> = {
 type TLSProfileSpec = {
   minTLSVersion?: TLSVersionValue
   ciphers?: string[]
+  groups?: string[]
 }
 
 type TLSSecurityProfile = {
@@ -44,6 +46,18 @@ type APIServer = {
   spec: APIServerSpec
 }
 
+// In FIPS mode, X25519MLKEM768 and X25519 are not approved and must be excluded.
+const ALL_ECDH_CURVES = [
+  'X25519',
+  'secp256r1',
+  'secp384r1',
+  'secp521r1',
+  'X25519MLKEM768',
+  'SecP256r1MLKEM768',
+  'SecP384r1MLKEM1024',
+]
+const FIPS_ECDH_CURVES = ['secp256r1', 'secp384r1', 'secp521r1', 'SecP256r1MLKEM768', 'SecP384r1MLKEM1024']
+
 /**
  * Built-in TLS security profiles for OpenShift API servers.
  * List of ciphers and minimum TLS version for each built-inprofile can be obtained from the following command:
@@ -51,7 +65,7 @@ type APIServer = {
  * oc explain apiserver.spec.tlsSecurityProfile.<lowercase-profile-name>
  * ```
  */
-const BUILTIN_SPECS: Record<string, { minTLSVersion: TLSVersionValue; ciphers: string[] }> = {
+const BUILTIN_SPECS: Record<string, { minTLSVersion: TLSVersionValue; ciphers: string[]; groups: string[] }> = {
   Old: {
     minTLSVersion: 'VersionTLS10',
     ciphers: [
@@ -85,6 +99,7 @@ const BUILTIN_SPECS: Record<string, { minTLSVersion: TLSVersionValue; ciphers: s
       'AES256-SHA',
       'DES-CBC3-SHA',
     ],
+    groups: ['X25519MLKEM768', 'X25519', 'secp256r1', 'secp384r1'],
   },
   Intermediate: {
     minTLSVersion: 'VersionTLS12',
@@ -101,10 +116,12 @@ const BUILTIN_SPECS: Record<string, { minTLSVersion: TLSVersionValue; ciphers: s
       'DHE-RSA-AES128-GCM-SHA256',
       'DHE-RSA-AES256-GCM-SHA384',
     ],
+    groups: ['X25519MLKEM768', 'X25519', 'secp256r1', 'secp384r1'],
   },
   Modern: {
     minTLSVersion: 'VersionTLS13',
     ciphers: ['TLS_AES_128_GCM_SHA256', 'TLS_AES_256_GCM_SHA384', 'TLS_CHACHA20_POLY1305_SHA256'],
+    groups: ['X25519MLKEM768', 'X25519', 'secp256r1', 'secp384r1'],
   },
 }
 
@@ -115,12 +132,19 @@ function toNodeTLSOptions(spec?: TLSSecurityProfile): SecureContextOptions {
       : (BUILTIN_SPECS[spec?.type ?? 'Intermediate'] ?? BUILTIN_SPECS['Intermediate'])
   const minVersion = TLS_VERSION_MAP[securityProfileSpec.minTLSVersion ?? 'VersionTLS12']
   const supportedCiphers = getCiphers()
-  // If the profile is custom and the minimum TLS version is TLSv1.3, custom ciphers are currently not allowed
+  // Per OpenShift API: if the profile is custom and the minimum TLS version is TLSv1.3, custom ciphers are not allowed
   // Use the modern ciphers if none are set.
   const defaultCiphers = spec?.type === 'Custom' && minVersion === 'TLSv1.3' ? BUILTIN_SPECS['Modern'].ciphers : []
   const potentialCiphers = securityProfileSpec.ciphers?.length > 0 ? securityProfileSpec.ciphers : defaultCiphers
   const ciphers = potentialCiphers?.filter((c) => supportedCiphers.includes(c.toLowerCase())).join(':')
-  return { minVersion, ciphers }
+  // If no groups are set, explicitly set ECDH curves to enable PQC (X25519MLKEM768).
+  // The default image crypto policy (/etc/crypto-policies/config) does not include them
+  const potentialGroups =
+    securityProfileSpec.groups?.length > 0 ? securityProfileSpec.groups : BUILTIN_SPECS['Intermediate'].groups
+  const ecdhCurve = potentialGroups
+    ?.filter((g) => (getFips() !== 0 ? FIPS_ECDH_CURVES : ALL_ECDH_CURVES).includes(g))
+    .join(':')
+  return { minVersion, ciphers, ecdhCurve }
 }
 
 const API_PATH = '/apis/config.openshift.io/v1/apiservers'
@@ -308,11 +332,25 @@ async function applyIfChanged(
   opts: SecureContextOptions,
   onProfileChange: (opts: SecureContextOptions) => Promise<void>
 ): Promise<void> {
-  if (currentTLSOptions?.minVersion === opts.minVersion && currentTLSOptions?.ciphers === opts.ciphers) {
-    logger.debug({ msg: 'TLS security profile unchanged', minVersion: opts.minVersion })
+  if (
+    currentTLSOptions?.minVersion === opts.minVersion &&
+    currentTLSOptions?.ciphers === opts.ciphers &&
+    currentTLSOptions?.ecdhCurve === opts.ecdhCurve
+  ) {
+    logger.debug({
+      msg: 'TLS security profile unchanged',
+      minVersion: opts.minVersion,
+      ciphers: opts.ciphers,
+      ecdhCurve: opts.ecdhCurve,
+    })
     return
   }
-  logger.info({ msg: 'TLS security profile changed', minVersion: opts.minVersion })
+  logger.info({
+    msg: 'TLS security profile changed',
+    minVersion: opts.minVersion,
+    ciphers: opts.ciphers,
+    ecdhCurve: opts.ecdhCurve,
+  })
   currentTLSOptions = opts
   await onProfileChange(opts)
 }

--- a/backend/test/lib/tlsProfileWatch.test.ts
+++ b/backend/test/lib/tlsProfileWatch.test.ts
@@ -4,8 +4,13 @@ import nock from 'nock'
 import type { SecureContextOptions } from 'node:tls'
 import { watchTLSSecurityProfile } from '../../src/lib/tlsProfileWatch'
 import * as serviceAccountTokenModule from '../../src/lib/serviceAccountToken'
+import * as crypto from 'node:crypto'
 
 jest.mock('../../src/lib/serviceAccountToken')
+jest.mock('node:crypto', () => {
+  const actual = jest.requireActual<typeof crypto>('node:crypto')
+  return { ...actual, getFips: jest.fn(() => 0) }
+})
 
 type ProfileChangeHandler = (opts: SecureContextOptions) => Promise<void>
 
@@ -15,6 +20,7 @@ const mockedGetServiceAccountToken = serviceAccountTokenModule.getServiceAccount
 const mockedGetCACertificate = serviceAccountTokenModule.getCACertificate as jest.MockedFunction<
   typeof serviceAccountTokenModule.getCACertificate
 >
+const mockedGetFips = crypto.getFips as jest.MockedFunction<typeof crypto.getFips>
 
 function createProfileChangeMock(): jest.MockedFunction<ProfileChangeHandler> {
   return jest.fn<Promise<void>, [SecureContextOptions]>().mockResolvedValue(undefined)
@@ -22,12 +28,18 @@ function createProfileChangeMock(): jest.MockedFunction<ProfileChangeHandler> {
 
 const API_PATH = '/apis/config.openshift.io/v1/apiservers'
 
-function makeAPIServerList(resourceVersion: string, profileType?: string, minTLSVersion?: string, ciphers?: string[]) {
+function makeAPIServerList(
+  resourceVersion: string,
+  profileType?: string,
+  minTLSVersion?: string,
+  ciphers?: string[],
+  groups?: string[]
+) {
   const spec: Record<string, unknown> = {}
   if (profileType) {
     const profile: Record<string, unknown> = { type: profileType }
     if (profileType === 'Custom') {
-      profile.custom = { minTLSVersion, ciphers }
+      profile.custom = { minTLSVersion, ciphers, groups }
     }
     spec.tlsSecurityProfile = profile
   }
@@ -51,12 +63,16 @@ function makeWatchEvent(
   resourceVersion: string,
   profileType?: string,
   minTLSVersion?: string,
-  extra?: Record<string, unknown>
+  extra?: Record<string, unknown>,
+  groups?: string[],
+  ciphers?: string[]
 ) {
   const spec: Record<string, unknown> = {}
   if (profileType) {
     spec.tlsSecurityProfile = { type: profileType }
-    if (minTLSVersion) {
+    if (profileType === 'Custom') {
+      ;(spec.tlsSecurityProfile as Record<string, unknown>).custom = { minTLSVersion, ciphers, groups }
+    } else if (minTLSVersion) {
       ;(spec.tlsSecurityProfile as Record<string, unknown>).custom = { minTLSVersion }
     }
   }
@@ -97,6 +113,7 @@ describe('tlsProfileWatch', () => {
     process.env.CLUSTER_API_URL = 'https://api.test-cluster.com:6443'
     mockedGetServiceAccountToken.mockReturnValue('mock-token')
     mockedGetCACertificate.mockReturnValue(undefined)
+    mockedGetFips.mockReturnValue(0)
   })
 
   afterEach(async () => {
@@ -549,5 +566,451 @@ describe('tlsProfileWatch', () => {
     expect(onProfileChange.mock.calls[0][0].minVersion).toBe('TLSv1.2')
     expect(onProfileChange.mock.calls[1][0].minVersion).toBe('TLSv1.3')
     expect(onProfileChange.mock.calls[2][0].minVersion).toBe('TLSv1')
+  })
+
+  describe('groups/ecdhCurve', () => {
+    it('should include default groups for Intermediate profile', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(200, makeAPIServerList('1000', 'Intermediate'))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519MLKEM768:X25519:secp256r1:secp384r1')
+    })
+
+    it('should include default groups for Old profile', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443').get(API_PATH).query(true).reply(200, makeAPIServerList('1000', 'Old'))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519MLKEM768:X25519:secp256r1:secp384r1')
+    })
+
+    it('should include default groups for Modern profile', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(200, makeAPIServerList('1000', 'Modern'))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519MLKEM768:X25519:secp256r1:secp384r1')
+    })
+
+    it('should use explicit groups from Custom profile', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList('1000', 'Custom', 'VersionTLS12', ['ECDHE-RSA-AES128-GCM-SHA256'], ['X25519', 'secp256r1'])
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519:secp256r1')
+    })
+
+    it('should fall back to Intermediate groups when Custom profile has no groups', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(200, makeAPIServerList('1000', 'Custom', 'VersionTLS12', ['ECDHE-RSA-AES128-GCM-SHA256']))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519MLKEM768:X25519:secp256r1:secp384r1')
+    })
+
+    it('should include PQC hybrid groups in Custom profile when specified', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList('1000', 'Custom', 'VersionTLS13', undefined, [
+            'X25519MLKEM768',
+            'SecP256r1MLKEM768',
+            'X25519',
+            'secp256r1',
+          ])
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519MLKEM768:SecP256r1MLKEM768:X25519:secp256r1')
+    })
+
+    it('should include secp521r1 when specified in Custom profile', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList(
+            '1000',
+            'Custom',
+            'VersionTLS12',
+            ['ECDHE-RSA-AES128-GCM-SHA256'],
+            ['X25519', 'secp256r1', 'secp384r1', 'secp521r1']
+          )
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519:secp256r1:secp384r1:secp521r1')
+    })
+
+    it('should trigger onProfileChange when only groups change via watch', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList('1000', 'Custom', 'VersionTLS12', ['ECDHE-RSA-AES128-GCM-SHA256'], ['X25519', 'secp256r1'])
+        )
+
+      const watchBody =
+        makeWatchEvent(
+          'MODIFIED',
+          '1001',
+          'Custom',
+          'VersionTLS12',
+          undefined,
+          ['X25519', 'secp256r1', 'secp384r1'],
+          ['ECDHE-RSA-AES128-GCM-SHA256']
+        ) + '\n'
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .reply(200, watchBody)
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 2)
+
+      expect(onProfileChange).toHaveBeenCalledTimes(2)
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519:secp256r1')
+      expect(onProfileChange.mock.calls[1][0].ecdhCurve).toBe('X25519:secp256r1:secp384r1')
+    })
+
+    it('should not trigger onProfileChange when groups are unchanged', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList('1000', 'Custom', 'VersionTLS12', ['ECDHE-RSA-AES128-GCM-SHA256'], ['X25519', 'secp256r1'])
+        )
+
+      const watchBody =
+        makeWatchEvent(
+          'MODIFIED',
+          '1001',
+          'Custom',
+          'VersionTLS12',
+          undefined,
+          ['X25519', 'secp256r1'],
+          ['ECDHE-RSA-AES128-GCM-SHA256']
+        ) + '\n'
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .reply(200, watchBody)
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      expect(onProfileChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('FIPS mode', () => {
+    beforeEach(() => {
+      mockedGetFips.mockReturnValue(1)
+    })
+
+    it('should exclude X25519 and X25519MLKEM768 from built-in profiles in FIPS mode', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(200, makeAPIServerList('1000', 'Intermediate'))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('secp256r1:secp384r1')
+    })
+
+    it('should exclude X25519 and X25519MLKEM768 from Custom profile groups in FIPS mode', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList(
+            '1000',
+            'Custom',
+            'VersionTLS12',
+            ['ECDHE-RSA-AES128-GCM-SHA256'],
+            ['X25519MLKEM768', 'X25519', 'secp256r1', 'secp384r1']
+          )
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('secp256r1:secp384r1')
+    })
+
+    it('should allow FIPS-approved PQC hybrids in FIPS mode', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList(
+            '1000',
+            'Custom',
+            'VersionTLS12',
+            ['ECDHE-RSA-AES128-GCM-SHA256'],
+            ['SecP256r1MLKEM768', 'SecP384r1MLKEM1024', 'secp256r1', 'secp384r1']
+          )
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe(
+        'SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1'
+      )
+    })
+
+    it('should allow secp521r1 in FIPS mode', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList(
+            '1000',
+            'Custom',
+            'VersionTLS12',
+            ['ECDHE-RSA-AES128-GCM-SHA256'],
+            ['secp256r1', 'secp384r1', 'secp521r1']
+          )
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('secp256r1:secp384r1:secp521r1')
+    })
+
+    it('should result in empty ecdhCurve when only non-FIPS groups are specified', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(
+          200,
+          makeAPIServerList(
+            '1000',
+            'Custom',
+            'VersionTLS12',
+            ['ECDHE-RSA-AES128-GCM-SHA256'],
+            ['X25519MLKEM768', 'X25519']
+          )
+        )
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('')
+    })
+  })
+
+  describe('Custom profile with TLS 1.3', () => {
+    it('should use Modern ciphers when Custom profile has TLS 1.3 and no ciphers', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(200, makeAPIServerList('1000', 'Custom', 'VersionTLS13', undefined, ['X25519MLKEM768', 'X25519']))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      const opts = onProfileChange.mock.calls[0][0]
+      expect(opts.minVersion).toBe('TLSv1.3')
+      expect(opts.ecdhCurve).toBe('X25519MLKEM768:X25519')
+      // Should contain TLS 1.3 ciphers from Modern profile
+      expect(opts.ciphers).toContain('TLS_AES_128_GCM_SHA256')
+    })
+
+    it('should use explicit groups with TLS 1.3 Custom profile', async () => {
+      const onProfileChange = createProfileChangeMock()
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query(true)
+        .reply(200, makeAPIServerList('1000', 'Custom', 'VersionTLS13', undefined, ['X25519MLKEM768']))
+
+      nock('https://api.test-cluster.com:6443')
+        .get(API_PATH)
+        .query((q) => q.watch !== undefined)
+        .delay(60000)
+        .reply(200, '')
+
+      stopWatch = watchTLSSecurityProfile(onProfileChange)
+
+      await waitForCalls(onProfileChange, 1)
+
+      expect(onProfileChange.mock.calls[0][0].ecdhCurve).toBe('X25519MLKEM768')
+    })
   })
 })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Complete TLS Profile consistency work for Console

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-30173

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [X] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [X] All new display strings are externalized for localization (English only)
- [X] *(Nice to have)* JSDoc comments added for new functions and interfaces

---

### 🗒️ Notes for Reviewers

This PR adds support for customizing the elliptic-curve groups used for post-quantum cryptography support, as well as test coverage for our code that watches the `APIServer` resource for its `tlsSecurityProfile` configuration.

I ran the [tls-scanner](https://github.com/openshift/tls-scanner) with 6 different configurations on both a regular cluster and a FIPS-enabled cluster and captured the results in a couple spreadsheets. For both cases, you can see that all rows have `TRUE` for **API MinVersionCompliance** and **API Cipher Compliance**. The regular case also shows `TRUE` for **PQC Capable**, but there are currently no approved PQC groups for FIPS. The scanner has not been updated to check compliance with groups. 

Also note that for the custom configuration with ciphers specified, I used a slightly different configuration for FIPS because the one I used for the regular cluster did not contain any TLS v1.3 cipher that is compatible with FIPS. This caused nodejs to automatically use all TLS v1.3 ciphers and made the **API Cipher Compliance** fail.

[Results - Regular](https://docs.google.com/spreadsheets/d/1KMrFy7asSEK7GJgQEt-82s0KFKte5FXPa9s7ck-TokY/edit?gid=1353809603#gid=1353809603)
[Results - FIPS](https://docs.google.com/spreadsheets/d/1LT18tmzsGaVvSblD2pTb9vNnT53avlBW9-Ju2wfvUAc/edit?gid=1353809603#gid=1353809603)

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - TLS security profiles now support configurable elliptic-curve groups, including custom and post-quantum hybrid options.
  - Built-in profiles automatically select appropriate curve groups for their security level.
  - FIPS-compliant environments now receive compatible curve selections automatically.

- **Bug Fixes**
  - TLS profile updates now apply when configured curve groups change.
  - Improved handling of profiles with unsupported or unavailable curve groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->