### PR TITLE
Trim whitespace when splitting security-group annotations

### DIFF
--- a/frontend/src/routes/Governance/overview/Overview.test.tsx
+++ b/frontend/src/routes/Governance/overview/Overview.test.tsx
@@ -16,6 +16,7 @@ import {
 import GovernanceOverview from './Overview'
 import userEvent from '@testing-library/user-event'
 import { defaultContext, PluginDataContext } from '../../../lib/PluginDataContext'
+import { Policy, PolicyApiVersion, PolicyKind } from '../../../resources'
 
 describe('Overview Page', () => {
   beforeEach(async () => nockIgnoreApiPaths())
@@ -140,5 +141,77 @@ describe('Overview Page', () => {
     expect(queryByText(/show 4 more/i)).not.toBeInTheDocument()
     userEvent.click(screen.getByText(/show 85 more/i))
     expect(queryByText(/show 85 more/i)).not.toBeInTheDocument()
+  })
+
+  test('Should aggregate Standards card by trimmed annotation value, not raw comma-split token', async () => {
+    // Regression test: a standard listed anywhere but first in a comma-separated
+    // policy.open-cluster-management.io/standards annotation must not produce a
+    // separate row on the Standards card just because of the leading space left
+    // behind by String.split(',').
+    const policyWithStandardFirstInList: Policy = {
+      apiVersion: PolicyApiVersion,
+      kind: PolicyKind,
+      metadata: {
+        name: 'policy-standards-first',
+        namespace: 'test',
+        uid: 'standards-test-uid-1',
+        annotations: {
+          'policy.open-cluster-management.io/standards': 'NIST SP 800-53, PCI-DSS 4.0',
+        },
+      },
+      spec: {
+        disabled: false,
+        'policy-templates': [],
+        remediationAction: 'inform',
+      },
+      status: {
+        compliant: 'Compliant',
+      },
+    }
+    const policyWithStandardLastInList: Policy = {
+      apiVersion: PolicyApiVersion,
+      kind: PolicyKind,
+      metadata: {
+        name: 'policy-standards-last',
+        namespace: 'test',
+        uid: 'standards-test-uid-2',
+        annotations: {
+          'policy.open-cluster-management.io/standards': 'CIS OpenShift Benchmark, PCI-DSS 4.0, NIST SP 800-53',
+        },
+      },
+      spec: {
+        disabled: false,
+        'policy-templates': [],
+        remediationAction: 'inform',
+      },
+      status: {
+        compliant: 'Compliant',
+      },
+    }
+
+    const pluginData = {
+      ...defaultContext,
+      loadStarted: true,
+      loadCompleted: true,
+    }
+    render(
+      <PluginDataContext.Provider value={pluginData}>
+        <RecoilRoot
+          initializeState={(snapshot) => {
+            snapshot.set(policiesState, [policyWithStandardFirstInList, policyWithStandardLastInList])
+            snapshot.set(managedClustersState, mockManagedClusters)
+          }}
+        >
+          <MemoryRouter>
+            <GovernanceOverview />
+          </MemoryRouter>
+        </RecoilRoot>
+      </PluginDataContext.Provider>
+    )
+
+    // Before the fix this rendered two separate rows/spans for the same logical
+    // standard (one from the untrimmed " NIST SP 800-53" split token).
+    expect(screen.getAllByText('NIST SP 800-53').length).toBe(1)
+    expect(screen.getAllByText('PCI-DSS 4.0').length).toBe(1)
   })
 })

--- a/frontend/src/routes/Governance/overview/Overview.test.tsx
+++ b/frontend/src/routes/Governance/overview/Overview.test.tsx
@@ -13,7 +13,8 @@ import {
   mockPolicy,
   mockPolicyNoStatus,
 } from '../governance.sharedMocks'
-import GovernanceOverview from './Overview'
+import GovernanceOverview, { SecurityGroupViolations } from './Overview'
+import { SecurityGroupPolicySummarySidebar } from './SecurityGroupPolicySummarySidebar'
 import userEvent from '@testing-library/user-event'
 import { defaultContext, PluginDataContext } from '../../../lib/PluginDataContext'
 import { Policy, PolicyApiVersion, PolicyKind } from '../../../resources'
@@ -213,5 +214,61 @@ describe('Overview Page', () => {
     // standard (one from the untrimmed " NIST SP 800-53" split token).
     expect(screen.getAllByText('NIST SP 800-53').length).toBe(1)
     expect(screen.getAllByText('PCI-DSS 4.0').length).toBe(1)
+  })
+
+  test('SecurityGroupPolicySummarySidebar should match policies by trimmed annotation value', async () => {
+    // Regression test for the sidebar drill-down: a policy whose standard is not
+    // the first item in its comma-separated annotation must still match the
+    // clicked-on violation, which is keyed by the trimmed value.
+    const policyWithStandardLastInList: Policy = {
+      apiVersion: PolicyApiVersion,
+      kind: PolicyKind,
+      metadata: {
+        name: 'policy-standards-last-sidebar',
+        namespace: 'test',
+        uid: 'standards-test-uid-3',
+        annotations: {
+          'policy.open-cluster-management.io/standards': 'CIS OpenShift Benchmark, PCI-DSS 4.0, NIST SP 800-53',
+        },
+      },
+      spec: {
+        disabled: false,
+        'policy-templates': [],
+        remediationAction: 'inform',
+      },
+      status: {
+        compliant: 'Compliant',
+      },
+    }
+    const violation: SecurityGroupViolations = {
+      name: 'NIST SP 800-53',
+      compliant: 1,
+      noncompliant: 0,
+      pending: 0,
+    }
+
+    const pluginData = {
+      ...defaultContext,
+      loadStarted: true,
+      loadCompleted: true,
+    }
+    render(
+      <PluginDataContext.Provider value={pluginData}>
+        <RecoilRoot
+          initializeState={(snapshot) => {
+            snapshot.set(policiesState, [policyWithStandardLastInList])
+          }}
+        >
+          <MemoryRouter>
+            <SecurityGroupPolicySummarySidebar violation={violation} secGroupName="standards" compliance="compliant" />
+          </MemoryRouter>
+        </RecoilRoot>
+      </PluginDataContext.Provider>
+    )
+
+    // Before the fix, the sidebar's filter compared the untrimmed " NIST SP 800-53"
+    // split token against violation.name ("NIST SP 800-53") and never matched,
+    // so the policy would not appear in this list.
+    expect(await screen.findByText('policy-standards-last-sidebar')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/Governance/overview/Overview.tsx
+++ b/frontend/src/routes/Governance/overview/Overview.tsx
@@ -100,7 +100,7 @@ function useSecurityGroupViolations(group: string, policies: Policy[]) {
       if (policy.spec.disabled) continue
       const annotation = policy.metadata.annotations?.[`policy.open-cluster-management.io/${group}`]
       if (!annotation) continue
-      const names = annotation.split(',')
+      const names = annotation.split(',').map((name) => name.trim())
       for (const name of names) {
         let v = clusterViolations[name]
         if (!v) {

--- a/frontend/src/routes/Governance/overview/SecurityGroupPolicySummarySidebar.tsx
+++ b/frontend/src/routes/Governance/overview/SecurityGroupPolicySummarySidebar.tsx
@@ -36,7 +36,7 @@ export function SecurityGroupPolicySummarySidebar(props: {
       if (!annotation) {
         return false
       }
-      const names = annotation.split(',')
+      const names = annotation.split(',').map((name) => name.trim())
       for (const name of names) {
         if (name === violation.name && policy.status?.compliant) {
           return true


### PR DESCRIPTION
## Summary

The Governance Overview Standards/Categories/Controls cards (and the policy
drill-down sidebar behind them) group policies by splitting the
`policy.open-cluster-management.io/{standards,categories,controls}`
annotation on `,`:

```ts
const names = annotation.split(',')
for (const name of names) {
  let v = clusterViolations[name]   // raw, untrimmed string used as the aggregation key
  ...
}
```

`String.split(',')` leaves a leading space on every token after the first
(e.g. `"A, B".split(',')` → `["A", " B"]`). If the same logical value (e.g.
`"NIST SP 800-53"`) is the first item in one policy's annotation but a later
item in another policy's annotation, the two policies produce different map
keys (`"NIST SP 800-53"` vs `" NIST SP 800-53"`) and render as two separate
rows on the card instead of aggregating into one.

The same unfixed split exists in the drill-down sidebar filter
(`SecurityGroupPolicySummarySidebar.tsx`), which does a strict equality
check (`name === violation.name`) against the untrimmed token, so the
sidebar's policy list can also fail to match policies whose annotation
formatting differs from the row that was clicked.

## Fix

Trim each token after splitting, in both `useSecurityGroupViolations`
(`Overview.tsx`) and the matching filter in
`SecurityGroupPolicySummarySidebar.tsx`, so aggregation and drill-down
filtering key off the same normalized value regardless of comma-spacing.

## Reproduction (single managed cluster is sufficient)

1. Create Policy A with annotation:
   `policy.open-cluster-management.io/standards: "NIST SP 800-53, PCI-DSS 4.0"`
2. Create Policy B with annotation:
   `policy.open-cluster-management.io/standards: "CIS OpenShift Benchmark, PCI-DSS 4.0, NIST SP 800-53"`
3. Propagate both to any managed cluster, wait for Compliant status.
4. Governance Overview → Standards card shows "NIST SP 800-53" as **two**
   separate rows instead of one aggregated row.

## Test plan

- Added a regression test to `Overview.test.tsx` that renders the Standards
  card with two policies carrying the same standard in different list
  positions, and asserts a single aggregated row.
- Verified the new test **fails** without the fix (`Expected: 1, Received: 2`)
  and **passes** with it.
- `eslint --max-warnings=0` clean on all changed files.

Reported in Red Hat case 04500068.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Governance overview aggregation by trimming whitespace in comma-separated standards and security group names from annotations.
  * Fixed policy matching so clicked violation names correctly align with standards even when annotation tokens include extra spaces.
* **Tests**
  * Added regression coverage to verify standards are deduplicated after trimming and that the sidebar includes the expected policy when names match non-first tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->