### PR TITLE
MGMT-24641: Attempt to choose 5 masters for standalone cluster blocked

### DIFF
--- a/frontend/__mocks__/@openshift-assisted/dummy.ts
+++ b/frontend/__mocks__/@openshift-assisted/dummy.ts
@@ -43,8 +43,6 @@ export const ClusterInstallationError = (): any => null
 export const EventsModal = (): any => null
 export const PostInstallAlert = (): any => null
 export const ACMClusterDeploymentDetailsStep = (): any => null
-export const ACMFeatureSupportLevelProvider = ({ children }: any): any => children
-export const FeatureGateContextProvider = ({ children }: any): any => children
 export const ClusterDeploymentWizard = (): any => null
 export const EditAgentModal = (): any => null
 export const HostedClusterHostsStep = (): any => null
@@ -103,6 +101,5 @@ export type FetchSecret = any
 
 // Constants
 export const AGENT_LOCATION_LABEL_KEY = 'agentclusterinstalls.extensions.hive.openshift.io/location'
-export const ACM_ENABLED_FEATURES = 'ACM_ENABLED_FEATURES'
 export const AGENT_BMH_NAME_LABEL_KEY = 'bmac.agent-install.openshift.io/bmh'
 export const BMH_HOSTNAME_ANNOTATION = 'bmac.agent-install.openshift.io/hostname'

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/DetailsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/DetailsForm.tsx
@@ -18,11 +18,8 @@ import { AcmKubernetesLabelsInput, AcmSelect } from '../../../../../../../ui-com
 import { useTranslation } from '../../../../../../../lib/acm-i18next'
 import {
   ACMClusterDeploymentDetailsStep,
-  ACMFeatureSupportLevelProvider,
-  ACM_ENABLED_FEATURES,
   ClusterDetailsValues,
   ClusterImageSetK8sResource,
-  FeatureGateContextProvider,
   LoadingState,
   labelsToArray,
 } from '@openshift-assisted/ui-lib/cim'
@@ -287,19 +284,15 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ control, handleChange, contro
   }, [controlProps?.metadata.uid, controlProps?.stringData?.pullSecret, controlProps?.stringData?.baseDomain])
 
   return clusterImages ? (
-    <FeatureGateContextProvider features={ACM_ENABLED_FEATURES}>
-      <ACMFeatureSupportLevelProvider clusterImages={clusterImages as ClusterImageSetK8sResource[]}>
-        <ACMClusterDeploymentDetailsStep
-          formRef={formRef}
-          onValuesChanged={onValuesChanged}
-          clusterImages={clusterImages as ClusterImageSetK8sResource[]}
-          usedClusterNames={usedClusterNames}
-          extensionAfter={extensionAfter}
-          isNutanix={control.additionalProps?.isNutanix}
-          osImages={agentServiceConfig?.spec.osImages}
-        />
-      </ACMFeatureSupportLevelProvider>
-    </FeatureGateContextProvider>
+    <ACMClusterDeploymentDetailsStep
+      formRef={formRef}
+      onValuesChanged={onValuesChanged}
+      clusterImages={clusterImages as ClusterImageSetK8sResource[]}
+      usedClusterNames={usedClusterNames}
+      extensionAfter={extensionAfter}
+      isNutanix={control.additionalProps?.isNutanix}
+      osImages={agentServiceConfig?.spec.osImages}
+    />
   ) : (
     <LoadingState />
   )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
@@ -3,7 +3,6 @@
 import { useState, useMemo } from 'react'
 import { PathParam, generatePath, useLocation, useNavigate, useParams } from 'react-router'
 import {
-  ACM_ENABLED_FEATURES,
   AgentK8sResource,
   BareMetalHostK8sResource,
   ClusterDeploymentDetailsValues,
@@ -11,7 +10,6 @@ import {
   ClusterDeploymentWizardStepsType,
   ClusterImageSetK8sResource,
   EditAgentModal,
-  FeatureGateContextProvider,
   LoadingState,
   getAgentsHostsNames,
   isAgentOfInfraEnv,
@@ -171,68 +169,62 @@ const EditAICluster: React.FC = () => {
         <AcmPageContent id="edit-cluster">
           <PageSection hasBodyWrapper={false} type="wizard" isFilled>
             <BulkActionModal<AgentK8sResource | BareMetalHostK8sResource> {...bulkModalProps} />
-            <FeatureGateContextProvider features={ACM_ENABLED_FEATURES}>
-              <ClusterDeploymentWizard
-                className="cluster-deployment-wizard"
-                clusterImages={clusterImageSets as ClusterImageSetK8sResource[]}
-                clusterDeployment={clusterDeployment}
-                agentClusterInstall={agentClusterInstall}
-                bareMetalHosts={bareMetalHosts}
-                usedClusterNames={[] /* We are in Edit flow - cluster name can not be changed. */}
-                onClose={() => navigate(-1)}
-                onSaveDetails={onSaveDetails}
-                onSaveNetworking={(values) => onSaveNetworking(agentClusterInstall, values)}
-                onSaveHostsSelection={(values) =>
-                  onHostsNext({ values, clusterDeployment, agents, agentClusterInstall })
-                }
-                onApproveAgent={onApproveAgent}
-                onChangeHostname={onChangeHostname}
-                onChangeBMHHostname={onChangeBMHHostname}
-                onSaveBMH={onSaveBMH}
-                onCreateBMH={
-                  infraEnv ? getOnCreateBMH(infraEnv) : undefined
-                } /* AI Flow specific. Not called for CIM. */
-                onSaveISOParams={
-                  infraEnv ? getOnSaveISOParams(infraEnv) : undefined /* AI Flow specific. Not called for CIM. */
-                }
-                onSaveHostsDiscovery={() =>
-                  onDiscoveryHostsNext({
-                    clusterDeployment,
-                    agents: agentsOfSingleInfraEnvCluster,
-                    agentClusterInstall,
-                  })
-                }
-                fetchSecret={fetchSecret}
-                infraNMStates={infraNMStates}
-                getClusterDeploymentLink={getClusterDeploymentLink}
-                hostActions={hostActions}
-                onFinish={async () => {
-                  const aci = await onEditFinish(agentClusterInstall, clusterCurator)
-                  navigate(generatePath(NavigationPath.clusterDetails, { name, namespace }))
-                  return aci
-                }}
-                aiConfigMap={aiConfigMap}
-                infraEnv={infraEnv}
-                initialStep={(searchParams.get('initialStep') as ClusterDeploymentWizardStepsType) || undefined}
-                fetchInfraEnv={fetchInfraEnv}
-                isPreviewOpen={isPreviewOpen}
-                setPreviewOpen={setPreviewOpen}
-                fetchManagedClusters={fetchManagedClusters}
-                fetchKlusterletAddonConfig={fetchKlusterletAddonConfig}
-                onCreateBmcByYaml={importYaml}
-                docVersion={DOC_VERSION}
-                provisioningConfigResult={provisioningConfigResult}
-                isNutanix={isNutanix}
+            <ClusterDeploymentWizard
+              className="cluster-deployment-wizard"
+              clusterImages={clusterImageSets as ClusterImageSetK8sResource[]}
+              clusterDeployment={clusterDeployment}
+              agentClusterInstall={agentClusterInstall}
+              bareMetalHosts={bareMetalHosts}
+              usedClusterNames={[] /* We are in Edit flow - cluster name can not be changed. */}
+              onClose={() => navigate(-1)}
+              onSaveDetails={onSaveDetails}
+              onSaveNetworking={(values) => onSaveNetworking(agentClusterInstall, values)}
+              onSaveHostsSelection={(values) => onHostsNext({ values, clusterDeployment, agents, agentClusterInstall })}
+              onApproveAgent={onApproveAgent}
+              onChangeHostname={onChangeHostname}
+              onChangeBMHHostname={onChangeBMHHostname}
+              onSaveBMH={onSaveBMH}
+              onCreateBMH={infraEnv ? getOnCreateBMH(infraEnv) : undefined} /* AI Flow specific. Not called for CIM. */
+              onSaveISOParams={
+                infraEnv ? getOnSaveISOParams(infraEnv) : undefined /* AI Flow specific. Not called for CIM. */
+              }
+              onSaveHostsDiscovery={() =>
+                onDiscoveryHostsNext({
+                  clusterDeployment,
+                  agents: agentsOfSingleInfraEnvCluster,
+                  agentClusterInstall,
+                })
+              }
+              fetchSecret={fetchSecret}
+              infraNMStates={infraNMStates}
+              getClusterDeploymentLink={getClusterDeploymentLink}
+              hostActions={hostActions}
+              onFinish={async () => {
+                const aci = await onEditFinish(agentClusterInstall, clusterCurator)
+                navigate(generatePath(NavigationPath.clusterDetails, { name, namespace }))
+                return aci
+              }}
+              aiConfigMap={aiConfigMap}
+              infraEnv={infraEnv}
+              initialStep={(searchParams.get('initialStep') as ClusterDeploymentWizardStepsType) || undefined}
+              fetchInfraEnv={fetchInfraEnv}
+              isPreviewOpen={isPreviewOpen}
+              setPreviewOpen={setPreviewOpen}
+              fetchManagedClusters={fetchManagedClusters}
+              fetchKlusterletAddonConfig={fetchKlusterletAddonConfig}
+              onCreateBmcByYaml={importYaml}
+              docVersion={DOC_VERSION}
+              provisioningConfigResult={provisioningConfigResult}
+              isNutanix={isNutanix}
+            />
+            {editAgent && (
+              <EditAgentModal
+                agent={editAgent}
+                usedHostnames={usedHostnames}
+                onClose={() => setEditAgent(undefined)}
+                onSave={onAgentChangeHostname([editAgent], bareMetalHosts, onChangeHostname, onChangeBMHHostname)}
               />
-              {editAgent && (
-                <EditAgentModal
-                  agent={editAgent}
-                  usedHostnames={usedHostnames}
-                  onClose={() => setEditAgent(undefined)}
-                  onSave={onAgentChangeHostname([editAgent], bareMetalHosts, onChangeHostname, onChangeBMHHostname)}
-                />
-              )}
-            </FeatureGateContextProvider>
+            )}
           </PageSection>
         </AcmPageContent>
       </AcmErrorBoundary>


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

https://redhat.atlassian.net/browse/MGMT-24641

Needs https://github.com/openshift-assisted/assisted-installer-ui/pull/3912

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined the assisted installer cluster details step for a simpler creation experience.
  * Simplified the AI cluster editing workflow while preserving existing controls and actions.
  * Improved consistency across cluster creation and editing screens by removing unnecessary feature-gating layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->