### PR TITLE
Disable Renovate updates for peerDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,11 @@
   ],
   "packageRules": [
     {
+      "description": "Do not bump peerDependencies ranges — they express compatibility, not pinned versions",
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false
+    },
+    {
       "description": "Restrict npm updates to main branch only",
       "matchManagers": ["npm"],
       "matchBaseBranches": ["!/^main$/"],


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Disable Renovate updates for peerDependencies

**Ticket Link:**  
N/A — tech debt item

**Type of Change:**  
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] ~~All new display strings are externalized for localization (English only)~~ N/A
- [ ] ~~JSDoc comments added for new functions and interfaces~~ N/A

---

### 🗒️ Notes for Reviewers

**Problem:** Renovate's `rangeStrategy: "bump"` applies to `peerDependencies` entries, which causes it to narrow compatibility ranges (e.g., `"react": ">=18"` → `">=18.3.1"`). This is counterproductive — peer dependencies express what versions a package is *compatible* with, not what should be pinned. Narrowing them makes the package less flexible for consumers without any functional change, since the lockfile already resolves to the latest compatible version.

Examples of unnecessary PRs this creates:
- #6546 — react `>=18` → `>=18.3.1`
- #6547 — react-dom `>=18` → `>=18.3.1`

**Fix:** Add a `packageRules` entry that disables Renovate for all `peerDependencies` entries. This is placed first in the rules array since it's a broad exclusion rule.

Once merged, PRs #6546 and #6547 can be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update settings to prevent automatic updates for peer dependency version ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->