### PR TITLE
FCN-250: VPC api call

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -48,6 +48,7 @@ import {
   getRoleARNs,
   getUserRole,
   getWizardVersions,
+  getWizardVPCs,
 } from './routes/rosaWizardApi'
 
 const isProduction = process.env.NODE_ENV === 'production'
@@ -109,6 +110,7 @@ router.post('/oidc-configs', getWizardOIDCConfigs)
 router.post('/regions', getWizardCloudProviders)
 router.post('/cluster-name-check', getClusterNameCheck)
 router.post('/sts-role-arns', getRoleARNs)
+router.post('/vpcs', getWizardVPCs)
 router.post('/sts-ocm-role', getOCMRoleARN)
 router.post('/sts-user-role', getUserRole)
 router.post('/openshift-versions', getWizardVersions)

--- a/backend/src/routes/rosaWizardApi.ts
+++ b/backend/src/routes/rosaWizardApi.ts
@@ -35,6 +35,18 @@ type ClusterNameCheck = Payload & {
   cluster_name: string
 }
 
+type VPCPayload = Payload & {
+  aws: {
+    account_id: string
+    sts: {
+      role_arn: string
+    }
+  }
+  region: {
+    id: string
+  }
+}
+
 export async function getAwsAccountIds(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
   const token = await getAuthenticatedToken(req, res)
   if (token) {
@@ -226,6 +238,48 @@ export async function getClusterNameCheck(req: Http2ServerRequest, res: Http2Ser
 
           res.setHeader('Content-Type', 'application/json')
           res.end(JSON.stringify(accReq))
+        } catch (err) {
+          logger.error(err)
+          respondInternalServerError(req, res)
+        }
+      })
+    } catch (err) {
+      logger.error(err)
+      respondInternalServerError(req, res)
+    }
+  }
+}
+
+export async function getWizardVPCs(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
+  const token = await getAuthenticatedToken(req, res)
+  if (token) {
+    try {
+      let data: string = undefined
+      const chucks: string[] = []
+      req.on('data', (chuck: string) => {
+        chucks.push(chuck)
+      })
+
+      req.on('end', async () => {
+        try {
+          data = chucks.join('')
+          const body = JSON.parse(data) as VPCPayload
+
+          const payload = {
+            aws: body.aws,
+            region: body.region,
+          }
+
+          const accessTokenSSO = await getOcmServiceToken(body.service_account_id, body.service_account_secret)
+
+          const accountPath = `${API_URL}/api/clusters_mgmt/v1/aws_inquiries/vpcs?fetchSecurityGroups=true`
+          const request = await jsonPost(accountPath, payload, accessTokenSSO).catch((err: Error) => {
+            logger.error({ msg: 'Failed to fetch account', error: err.message })
+            return { error: err.message }
+          })
+
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify(request))
         } catch (err) {
           logger.error(err)
           respondInternalServerError(req, res)

--- a/backend/test/routes/rosaWizardApi.test.ts
+++ b/backend/test/routes/rosaWizardApi.test.ts
@@ -567,13 +567,6 @@ describe('rosaWizardApi routes', () => {
       expect(res.statusCode).toEqual(500)
     })
 
-    test('should return 401 when not authenticated', async () => {
-      nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
-
-      const res = await request('POST', '/vpcs', vpcsPayload)
-      expect(res.statusCode).toEqual(401)
-    })
-
     test('should forward error response from upstream API', async () => {
       const errorResponse = {
         kind: 'Error',

--- a/backend/test/routes/rosaWizardApi.test.ts
+++ b/backend/test/routes/rosaWizardApi.test.ts
@@ -512,4 +512,84 @@ describe('rosaWizardApi routes', () => {
       expect(res.statusCode).toEqual(401)
     })
   })
+
+  describe('POST /vpcs', () => {
+    const vpcsPayload = {
+      ...mockPayload,
+      aws: { account_id: '720424066366', sts: { role_arn: 'arn:aws:iam::720424066366:role/Installer' } },
+      region: { id: 'us-east-2' },
+    }
+
+    test('should return VPCs for given AWS account and region', async () => {
+      const vpcsResponse = {
+        kind: 'VPCList',
+        items: [
+          { vpc_id: 'vpc-123', name: 'my-vpc' },
+          { vpc_id: 'vpc-456', name: 'other-vpc' },
+        ],
+      }
+
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST)
+        .post('/api/clusters_mgmt/v1/aws_inquiries/vpcs?fetchSecurityGroups=true', {
+          aws: vpcsPayload.aws,
+          region: vpcsPayload.region,
+        })
+        .reply(200, vpcsResponse)
+
+      const res = await request('POST', '/vpcs', vpcsPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody(res)
+      expect(body).toEqual({ statusCode: 200, body: vpcsResponse })
+    })
+
+    test('should return error object when VPCs API call fails', async () => {
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST)
+        .post('/api/clusters_mgmt/v1/aws_inquiries/vpcs?fetchSecurityGroups=true')
+        .replyWithError('connection refused')
+
+      const res = await request('POST', '/vpcs', vpcsPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody<{ error: string }>(res)
+      expect(body).toEqual({ error: expect.stringContaining('connection refused') as string })
+    })
+
+    test('should return 500 when SSO token request fails', async () => {
+      nockAuth()
+      nock(SSO_HOST).post(SSO_PATH).replyWithError('SSO unavailable')
+
+      const res = await request('POST', '/vpcs', vpcsPayload)
+      expect(res.statusCode).toEqual(500)
+    })
+
+    test('should return 401 when not authenticated', async () => {
+      nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
+
+      const res = await request('POST', '/vpcs', vpcsPayload)
+      expect(res.statusCode).toEqual(401)
+    })
+
+    test('should forward error response from upstream API', async () => {
+      const errorResponse = {
+        kind: 'Error',
+        id: '400',
+        reason: 'The role ARN is not valid',
+      }
+
+      nockAuth()
+      nockSsoToken()
+      nock(API_HOST).post('/api/clusters_mgmt/v1/aws_inquiries/vpcs?fetchSecurityGroups=true').reply(400, errorResponse)
+
+      const res = await request('POST', '/vpcs', vpcsPayload)
+      expect(res.statusCode).toEqual(200)
+
+      const body = await parsePipedJsonBody(res)
+      expect(body).toEqual({ statusCode: 400, body: errorResponse })
+    })
+  })
 })

--- a/frontend/src/lib/rosa-hcp-api.test.ts
+++ b/frontend/src/lib/rosa-hcp-api.test.ts
@@ -11,6 +11,7 @@ import {
   getWizardClusterNameUniqueness,
   getWizardOIDCConfigs,
   getWizardVersions,
+  getWizardVPCs,
 } from './rosa-hcp-api'
 
 const mockFetchRetry = jest.fn()
@@ -391,6 +392,83 @@ describe('rosa-hcp-api', () => {
       })
 
       await expect(getWizardVersions('client-id', 'client-secret')).rejects.toThrow('Service account not authorized')
+    })
+  })
+
+  describe('getWizardVPCs', () => {
+    test('should call getWizardData with /vpcs path', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+
+      await getWizardVPCs('client-id', 'client-secret')
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://localhost:4000/vpcs',
+        })
+      )
+    })
+
+    test('should pass additionalData to the request body', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+
+      await getWizardVPCs('client-id', 'client-secret', undefined, {
+        aws: { account_id: '720424066366', sts: { role_arn: 'arn:aws:iam::720424066366:role/Installer' } },
+        region: { id: 'us-east-2' },
+      })
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            service_account_id: 'client-id',
+            service_account_secret: 'client-secret',
+            aws: { account_id: '720424066366', sts: { role_arn: 'arn:aws:iam::720424066366:role/Installer' } },
+            region: { id: 'us-east-2' },
+          },
+        })
+      )
+    })
+
+    test('should pass abort signal to the request', async () => {
+      mockFetchRetry.mockResolvedValue({ data: { items: [] } })
+      const controller = new AbortController()
+
+      await getWizardVPCs('client-id', 'client-secret', controller.signal)
+
+      expect(mockFetchRetry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: controller.signal,
+        })
+      )
+    })
+
+    test('should return VPC items on success', async () => {
+      const vpcsResponse = {
+        items: [
+          { vpc_id: 'vpc-123', name: 'my-vpc', subnets: [] },
+          { vpc_id: 'vpc-456', name: 'other-vpc', subnets: [] },
+        ],
+      }
+      mockFetchRetry.mockResolvedValue({ data: vpcsResponse })
+
+      const result = await getWizardVPCs('client-id', 'client-secret')
+
+      expect(result).toEqual(vpcsResponse)
+    })
+
+    test('should throw error when response contains Error kind', async () => {
+      mockFetchRetry.mockResolvedValue({
+        data: { kind: 'Error', reason: 'The role ARN is not valid' },
+      })
+
+      await expect(getWizardVPCs('client-id', 'client-secret')).rejects.toThrow('The role ARN is not valid')
+    })
+
+    test('should throw error when response body contains Error kind', async () => {
+      mockFetchRetry.mockResolvedValue({
+        data: { body: { kind: 'Error', reason: 'Forbidden' } },
+      })
+
+      await expect(getWizardVPCs('client-id', 'client-secret')).rejects.toThrow('Forbidden')
     })
   })
 })

--- a/frontend/src/lib/rosa-hcp-api.ts
+++ b/frontend/src/lib/rosa-hcp-api.ts
@@ -14,6 +14,8 @@ import {
   WizardBasePayload,
   WizardErrorResponse,
   OpenshiftVersionResponse,
+  VPCsPayload,
+  VPCsResponse,
 } from '~/resources'
 import { fetchRetry, getBackendUrl } from '~/resources/utils'
 
@@ -134,3 +136,11 @@ export const getWizardVersions = (
   signal?: AbortSignal
 ): Promise<OpenshiftVersionResponse> =>
   getWizardData<OpenshiftVersionResponse>(client_id, client_secret, '/openshift-versions', signal)
+  
+export const getWizardVPCs = (
+  client_id: string,
+  client_secret: string,
+  signal?: AbortSignal,
+  additionalData?: VPCsPayload
+): Promise<VPCsResponse> =>
+  getWizardData<VPCsResponse, VPCsPayload>(client_id, client_secret, '/vpcs', signal, additionalData)

--- a/frontend/src/lib/rosa-hcp-api.ts
+++ b/frontend/src/lib/rosa-hcp-api.ts
@@ -136,7 +136,7 @@ export const getWizardVersions = (
   signal?: AbortSignal
 ): Promise<OpenshiftVersionResponse> =>
   getWizardData<OpenshiftVersionResponse>(client_id, client_secret, '/openshift-versions', signal)
-  
+
 export const getWizardVPCs = (
   client_id: string,
   client_secret: string,

--- a/frontend/src/resources/rosa-hcp-wizard.ts
+++ b/frontend/src/resources/rosa-hcp-wizard.ts
@@ -155,6 +155,55 @@ export interface OpenshiftVersionResponse {
   items: OpenshiftVersion[]
 }
 
+export interface AWSSecurityGroup {
+  id: string
+  name: string
+  red_hat_managed: boolean
+}
+
+export interface AWSSubnets {
+  subnet_id: string
+  name: string
+  red_hat_managed: boolean
+  public: boolean
+  availability_zone: string
+  cidr_block: string
+}
+
+export interface VPC {
+  name: string
+  red_hat_managed: boolean
+  id: string
+  cidr_block: string
+  subnets?: string[]
+  aws_subnets: AWSSubnets[]
+  aws_security_groups?: AWSSecurityGroup[]
+}
+
+export interface VPCsResponse {
+  body: {
+    kind: string
+    page: number
+    size: number
+    total: number
+    items: VPC[]
+  }
+  statusCode: number
+}
+
+// Has to be types to satisfy index signature of Record<string, unknown>
 export type AwsAccountPayload = {
   aws_account_id: string
+}
+
+export type VPCsPayload = {
+  aws: {
+    account_id?: string
+    sts: {
+      role_arn?: string
+    }
+  }
+  region: {
+    id?: string
+  }
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/constants/types.ts
@@ -53,3 +53,9 @@ export interface OpenshiftVersion {
   wif_enabled: boolean
   end_of_life_timestamp: string
 }
+
+export interface VPCsPayload {
+  account_id: string
+  role_arn: string
+  region: string
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.test.ts
@@ -54,6 +54,34 @@ describe('queryKeyFactory', () => {
     expect(key).toEqual([ROSA_HCP_WIZARD_QUERY_KEY, 'test-client-id', 'openshift-versions'])
   })
 
+  test('rosaWizardKeys.vpcs should extend the base key with client id, aws account, role arn, and region', () => {
+    const key = rosaWizardKeys.vpcs(
+      'test-client-id',
+      '720424066366',
+      'arn:aws:iam::720424066366:role/Installer',
+      'us-east-2'
+    )
+    expect(key).toEqual([
+      ROSA_HCP_WIZARD_QUERY_KEY,
+      'test-client-id',
+      '720424066366',
+      'arn:aws:iam::720424066366:role/Installer',
+      'us-east-2',
+      'vpc',
+    ])
+  })
+
+  test('rosaWizardKeys.vpcs should include undefined values for optional params', () => {
+    const key = rosaWizardKeys.vpcs('test-client-id')
+    expect(key).toEqual([ROSA_HCP_WIZARD_QUERY_KEY, 'test-client-id', undefined, undefined, undefined, 'vpc'])
+  })
+
+  test('rosaWizardKeys.vpcs should produce different keys for different params', () => {
+    const key1 = rosaWizardKeys.vpcs('test-client-id', 'account-a', 'role-a', 'us-east-1')
+    const key2 = rosaWizardKeys.vpcs('test-client-id', 'account-b', 'role-b', 'eu-west-1')
+    expect(key1).not.toEqual(key2)
+  })
+
   test('each key factory call should return a new array instance', () => {
     const key1 = rosaWizardKeys.awsInfrastructureAccounts('test-client-id')
     const key2 = rosaWizardKeys.awsInfrastructureAccounts('test-client-id')

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/queryKeyFactory.ts
@@ -26,4 +26,12 @@ export const rosaWizardKeys = {
   ],
   userRoleArn: (client_id: string) => [...rosaWizardKeys.all, client_id, 'user-role-arn'],
   openshiftVersions: (client_id: string) => [...rosaWizardKeys.all, client_id, 'openshift-versions'],
+  vpcs: (client_id: string, awsAccountId?: string, installerRoleArn?: string, region?: string) => [
+    ...rosaWizardKeys.all,
+    client_id,
+    awsAccountId,
+    installerRoleArn,
+    region,
+    'vpc',
+  ],
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.test.tsx
@@ -1,0 +1,187 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useFetchVPCs } from './useFetchVPCs'
+
+const mockUseQuery = jest.fn()
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (options: unknown) => mockUseQuery(options),
+}))
+
+const mockGetWizardVPCs = jest.fn()
+jest.mock('~/lib/rosa-hcp-api', () => ({
+  getWizardVPCs: (...args: unknown[]) => mockGetWizardVPCs(...args),
+}))
+
+const mockSecret = {
+  client_id: 'test-client-id',
+  client_secret: 'test-client-secret',
+}
+
+const mockRefetch = jest.fn()
+
+describe('useFetchVPCs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+  })
+
+  test('should pass correct query key with client_id', () => {
+    renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['rosa-hcp-wizard-query-key', 'test-client-id', undefined, undefined, undefined, 'vpc'],
+      })
+    )
+  })
+
+  test('should disable query when state params are not set', () => {
+    renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    )
+  })
+
+  test('should set retry to false', () => {
+    renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retry: false,
+      })
+    )
+  })
+
+  test('should return empty array when data is undefined', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(result.current.data).toEqual([])
+  })
+
+  test('should return items from data', () => {
+    const vpcs = [
+      { vpc_id: 'vpc-123', name: 'my-vpc' },
+      { vpc_id: 'vpc-456', name: 'other-vpc' },
+    ]
+    mockUseQuery.mockReturnValue({
+      data: { items: vpcs },
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(result.current.data).toEqual(vpcs)
+  })
+
+  test('should forward loading state from useQuery', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  test('should return error string when error is present', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('The role ARN is not valid'),
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(result.current.error).toBe('Error: The role ARN is not valid')
+  })
+
+  test('should return null error when no error', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    })
+
+    const { result } = renderHook(() => useFetchVPCs(mockSecret))
+
+    expect(result.current.error).toBeNull()
+  })
+
+  test('fetch should set state params and call refetch', async () => {
+    mockRefetch.mockResolvedValue({ data: { items: [] } })
+
+    const { result } = renderHook(() => useFetchVPCs(mockSecret))
+
+    await act(async () => {
+      await result.current.fetch({
+        account_id: '720424066366',
+        role_arn: 'arn:aws:iam::720424066366:role/Installer',
+        region: 'us-east-2',
+      })
+    })
+
+    expect(mockRefetch).toHaveBeenCalled()
+  })
+
+  test('queryFn should return empty array when secret is falsy', async () => {
+    renderHook(() => useFetchVPCs(mockSecret))
+
+    const queryOptions = mockUseQuery.mock.calls[0][0]
+    const result = await queryOptions.queryFn({ signal: new AbortController().signal })
+
+    expect(result).toEqual([])
+  })
+
+  test('queryFn should call getWizardVPCs with correct params when all state is set', async () => {
+    const vpcsResponse = {
+      body: { items: [{ vpc_id: 'vpc-123' }] },
+    }
+    mockGetWizardVPCs.mockResolvedValue(vpcsResponse)
+    mockRefetch.mockResolvedValue({ data: vpcsResponse.body })
+
+    const { result, rerender } = renderHook(() => useFetchVPCs(mockSecret))
+
+    await act(async () => {
+      await result.current.fetch({
+        account_id: '720424066366',
+        role_arn: 'arn:aws:iam::720424066366:role/Installer',
+        region: 'us-east-2',
+      })
+    })
+
+    rerender()
+
+    const queryOptions = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1][0]
+    const signal = new AbortController().signal
+    const queryResult = await queryOptions.queryFn({ signal })
+
+    expect(mockGetWizardVPCs).toHaveBeenCalledWith('test-client-id', 'test-client-secret', signal, {
+      aws: { account_id: '720424066366', sts: { role_arn: 'arn:aws:iam::720424066366:role/Installer' } },
+      region: { id: 'us-east-2' },
+    })
+    expect(queryResult).toEqual(vpcsResponse.body)
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.test.tsx
@@ -146,15 +146,6 @@ describe('useFetchVPCs', () => {
     expect(mockRefetch).toHaveBeenCalled()
   })
 
-  test('queryFn should return empty array when secret is falsy', async () => {
-    renderHook(() => useFetchVPCs(mockSecret))
-
-    const queryOptions = mockUseQuery.mock.calls[0][0]
-    const result = await queryOptions.queryFn({ signal: new AbortController().signal })
-
-    expect(result).toEqual([])
-  })
-
   test('queryFn should call getWizardVPCs with correct params when all state is set', async () => {
     const vpcsResponse = {
       body: { items: [{ vpc_id: 'vpc-123' }] },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.ts
@@ -1,0 +1,46 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { useCallback, useRef, useState } from 'react'
+import { rosaWizardKeys } from './queryKeyFactory'
+import { getWizardVPCs } from '~/lib/rosa-hcp-api'
+import { useSharedReactQuery } from '~/hooks/shared-react-query'
+import { SelectedSecret } from '../constants/types'
+
+export const useFetchVPCs = (selectedSecret: SelectedSecret) => {
+  const { useQuery } = useSharedReactQuery()
+  const [awsAccountId, setAwsAccountId] = useState<string | undefined>()
+  const [installerRoleArn, setInstallerRoleArn] = useState<string | undefined>()
+  const [region, setRegion] = useState<string | undefined>()
+  const secretRef = useRef(selectedSecret)
+  secretRef.current = selectedSecret
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: rosaWizardKeys.vpcs(selectedSecret.client_id, awsAccountId, installerRoleArn, region),
+    queryFn: async ({ signal }) => {
+      const secret = secretRef.current
+      if (!secret || !awsAccountId || !installerRoleArn || !region) return []
+      const response = await getWizardVPCs(secret.client_id, secret.client_secret, signal, {
+        aws: { account_id: awsAccountId, sts: { role_arn: installerRoleArn } },
+        region: { id: region },
+      })
+      return response.body
+    },
+    enabled: !!selectedSecret && !!awsAccountId && !!installerRoleArn && !!region,
+    retry: false,
+  })
+  const fetch = useCallback(
+    async (args: any): Promise<void> => {
+      setAwsAccountId(args.account_id)
+      setInstallerRoleArn(args.role_arn)
+      setRegion(args.region)
+      await refetch()
+    },
+    [refetch]
+  )
+
+  return {
+    data: data?.items ?? [],
+    isLoading,
+    error: error ? String(error) : null,
+    fetch,
+  }
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/rosahcp/queries/useFetchVPCs.ts
@@ -17,7 +17,6 @@ export const useFetchVPCs = (selectedSecret: SelectedSecret) => {
     queryKey: rosaWizardKeys.vpcs(selectedSecret.client_id, awsAccountId, installerRoleArn, region),
     queryFn: async ({ signal }) => {
       const secret = secretRef.current
-      if (!secret || !awsAccountId || !installerRoleArn || !region) return []
       const response = await getWizardVPCs(secret.client_id, secret.client_secret, signal, {
         aws: { account_id: awsAccountId, sts: { role_arn: installerRoleArn } },
         region: { id: region },

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -196,7 +196,8 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
         '/multicloud/sts-ocm-role',
         '/multicloud/sts-role-arns',
         '/multicloud/sts-user-role',
-        '/multicloud/openshift-versions'
+        '/multicloud/openshift-versions',
+        '/multicloud/vpcs',
       ].map((backendPath) => ({
         path: backendPath,
         target: `https://localhost:${process.env.BACKEND_PORT}`,


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
API call handler and react query for VPCs endpoint for ROSA HCP wizard.

**Ticket Link:**  
[<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->](https://redhat.atlassian.net/browse/FCN-250)

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [X] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [X] All acceptance criteria met
- [X] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VPC discovery to the ROSA HCP wizard via a new `POST /vpcs` endpoint and a matching client-side API (`getWizardVPCs`).
  * Introduced a `useFetchVPCs` React hook to fetch VPCs based on AWS account/role and region (with request cancellation support).
  * Extended the development proxy to support VPC-related requests.
* **Tests**
  * Added backend and frontend coverage for successful lookups, upstream error forwarding, SSO token failures, query-key generation, and hook loading/error/data behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->