### PR TITLE
ACM-32999: GRC namespace-scoped user empty results UX [release-2.16]

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -1,6 +1,16 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { Icon, PageSection, Title, Tooltip } from '@patternfly/react-core'
-import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
+import {
+  Alert,
+  AlertVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Icon,
+  PageSection,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core'
+import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, LockIcon } from '@patternfly/react-icons'
 import { AcmEmptyState, AcmTable, AcmTableStateProvider, compareStrings } from '../../../../ui-components'
 import { ReactNode, useMemo } from 'react'
 import { Link, generatePath } from 'react-router-dom-v5-compat'
@@ -130,6 +140,21 @@ export default function PolicyDetailsResults() {
     })
     return status
   }, [policy, policies])
+
+  // All clusters the root policy reports status for (always visible regardless of RBAC)
+  const allPropagatedClusters = useMemo(
+    () => new Set((policy.status?.status ?? []).map((s) => s.clustername)),
+    [policy.status?.status]
+  )
+
+  // Clusters actually visible in the Results tab (may be a subset for namespace-scoped users)
+  const visibleClusterCount = useMemo(
+    () => new Set(policiesDeployedOnCluster.map((row) => row.cluster)).size,
+    [policiesDeployedOnCluster]
+  )
+
+  const hasNoAccess = allPropagatedClusters.size > 0 && visibleClusterCount === 0
+  const hasPartialAccess = allPropagatedClusters.size > visibleClusterCount && visibleClusterCount > 0
 
   const columns = useMemo(
     () => [
@@ -312,19 +337,49 @@ export default function PolicyDetailsResults() {
     [canCreatePolicy, t]
   )
 
+  const restrictedAccessEmptyState = (
+    <EmptyState headingLevel="h4" titleText={t('Restricted Access')} variant={EmptyStateVariant.lg} icon={LockIcon}>
+      <EmptyStateBody>
+        <p>{t("You don't have permission to view these results.")}</p>
+        <p>
+          {t(
+            'Check the Details tab for a compliance summary, or contact your cluster administrator for additional access.'
+          )}
+        </p>
+      </EmptyStateBody>
+    </EmptyState>
+  )
+
   return (
     <PageSection hasBodyWrapper={false}>
       <Title headingLevel="h3">{t('Clusters')}</Title>
+      {hasPartialAccess && (
+        <Alert
+          variant={AlertVariant.info}
+          isInline
+          title={t('Showing results for {{visible}} of {{total}} clusters.', {
+            visible: visibleClusterCount,
+            total: allPropagatedClusters.size,
+          })}
+          style={{ marginBottom: '1rem' }}
+        >
+          {t("You don't have permission to view results for the remaining clusters.")}
+        </Alert>
+      )}
       <AcmTableStateProvider localStorageKey="grc-status-view">
         <AcmTable<ResultsTableData>
           showExportButton
           exportFilePrefix={`${policy.metadata.name}-${policy.metadata.namespace}`}
           items={policiesDeployedOnCluster}
           emptyState={
-            <AcmEmptyState
-              title={t('No cluster results')}
-              message={t('No clusters are reporting status for this policy.')}
-            />
+            hasNoAccess ? (
+              restrictedAccessEmptyState
+            ) : (
+              <AcmEmptyState
+                title={t('No cluster results')}
+                message={t('No clusters are reporting status for this policy.')}
+              />
+            )
           }
           columns={columns}
           keyFn={(item) => `${item.cluster}.${item.templateName}`}

--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
@@ -16,7 +16,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { Link, generatePath } from 'react-router-dom-v5-compat'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
-import { NavigationPath } from '../../../../NavigationPath'
+import { NavigationPath, UNKNOWN_NAMESPACE } from '../../../../NavigationPath'
 import { Policy, PolicySet } from '../../../../resources'
 import { exportObjectString } from '../../../../resources/utils'
 import {
@@ -169,7 +169,14 @@ export function PolicySetDetailSidebar(props: { policySet: PolicySet }) {
           /* istanbul ignore next */
           compareStrings(a, b),
         cell: (cluster: string) => (
-          <a href={`/multicloud/infrastructure/clusters/details/${cluster}/${cluster}/overview`}>{cluster}</a>
+          <Link
+            to={generatePath(NavigationPath.clusterOverview, {
+              name: cluster,
+              namespace: cluster || UNKNOWN_NAMESPACE,
+            })}
+          >
+            {cluster}
+          </Link>
         ),
         exportContent: (cluster: string) => cluster,
       },


### PR DESCRIPTION
## Summary

Backport of #6594 to release-2.16.

Implements the agreed UX for namespace-scoped users who cannot see propagated policy results on the GRC Results tab.

- **Restricted Access empty state**: When a namespace-scoped user has zero visible results but `policy.status.status` confirms the policy is propagated to clusters, show a "Restricted Access" empty state (LockIcon) with messaging to check the Details tab or contact an admin.
- **Partial access inline alert**: When a user can see *some* but not *all* cluster results, show an inline info Alert above the table with accurate counts.
- **PolicySetDetailSidebar link fix**: Replace hardcoded `<a href>` cluster link with React Router `<Link>` + `generatePath`.

Relates to: ACM-32999

## Test plan

- [ ] As a full-access admin user, verify Results tab shows normally
- [ ] As a namespace-scoped user with zero access: Results tab shows "Restricted Access" empty state
- [ ] As a namespace-scoped user with partial access: Results tab shows visible results + inline alert
- [ ] PolicySet sidebar cluster links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)