### PR TITLE
ACM-39213 fix(backend): use GET /api with body drain instead of HEAD [release-2.17]

### DIFF
--- a/backend/src/lib/authenticated.ts
+++ b/backend/src/lib/authenticated.ts
@@ -7,9 +7,8 @@ export function authenticated(req: Http2ServerRequest, res: Http2ServerResponse)
   const token = getToken(req)
   if (!token) return unauthorized(req, res)
   isAuthenticated(token)
-    .then((response) => {
-      res.writeHead(response.status).end()
-      void response.blob()
+    .then((status) => {
+      res.writeHead(status).end()
     })
     .catch(catchInternalServerError(res))
 }

--- a/backend/src/lib/token.ts
+++ b/backend/src/lib/token.ts
@@ -28,10 +28,15 @@ export function getToken(req: Http2ServerRequest): string | undefined {
   return token
 }
 
-export async function isAuthenticated(token: string) {
-  return fetchRetry(process.env.CLUSTER_API_URL + '/apis', {
+// GET /api returns the core API group (~200 bytes) — unlike /apis which grows
+// with every installed CRD. The response body is drained so the socket returns
+// to the keepAlive pool immediately and native memory does not accumulate.
+export async function isAuthenticated(token: string): Promise<number> {
+  const response = await fetchRetry(process.env.CLUSTER_API_URL + '/api', {
     headers: { [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${token}` },
   })
+  response.body?.on('error', () => undefined).resume()
+  return response.status
 }
 
 export const isHttp2ServerResponse = (
@@ -51,22 +56,19 @@ export async function getAuthenticatedToken(
   const token = getToken(req)
 
   if (token) {
-    const authResponse = await isAuthenticated(token)
+    const status = await isAuthenticated(token)
     /* istanbul ignore if */
-    if (authResponse.status === constants.HTTP_STATUS_OK) {
+    if (status === constants.HTTP_STATUS_OK) {
       if (process.env.NODE_ENV === 'development') {
         const localStorage = new LocalStorage(LOCAL_STORAGE)
         localStorage.setItem(ADMIN_TOKEN, token)
       }
       return token
+    }
+    if (isHttp2ServerResponse(resOrSocket)) {
+      resOrSocket.writeHead(status).end()
     } else {
-      if (isHttp2ServerResponse(resOrSocket)) {
-        resOrSocket.writeHead(authResponse.status).end()
-      } else {
-        resOrSocket.destroy()
-      }
-
-      void authResponse.blob()
+      resOrSocket.destroy()
     }
   } else if (isHttp2ServerResponse(resOrSocket)) {
     unauthorized(req, resOrSocket)

--- a/backend/src/routes/liveness.ts
+++ b/backend/src/routes/liveness.ts
@@ -29,15 +29,15 @@ export function setDead(): void {
 export async function apiServerPing(): Promise<void> {
   const msg = 'kube api server ping failed'
   try {
-    const response = await fetchRetry(process.env.CLUSTER_API_URL + '/apis', {
+    const response = await fetchRetry(process.env.CLUSTER_API_URL + '/api', {
       headers: { [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${getServiceAccountToken()}` },
     })
+    response.body?.on('error', () => undefined).resume()
     if (response.status !== 200) {
       const { status } = response
       logger.error({ msg, response: { status } })
       setDead()
     }
-    void response.blob()
   } catch (err) {
     if (err instanceof FetchError) {
       logger.error({ msg, error: err.message })

--- a/backend/test/routes/aggregator.test.ts
+++ b/backend/test/routes/aggregator.test.ts
@@ -51,7 +51,7 @@ describe(`aggregator Route`, function () {
   })
 
   it(`should page Unfiltered Applications`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
 
     // initialize events - cache sequentially to ensure deterministic order
     for (const resource of resources) {
@@ -98,7 +98,7 @@ describe(`aggregator Route`, function () {
     expect(await parseResponseJsonBody(res)).toEqual(responseNoFilter)
   })
   it(`should page Filtered Applications`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
 
     // initialize events - cache sequentially to ensure deterministic order
     for (const resource of resources) {
@@ -129,7 +129,7 @@ describe(`aggregator Route`, function () {
     expect(await parseResponseJsonBody(res)).toEqual(responseFiltered)
   })
   it(`should return application  counts`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
 
     // initialize events - cache sequentially to ensure deterministic order
     for (const resource of resources) {
@@ -153,7 +153,7 @@ describe(`aggregator Route`, function () {
     expect(await parseResponseJsonBody(res)).toEqual(responseCount)
   })
   it(`should return appset data`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
 
     // initialize events - cache sequentially to ensure deterministic order
     for (const resource of resources) {

--- a/backend/test/routes/ansibletower.test.ts
+++ b/backend/test/routes/ansibletower.test.ts
@@ -8,7 +8,7 @@ const TOWER_HOST = 'https://ansible-tower.com'
 
 describe(`ansibletower Route`, function () {
   it(`should list Ansible Automation controller Jobs`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
       towerHost: TOWER_HOST + ansiblePaths[0],
@@ -19,7 +19,7 @@ describe(`ansibletower Route`, function () {
   })
 
   it(`when bad things happen to Ansible Automation controller Jobs 1`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
       towerHost: TOWER_HOST + '/badPath',
@@ -30,7 +30,7 @@ describe(`ansibletower Route`, function () {
   })
 
   it(`when bad things happen to Ansible Automation controller Jobs 2`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
       token: '12345',
@@ -39,7 +39,7 @@ describe(`ansibletower Route`, function () {
   })
 
   it(`when bad things happen to Ansible Automation controller Jobs 3`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(400)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(400)
     const res = await request('POST', '/ansibletower')
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify({}))
   })

--- a/backend/test/routes/apiPath.test.ts
+++ b/backend/test/routes/apiPath.test.ts
@@ -15,7 +15,7 @@ describe(`apiPath Route`, function () {
 
     nock(process.env.CLUSTER_API_URL).get(paths[0]).reply(200, response)
 
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
       paths: response,
     })

--- a/backend/test/routes/hub.test.ts
+++ b/backend/test/routes/hub.test.ts
@@ -6,7 +6,7 @@ import { cacheResource, resetResourceCache } from '../../src/routes/events'
 import { request } from '../mock-request'
 
 function mockCrdNock(url: string) {
-  const apisScope = nock(url).get('/apis').reply(200, { status: 200 })
+  const apisScope = nock(url).get('/api').reply(200, { status: 200 })
   const crdScope = nock(url)
     .get('/apis/apiextensions.k8s.io/v1/customresourcedefinitions')
     .reply(200, {

--- a/backend/test/routes/hypershift-status.test.ts
+++ b/backend/test/routes/hypershift-status.test.ts
@@ -4,7 +4,7 @@ import { parseResponseJsonBody } from '../../src/lib/body-parser'
 import nock from 'nock'
 
 describe('hypershift-status Route', function () {
-  const mockAuth = () => nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, { status: 200 })
+  const mockAuth = () => nock(process.env.CLUSTER_API_URL).get('/api').reply(200, { status: 200 })
 
   const mockMCE = (hypershiftEnabled = true, localHostingEnabled = true) =>
     nock(process.env.CLUSTER_API_URL)

--- a/backend/test/routes/liveness.test.ts
+++ b/backend/test/routes/liveness.test.ts
@@ -9,7 +9,7 @@ describe(`liveness Route`, function () {
     expect(res.statusCode).toEqual(200)
   })
   it(`GET /livenessProbe should return status code 500 if dead`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(401)
     await apiServerPing()
     const res = await request('GET', '/livenessProbe')
     expect(res.statusCode).toEqual(500)

--- a/backend/test/routes/metricsProxy.test.ts
+++ b/backend/test/routes/metricsProxy.test.ts
@@ -4,14 +4,14 @@ import { request } from '../mock-request'
 
 describe('metrics proxy route', function () {
   it('Successfully calls prometheus endpoint', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     const res = await request('GET', '/prometheus/query')
     expect(res.statusCode).toEqual(200)
   })
   it(`Successfully calls observability endpoint`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     const res = await request('GET', '/observability/query')

--- a/backend/test/routes/operatorCheck.test.ts
+++ b/backend/test/routes/operatorCheck.test.ts
@@ -23,7 +23,7 @@ const subscriptionOperators = {
 
 describe(`operatorCheck Route`, function () {
   it(`returns valid response with version for installed operator`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL)
@@ -38,7 +38,7 @@ describe(`operatorCheck Route`, function () {
     })
   })
   it(`returns valid response for not-installed operator`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL)
@@ -52,7 +52,7 @@ describe(`operatorCheck Route`, function () {
     })
   })
   it(`returns bad request for arbitrary operator`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL)

--- a/backend/test/routes/placementDebug.test.ts
+++ b/backend/test/routes/placementDebug.test.ts
@@ -5,7 +5,7 @@ import nock from 'nock'
 const upstreamHost = 'https://cluster-manager-placement.open-cluster-management-hub.svc.cluster.local:9443'
 
 function nockAuth(status = 200) {
-  nock(process.env.CLUSTER_API_URL).get('/apis').reply(status, { status })
+  nock(process.env.CLUSTER_API_URL).get('/api').reply(status, { status })
 }
 
 describe(`placementDebug Route`, function () {

--- a/backend/test/routes/readiness.test.ts
+++ b/backend/test/routes/readiness.test.ts
@@ -9,7 +9,7 @@ describe(`readiness Route`, function () {
     expect(res.statusCode).toEqual(200)
   })
   it(`GET /readinessProbe should return status code 500 if dead`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(401)
     await apiServerPing()
     const res = await request('GET', '/readinessProbe')
     expect(res.statusCode).toEqual(500)

--- a/backend/test/routes/search.test.ts
+++ b/backend/test/routes/search.test.ts
@@ -4,7 +4,7 @@ import nock from 'nock'
 
 describe(`search Route`, function () {
   it(`uses search-api in the namespace of the MultiClusterHub`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL)
@@ -27,7 +27,7 @@ describe(`search Route`, function () {
     //expect(res.statusCode).toEqual(200)
   })
   it(`uses search-api in namespace of pod if no MultiClusterHub`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL).get('/apis/operator.open-cluster-management.io/v1/multiclusterhubs').reply(200, {

--- a/backend/test/routes/upgrade-risks-prediction.test.ts
+++ b/backend/test/routes/upgrade-risks-prediction.test.ts
@@ -11,7 +11,7 @@ describe('Upgrade risks prediction Route', function () {
   it('should use UPGRADE_RISKS_PREDICTION_URL env var when set', async function () {
     process.env.UPGRADE_RISKS_PREDICTION_URL =
       'https://on-prem.example.com/api/insights-results-aggregator/v2/upgrade-risks-prediction'
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .get('/api/v1/namespaces/openshift-config/secrets')
       .reply(200, {
@@ -38,7 +38,7 @@ describe('Upgrade risks prediction Route', function () {
   })
 
   it('should return the upgrade risks', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .get('/api/v1/namespaces/openshift-config/secrets')
       .reply(200, {

--- a/backend/test/routes/username.test.ts
+++ b/backend/test/routes/username.test.ts
@@ -5,7 +5,7 @@ import nock from 'nock'
 
 describe('username Route', function () {
   it('should return the username', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL)
@@ -23,7 +23,7 @@ describe('username Route', function () {
     expect(body).toEqual({ username: 'testuser' })
   })
   it('should return empty string if no username provided', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200, {
       status: 200,
     })
     nock(process.env.CLUSTER_API_URL)

--- a/backend/test/routes/userpreference.test.ts
+++ b/backend/test/routes/userpreference.test.ts
@@ -5,7 +5,7 @@ import { request } from '../mock-request'
 
 describe('userpreference Route', function () {
   it('should return the userpreference', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post('/apis/authentication.k8s.io/v1/tokenreviews')
       .reply(200, {
@@ -53,7 +53,7 @@ describe('userpreference Route', function () {
         savedSearches: [{ description: '', id: '1678205878189', name: 'testing', searchText: 'kind:Pod' }],
       },
     }
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post('/apis/authentication.k8s.io/v1/tokenreviews')
       .reply(200, {

--- a/backend/test/routes/virtualMachineProxy.test.ts
+++ b/backend/test/routes/virtualMachineProxy.test.ts
@@ -10,7 +10,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully call start action', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -57,7 +57,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully call pause action', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -104,7 +104,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully take snapshot action', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -175,7 +175,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should error on start action request', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -220,7 +220,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should fail with invalid route and secret', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -252,7 +252,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully restore a snapshot', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -323,7 +323,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully get VM', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -366,7 +366,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully get VM snapshot', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -409,7 +409,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully delete VM', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -457,7 +457,7 @@ describe('Virtual Machine actions', function () {
   })
 
   it('should successfully delete VM Snapshot', async function () {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
     nock(process.env.CLUSTER_API_URL)
       .post(
         '/apis/authorization.k8s.io/v1/selfsubjectaccessreviews',
@@ -507,7 +507,7 @@ describe('Virtual Machine actions', function () {
 
 describe('vmResourceUsageProxy', () => {
   beforeEach(() => {
-    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL).get('/api').reply(200)
   })
   afterEach(() => {
     nock.cleanAll()


### PR DESCRIPTION
## Summary
- Fixes 405 regression from the original HEAD /api approach — `HEAD /api` is rejected by some cluster API server / proxy configurations
- Switches `isAuthenticated()` to `GET /api` with explicit body drain (`.resume()`)
- Also fixes `apiServerPing()` in `liveness.ts` from `GET /apis` to `GET /api` with body drain (same memory leak pattern, flagged by Kevin)
- Preserves the memory leak fix: `/api` response is ~200 bytes (vs several MB for `/apis`), drained immediately so sockets return to the keepAlive pool

## Changes
- `backend/src/lib/token.ts`: GET /api with body drain, returns `Promise<number>`
- `backend/src/lib/authenticated.ts`: updated to consume numeric status from `isAuthenticated()`
- `backend/src/routes/liveness.ts`: `apiServerPing()` switched from GET /apis to GET /api with body drain
- All test files: nock interceptors updated from `.get('/apis')` to `.get('/api')`

## Test plan
- [x] All backend unit tests pass (261 tests)

Backport of #6600 to release-2.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)