### PR TITLE
ACM-32281 Use system label on FG RBAC Placements

### DIFF
--- a/frontend/src/resources/clients/constants.ts
+++ b/frontend/src/resources/clients/constants.ts
@@ -3,3 +3,10 @@
 export const ManagedByConsoleLabelKey = 'open-cluster-management.io/managed-by'
 export const ManagedByConsoleLabelValue = 'console'
 export const ManagedByConsoleLabel: Record<string, string> = { [ManagedByConsoleLabelKey]: ManagedByConsoleLabelValue }
+
+/** System label for Placements created by fine-grained RBAC (aligns with MTV / GitOps). */
+export const PlacementManagedBySystemLabelKey = 'cluster.open-cluster-management.io/placement-managed-by-system'
+export const PlacementManagedBySystemLabelValue = 'true'
+export const PlacementManagedBySystemLabel: Record<string, string> = {
+  [PlacementManagedBySystemLabelKey]: PlacementManagedBySystemLabelValue,
+}

--- a/frontend/src/resources/clients/placement-client.test.ts
+++ b/frontend/src/resources/clients/placement-client.test.ts
@@ -6,7 +6,11 @@ import { GlobalPlacementName, Placement, PlacementApiVersionBeta, PlacementKind 
 import { PlacementDecision } from '../placement-decision'
 import { MatchExpressions } from '../selector'
 import { createResource } from '../utils'
-import { ManagedByConsoleLabel, ManagedByConsoleLabelKey, ManagedByConsoleLabelValue } from './constants'
+import {
+  PlacementManagedBySystemLabel,
+  PlacementManagedBySystemLabelKey,
+  PlacementManagedBySystemLabelValue,
+} from './constants'
 import {
   createForClusters,
   createForClusterSets,
@@ -474,7 +478,7 @@ describe('placement-client', () => {
         metadata: {
           name: 'cluster-sets-cluster-set-1-and-cluster-set-2',
           namespace: MulticlusterRoleAssignmentNamespace,
-          labels: ManagedByConsoleLabel,
+          labels: PlacementManagedBySystemLabel,
         },
         spec: {
           clusterSets,
@@ -559,7 +563,7 @@ describe('placement-client', () => {
       )
     })
 
-    it('should include metadata.labels (ManagedByConsoleLabel)', () => {
+    it('should include metadata.labels (PlacementManagedBySystemLabel)', () => {
       // Arrange
       const clusterSets = ['label-test']
       const mockResult = {
@@ -575,13 +579,13 @@ describe('placement-client', () => {
       expect(createResourceMock).toHaveBeenCalledWith(
         expect.objectContaining({
           metadata: expect.objectContaining({
-            labels: ManagedByConsoleLabel,
+            labels: PlacementManagedBySystemLabel,
           }),
         })
       )
     })
 
-    it('should set managed-by label with OCM key (open-cluster-management.io/managed-by: console) to avoid literal key regression', () => {
+    it('should set placement-managed-by-system label with OCM key (cluster.open-cluster-management.io/placement-managed-by-system: true) to avoid literal key regression', () => {
       const clusterSets = ['regression-label-key']
       createResourceMock.mockReturnValue({
         promise: Promise.resolve({} as Placement),
@@ -589,8 +593,8 @@ describe('placement-client', () => {
       })
       createForClusterSets(clusterSets)
       const placement = createResourceMock.mock.calls[0][0] as Placement
-      expect(placement.metadata?.labels?.[ManagedByConsoleLabelKey]).toBe(ManagedByConsoleLabelValue)
-      expect(placement.metadata?.labels).not.toHaveProperty('ManagedByConsoleLabelKey')
+      expect(placement.metadata?.labels?.[PlacementManagedBySystemLabelKey]).toBe(PlacementManagedBySystemLabelValue)
+      expect(placement.metadata?.labels).not.toHaveProperty('PlacementManagedBySystemLabelKey')
     })
 
     it('should return the IRequestResult from createResource', () => {
@@ -666,7 +670,7 @@ describe('placement-client', () => {
         metadata: {
           name: 'clusters-cluster-1-and-cluster-2',
           namespace: MulticlusterRoleAssignmentNamespace,
-          labels: ManagedByConsoleLabel,
+          labels: PlacementManagedBySystemLabel,
         },
         spec: {
           predicates: [
@@ -836,7 +840,7 @@ describe('placement-client', () => {
       )
     })
 
-    it('should include metadata.labels (ManagedByConsoleLabel)', () => {
+    it('should include metadata.labels (PlacementManagedBySystemLabel)', () => {
       // Arrange
       const clusters = ['label-test']
       const mockResult = {
@@ -852,13 +856,13 @@ describe('placement-client', () => {
       expect(createResourceMock).toHaveBeenCalledWith(
         expect.objectContaining({
           metadata: expect.objectContaining({
-            labels: ManagedByConsoleLabel,
+            labels: PlacementManagedBySystemLabel,
           }),
         })
       )
     })
 
-    it('should set managed-by label with OCM key (open-cluster-management.io/managed-by: console) to avoid literal key regression', () => {
+    it('should set placement-managed-by-system label with OCM key (cluster.open-cluster-management.io/placement-managed-by-system: true) to avoid literal key regression', () => {
       const clusters = ['regression-label-key']
       createResourceMock.mockReturnValue({
         promise: Promise.resolve({} as Placement),
@@ -866,8 +870,8 @@ describe('placement-client', () => {
       })
       createForClusters(clusters)
       const placement = createResourceMock.mock.calls[0][0] as Placement
-      expect(placement.metadata?.labels?.[ManagedByConsoleLabelKey]).toBe(ManagedByConsoleLabelValue)
-      expect(placement.metadata?.labels).not.toHaveProperty('ManagedByConsoleLabelKey')
+      expect(placement.metadata?.labels?.[PlacementManagedBySystemLabelKey]).toBe(PlacementManagedBySystemLabelValue)
+      expect(placement.metadata?.labels).not.toHaveProperty('PlacementManagedBySystemLabelKey')
     })
   })
 
@@ -883,7 +887,7 @@ describe('placement-client', () => {
       })
     })
 
-    // Helper to create a placement with predicates (includes ManagedByConsoleLabel so useFindPlacements returns it)
+    // Helper to create a placement with predicates (includes PlacementManagedBySystemLabel so useFindPlacements returns it)
     const createPlacementWithPredicates = (
       name: string,
       clusterNames: string[],
@@ -891,7 +895,7 @@ describe('placement-client', () => {
     ): Placement => ({
       apiVersion: PlacementApiVersionBeta,
       kind: PlacementKind,
-      metadata: { name, namespace: 'default', labels: ManagedByConsoleLabel },
+      metadata: { name, namespace: 'default', labels: PlacementManagedBySystemLabel },
       spec: {
         predicates: [
           {
@@ -955,7 +959,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'no-predicates', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'no-predicates', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {},
         }
         useRecoilValueMock.mockReturnValue([placement, globalPlacement])
@@ -975,7 +979,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'empty-predicates', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'empty-predicates', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: { predicates: [] },
         }
         useRecoilValueMock.mockReturnValue([placement, globalPlacement])
@@ -995,7 +999,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'wrong-key', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'wrong-key', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1028,7 +1032,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'mixed-keys', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'mixed-keys', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1062,7 +1066,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'no-label-selector', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'no-label-selector', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1088,7 +1092,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'no-match-expressions', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'no-match-expressions', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1116,7 +1120,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'empty-match-expressions', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'empty-match-expressions', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1146,7 +1150,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'no-values', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'no-values', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1176,7 +1180,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'empty-values', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'empty-values', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1206,7 +1210,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'falsy-values', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'falsy-values', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1242,7 +1246,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'duplicates', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'duplicates', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1282,7 +1286,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'multi-predicates', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'multi-predicates', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {
             predicates: [
               {
@@ -1387,7 +1391,7 @@ describe('placement-client', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,
-          metadata: { name: 'decision-only-clusters', namespace: 'default', labels: ManagedByConsoleLabel },
+          metadata: { name: 'decision-only-clusters', namespace: 'default', labels: PlacementManagedBySystemLabel },
           spec: {},
         }
         const placementDecision = createPlacementDecision('decision-3', 'decision-only-clusters', [
@@ -1504,8 +1508,8 @@ describe('placement-client', () => {
       })
     })
 
-    describe('labels filter (ManagedByConsoleLabel)', () => {
-      it('should return only placements that have ManagedByConsoleLabel', () => {
+    describe('labels filter (PlacementManagedBySystemLabel)', () => {
+      it('should return only placements that have PlacementManagedBySystemLabel', () => {
         const withLabel = createPlacementWithPredicates('with-label', ['cluster-a'])
         const withoutLabel: Placement = {
           apiVersion: PlacementApiVersionBeta,
@@ -1534,7 +1538,7 @@ describe('placement-client', () => {
         expect(result.current[1].placement.metadata.name).toBe(GlobalPlacementName)
       })
 
-      it('should return empty array when no placements have ManagedByConsoleLabel', () => {
+      it('should return empty array when no placements have PlacementManagedBySystemLabel', () => {
         const placement: Placement = {
           apiVersion: PlacementApiVersionBeta,
           kind: PlacementKind,

--- a/frontend/src/resources/clients/placement-client.ts
+++ b/frontend/src/resources/clients/placement-client.ts
@@ -11,7 +11,7 @@ import {
 } from '../placement'
 import { PlacementDecision } from '../placement-decision'
 import { createResource, IRequestResult } from '../utils'
-import { ManagedByConsoleLabel } from './constants'
+import { PlacementManagedBySystemLabel } from './constants'
 import { PlacementClusters } from './model/placement-clusters'
 import { getClustersFromPlacementDecision, useFindPlacementDecisions } from './placement-decision-client'
 
@@ -211,7 +211,7 @@ const doesPlacementDecisionBelongToPlacement = (placementDecision: PlacementDeci
 export const useGetPlacementClusters = (placementNames?: string[]): PlacementClusters[] => {
   const placements = useFindPlacements({
     placementNames,
-    labels: [ManagedByConsoleLabel],
+    labels: [PlacementManagedBySystemLabel],
     includeGlobalPlacement: true,
   })
   const placementDecisions = useFindPlacementDecisions({
@@ -298,7 +298,7 @@ const createPlacement = (
     metadata: {
       name: producePlacementName(nameElements, namePrefix),
       namespace,
-      labels: ManagedByConsoleLabel,
+      labels: PlacementManagedBySystemLabel,
     },
     spec: {
       ...specContent,


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Fine grained RBAC label Placements created for MulticlusterRoleAssignment with a system label

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-32281

**Type of Change:**  
- [ ] 🐞 Bug Fix  
- [x] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [x] All acceptance criteria met
- [x] Unit test coverage added or updated
- [x] Relevant documentation or comments included

---

### 🗒️ Notes for Reviewers

Placements created for MulticlusterRoleAssignment now use:

`cluster.open-cluster-management.io/placement-managed-by-system: "true"`

instead of:

`open-cluster-management.io/managed-by: "console"`

MulticlusterRoleAssignment resources still use `open-cluster-management.io/managed-by: "console"` (unchanged).

#### Existing Placements (doc / manual relabel)

This PR does **not** auto-migrate existing Placements. Operators can relabel console-created FG RBAC Placements so they filter correctly on the Placements table and match the new lookup key:

```bash
# List Placements still using the legacy label (typically in open-cluster-management-global-set)
oc get placement -A -l open-cluster-management.io/managed-by=console

# Relabel a specific Placement (example namespace/name)
oc label placement <placement-name> -n open-cluster-management-global-set \
  cluster.open-cluster-management.io/placement-managed-by-system=true \
  open-cluster-management.io/managed-by-

# Or relabel all matching Placements in the FG RBAC namespace
oc label placement -n open-cluster-management-global-set \
  -l open-cluster-management.io/managed-by=console \
  cluster.open-cluster-management.io/placement-managed-by-system=true \
  open-cluster-management.io/managed-by-
```

(`open-cluster-management.io/managed-by-` removes the old key.)

Please also create/link a Customer Portal Doc issue from [The Playbook](https://docs.google.com/document/d/1YTqpZRH54Bnn4WJ2nZmjaCoiRtqmrc2w6DdQxe_yLZ8/edit#heading=h.9fvyr2rdriby) covering this relabel guidance.

#### console-e2e unchanged

No updates to `console-e2e` are required. FG-RBAC e2e asserts the `open-cluster-management.io/managed-by: console` label on **MulticlusterRoleAssignment** resources only (`MCRA_RESOURCE`), not on Placement CRs. Placement names referenced in MCRA specs are unchanged.

#### How to test (plugin mode)

1. Run `npm run plugins` and open http://localhost:9000
2. With fine-grained RBAC enabled, create a role assignment that creates a Placement
3. Confirm the Placement has `cluster.open-cluster-management.io/placement-managed-by-system=true` and does not have the legacy managed-by label
4. Confirm MRA resources still have `open-cluster-management.io/managed-by=console`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated placement management to use the correct system-managed label.
  * Placement creation and cluster retrieval now consistently identify system-managed placements.
  * Updated filtering behavior to exclude placements using the outdated console-managed label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->