### PR TITLE
Fix example Jira link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 <!-- Use the exact title from Jira or a brief, clear summary -->
 
 **Ticket Link:**  
-<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
+<!-- e.g. https://redhat.atlassian.net/browse/ACM-12345 -->
 
 **Type of Change:**  
 <!-- Select one -->

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -1121,7 +1121,7 @@ export function getKubeApiServer(
   return (
     clusterDeployment?.status?.apiURL ??
     managedClusterInfo?.spec?.masterEndpoint ??
-    // Temporary workaround until https://issues.redhat.com/browse/HIVE-1666
+    // Temporary workaround until https://redhat.atlassian.net/browse/HIVE-1666
     getClusterApiUrlAI(clusterDeployment as ClusterDeploymentK8sResource, agentClusterInstall)
   )
 }
@@ -1158,7 +1158,7 @@ export function getConsoleUrl(
   return (
     clusterDeployment?.status?.webConsoleURL ??
     managedClusterInfo?.status?.consoleURL ??
-    // Temporary workaround until https://issues.redhat.com/browse/HIVE-1666
+    // Temporary workaround until https://redhat.atlassian.net/browse/HIVE-1666
     getConsoleUrlAI(clusterDeployment as ClusterDeploymentK8sResource, agentClusterInstall) ??
     getHypershiftConsoleURL(hostedCluster)
   )


### PR DESCRIPTION
PR template has out-of-date example link for on-prem Jira.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template’s ticket link example to use a Jira-style URL format.  
  * Refreshed two temporary workaround comment links to use the updated Jira-style domain format (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->