### PR TITLE
ACM-38874: build(containerfile): switch base image to floating :latest tag (main)

### DIFF
--- a/Containerfile.acm
+++ b/Containerfile.acm
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 FROM ${NODE_BASE} as build-base
 USER root

--- a/Containerfile.mce
+++ b/Containerfile.mce
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 FROM ${NODE_BASE} as build-base
 USER root

--- a/renovate.json
+++ b/renovate.json
@@ -129,6 +129,11 @@
       ],
       "groupName": "patternfly packages",
       "groupSlug": "patternfly"
+    },
+    {
+      "description": "Disable Dockerfile manager — base images use floating :latest tags managed by ART/Konflux",
+      "matchManagers": ["dockerfile"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Switch base image from SHA-pinned digest to floating \`:latest\` tag in all Containerfiles
- ART/Konflux handles base image refresh automatically on rebuild — no more manual SHA bumps
- Also disables renovate's Dockerfile manager on \`main\` to prevent re-pinning the digest

Fixes: ACM-38874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s containerized build and runtime environments to use the latest supported Node.js 24 base image.
  * Standardized the base image selection across container build stages for more consistent deployments.
  * Disabled automated container base-image update proposals to provide greater control over image changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->