### PR TITLE
ACM-38874: build(containerfile): switch base image to floating :latest tag (release-2.17)

### DIFF
--- a/Containerfile.acm
+++ b/Containerfile.acm
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 FROM ${NODE_BASE} as build-base
 USER root

--- a/Containerfile.mce
+++ b/Containerfile.mce
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+ARG NODE_BASE=registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 FROM ${NODE_BASE} as build-base
 USER root


### PR DESCRIPTION
## Summary

- Switch base image from SHA-pinned digest to floating \`:latest\` tag in all Containerfiles
- ART/Konflux handles base image refresh automatically on rebuild — no more manual SHA bumps

Fixes: ACM-38874

🤖 Generated with [Claude Code](https://claude.com/claude-code)