### PR TITLE
ACM-38874: build(containerfile): switch base image to floating :latest tag (release-2.16)

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:acm && npm cache clean --force
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:mce
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Dockerfile.mce.prow
+++ b/Dockerfile.mce.prow
@@ -1,12 +1,12 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 as dynamic-plugin
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest as dynamic-plugin
 WORKDIR /app/frontend
 COPY ./frontend .
 RUN npm ci --legacy-peer-deps --ignore-scripts
 RUN npm run build:plugin:mce
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 as backend
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest as backend
 WORKDIR /app/backend
 # Copy only package.json and package-lock.json so that the docker layer cache only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
@@ -15,12 +15,12 @@ RUN npm ci --omit=optional --ignore-scripts
 COPY ./backend .
 RUN npm run build
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 as production
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest as production
 WORKDIR /app/backend
 COPY ./backend/package-lock.json ./backend/package.json ./
 RUN npm ci --omit=optional --only=production --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest
 WORKDIR /app
 ENV NODE_ENV production
 COPY --from=production /app/backend/node_modules ./node_modules

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,12 +1,12 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 as dynamic-plugin
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest as dynamic-plugin
 WORKDIR /app/frontend
 COPY ./frontend .
 RUN npm ci --legacy-peer-deps --ignore-scripts
 RUN npm run build:plugin:acm
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 as backend
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest as backend
 WORKDIR /app/backend
 # Copy only package.json and package-lock.json so that the docker layer cache only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
@@ -15,12 +15,12 @@ RUN npm ci --omit=optional --ignore-scripts
 COPY ./backend .
 RUN npm run build
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 as production
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest as production
 WORKDIR /app/backend
 COPY ./backend/package-lock.json ./backend/package.json ./
 RUN npm ci --omit=optional --only=production --ignore-scripts
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest
 WORKDIR /app
 ENV NODE_ENV production
 COPY --from=production /app/backend/node_modules ./node_modules


### PR DESCRIPTION
## Summary

- Switch base image from SHA-pinned digest to floating \`:latest\` tag in all Containerfiles
- ART/Konflux handles base image refresh automatically on rebuild — no more manual SHA bumps

Fixes: ACM-38874

🤖 Generated with [Claude Code](https://claude.com/claude-code)