### PR TITLE
ACM-38874: build(containerfile): switch base image to floating :latest tag (release-2.12)

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1 AS builder
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:acm
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm
 
-FROM registry.redhat.io/ubi9/nodejs-24-minimal@sha256:5225726fc98379c9868b87ccb5b9c0f205555e0372cd7d0ecc6e772df8f1e5d1
+FROM registry.redhat.io/ubi9/nodejs-24-minimal:latest
 
 WORKDIR /app
 ENV NODE_ENV production


### PR DESCRIPTION
## Summary

- Switch base image from SHA-pinned digest to floating \`:latest\` tag in all Containerfiles
- ART/Konflux handles base image refresh automatically on rebuild — no more manual SHA bumps

Fixes: ACM-38874

🤖 Generated with [Claude Code](https://claude.com/claude-code)