### PR TITLE
ACM-37712 docs: add commit standards to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,13 @@ Each commit in a pull request should be small, logical, and complete:
 
 - **Small** — One coherent idea per commit. A reviewer can understand the change in isolation.
 - **Logical** — Related changes grouped together, unrelated changes in separate commits.
-- **Complete** — Every commit passes unit tests (`npm test`) and repository checks (`npm run check` — TypeScript, linting, copyright headers, and translation validation) independently.
+- **Complete** — Every commit passes unit tests (`npm test`) and repository checks
+  (`npm run check` — TypeScript, linting, copyright headers, and translation validation)
+  independently.
 - **Tests separate** — Add test cases in their own commits, separate from the implementation they cover.
-- **Clean history** — If reverting a change during development, drop the original commit rather than adding a revert commit. Use interactive rebase to keep the PR history clean before requesting review.
+- **Clean history** — If reverting a change during development, drop the original commit
+  rather than adding a revert commit. Use interactive rebase to keep the PR history clean
+  before requesting review.
 - **No WIP** — Avoid "WIP", "fixup", or "temp" commits in the final PR. Squash or rebase them before review.
 
 ## Branch Strategy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,17 @@ All source files must start with the copyright header:
 - **Constants**: `UPPER_SNAKE_CASE` for truly constant values (e.g., `MAX_RETRY_ATTEMPTS`)
 - **Reusable UI components**: Prefix with `Acm` (e.g., `AcmTable`, `AcmButton`) — these live in `frontend/src/ui-components/`
 
+## Commit Standards
+
+Each commit in a pull request should be small, logical, and complete:
+
+- **Small** — One coherent idea per commit. A reviewer can understand the change in isolation.
+- **Logical** — Related changes grouped together, unrelated changes in separate commits.
+- **Complete** — Every commit passes unit tests (`npm test`) and repository checks (`npm run check` — TypeScript, linting, copyright headers, and translation validation) independently.
+- **Tests separate** — Add test cases in their own commits, separate from the implementation they cover.
+- **Clean history** — If reverting a change during development, drop the original commit rather than adding a revert commit. Use interactive rebase to keep the PR history clean before requesting review.
+- **No WIP** — Avoid "WIP", "fixup", or "temp" commits in the final PR. Squash or rebase them before review.
+
 ## Branch Strategy
 
 The same codebase builds images for ACM (`release-*` branches) and MCE (`backplane-*` branches). The build system automatically fast-forwards commits between paired branches. See the "Active Release Branches" section in `README.md` for the current branch chains. Pull requests should target the first branch in each chain, which is `main` for the current release. Never open a PR directly against a `backplane-*` branch. 


### PR DESCRIPTION
## What

Adds a new "Commit Standards" section to AGENTS.md that defines expectations for how commits in PRs should be organized. This applies to both human contributors and AI agents.

## Why

ACM-37712 — We had no explicit guidance on commit organization. The existing AGENTS.md covered commit message format (via Code Quality Standards) but not commit structure, history cleanliness, or test separation.

This section is intentionally declarative (what good looks like) rather than procedural (how to do it). The procedural how-to lives in the console-harness `git-workflow` skill, which references these standards. This separation means the standards apply to all agents regardless of which harness or tooling they use.

## Standards added

- **Small** — One coherent idea per commit
- **Logical** — Related changes grouped, unrelated changes separated
- **Complete** — Every commit independently passes `npm test` and `npm run check` (TypeScript, linting, copyright headers, translation validation)
- **Tests separate** — Test cases in their own commits
- **Clean history** — Drop-not-revert policy, interactive rebase before review
- **No WIP** — No "WIP", "fixup", or "temp" commits in final PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added commit standards outlining expectations for clear, focused, complete, tested, and production-ready commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->