### PR TITLE
ACM-39799 Add NetworkPolicy in setup.sh for search api access

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -132,6 +132,31 @@ EOF
   echo SEARCH_API_URL=$SEARCH_API_URL >> ./backend/.env
 fi
 
+# Create NetworkPolicy to allow access to the search-api service.
+if [[ -n "$INSTALLATION_NAMESPACE" ]]; then
+  oc apply -f - << EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: search-api-localdev-route-access
+  namespace: $INSTALLATION_NAMESPACE
+spec:
+  podSelector:
+    matchLabels:
+      name: search-api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: openshift-ingress
+      ports:
+      - port: 4010
+        protocol: TCP
+EOF
+fi
+
 # Create route to the placement debug service for local development.
 oc apply -f - << EOF
 apiVersion: route.openshift.io/v1


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Add new NetworkPolicy to allow local dev env to access the search api

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-39799

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Search added a NetworkPolicy to block external access to the search api. This prevents the local dev env from accessing the search api as well. Fortunately, the NetworkPolicies are stackable so we can create multiple NetworkPolicies to get additional access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment**
  - Added an optional Kubernetes network policy during installation.
  - Allows approved ingress traffic to the Search API on TCP port 4010.
  - Improves connectivity between the platform’s ingress layer and search services while restricting access to the designated installation namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->