### PR TITLE
Add graphql-ws dep in multicluster-sdk package.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38909,13 +38909,14 @@
     },
     "packages/multicluster-sdk": {
       "name": "@stolostron/multicluster-sdk",
-      "version": "1.0.0",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "3.14.1",
         "@patternfly/react-core": "^6.6.0",
         "@patternfly/react-styles": "^6.6.0",
         "graphql": "^16.14.2",
+        "graphql-ws": "^6.1.1",
         "react-i18next": "~16.5.8",
         "react-router": "~7.13.1",
         "react-transition-group": "^4.4.5",

--- a/frontend/packages/multicluster-sdk/package.json
+++ b/frontend/packages/multicluster-sdk/package.json
@@ -69,6 +69,7 @@
     "@patternfly/react-core": "^6.6.0",
     "@patternfly/react-styles": "^6.6.0",
     "graphql": "^16.14.2",
+    "graphql-ws": "^6.1.1",
     "react-i18next": "~16.5.8",
     "react-router": "~7.13.1",
     "react-transition-group": "^4.4.5",


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
With the new changes to add the useFleetSearch hook in the multicluster-sdk package. I missed adding the graphql-ws package as a dependency. This adds graphql-ws to the dependencies list. 

**Ticket Link:**  


**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for GraphQL WebSocket connections in the multicluster SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->