### PR TITLE
ACM-17610: Allow setting the 'Etcd storage class' for Baremetal HCP Clusters from ACM GUI just like OSV HCP

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/DetailsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/DetailsForm.tsx
@@ -35,6 +35,7 @@ type FormControl = {
     releaseImage?: string
     sshPublicKey?: string
     userManagedNetworking?: boolean
+    storageClass?: string
   }
   disabled?: VoidFunction
   reverse?: (control: { active: ClusterDetailsValues }, templateObject: any) => void
@@ -54,6 +55,7 @@ const fields: any = {
   baseDnsDomain: { path: 'HostedCluster[0].spec.dns.baseDomain' },
   releaseImage: { path: 'HostedCluster[0].spec.release.image' },
   pullSecret: {},
+  storageClass: { path: 'HostedCluster[0].spec.etcd.managed.storage.persistentVolume.storageClassName' },
 }
 
 const DetailsForm: React.FC<DetailsFormProps> = ({ control, handleChange, controlProps }) => {
@@ -191,9 +193,15 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ control, handleChange, contro
       pullSecret: getDefault([controlProps?.stringData?.pullSecret, control.active.pullSecret, '']),
       baseDnsDomain: getDefault([controlProps?.stringData?.baseDomain, control.active.baseDnsDomain, '']),
       sshPublicKey: getDefault([controlProps?.stringData?.['ssh-publickey'], control.active.sshPublicKey, '']),
+      storageClass: getDefault([controlProps?.stringData?.storageClass, control.active.storageClass, '']),
     }
     handleChange(control)
-  }, [controlProps?.metadata.uid, controlProps?.stringData?.pullSecret, controlProps?.stringData?.baseDomain])
+  }, [
+    controlProps?.metadata.uid,
+    controlProps?.stringData?.pullSecret,
+    controlProps?.stringData?.baseDomain,
+    controlProps?.stringData?.storageClass,
+  ])
 
   return clusterImages ? (
     <HostedClusterDetailsStep

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAgentContext.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAgentContext.tsx
@@ -34,6 +34,8 @@ export type HypershiftAgentContextType = {
   setInfraEnvNamespace: (ns: string) => void
   sshPublicKey: string
   setSshPublicKey: (key: string) => void
+  storageClass: string
+  setStorageClass: (storageClass: string) => void
 }
 
 export const HypershiftAgentContext = React.createContext<HypershiftAgentContextType>({
@@ -55,6 +57,8 @@ export const HypershiftAgentContext = React.createContext<HypershiftAgentContext
   setInfraEnvNamespace: noop,
   sshPublicKey: '',
   setSshPublicKey: noop,
+  storageClass: '',
+  setStorageClass: noop,
 })
 
 export const useHypershiftContextValues = (): HypershiftAgentContextType => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
@@ -55,6 +55,16 @@ spec:
   infraID: '{{{hypershift.name}}}'
   dns:
     baseDomain: '{{{hypershift.baseDnsDomain}}}'
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+          {{#if hypershift.storageClass}}
+          storageClassName: {{{hypershift.storageClass}}}
+          {{/if}}
+        type: PersistentVolume
+    managementType: Managed
   services:
   - service: APIServer
     servicePublishingStrategy:


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

Allow setting the 'Etcd storage class' for Baremetal HCP Clusters from ACM GUI just like OSV HCP

**Ticket Link:**  
<!-- e.g. https://redhat.atlassian.net/browse/ACM-12345 -->

https://redhat.atlassian.net/browse/ACM-17610


**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional storage class configuration when creating Hypershift clusters.
  * Hosted etcd storage now uses an 8 GiB persistent volume, with support for a custom storage class.
  * Storage class values are initialized from the selected secret and reflected in the cluster form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->